### PR TITLE
ci: use macos 10.15 for test action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: ['10', '12', '14']
-        os: [macos-10.14, ubuntu-18.04]
+        os: [macos-10.15, ubuntu-18.04]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->

macos-10.14 is no longer supported by github actions (it seems).

update to macos-10.15 image.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> No
