### PR TITLE
build: add esm and es2015 builds

### DIFF
--- a/babel.es2015.config.js
+++ b/babel.es2015.config.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        targets: {
+          browsers: ['chrome 10'],
+        },
+      },
+    ],
+    '@babel/preset-typescript',
+  ],
+};

--- a/packages/analyticsConnector/package.json
+++ b/packages/analyticsConnector/package.json
@@ -3,6 +3,8 @@
   "version": "1.5.2",
   "description": "Connector package for Amplitude SDKs",
   "main": "dist/analyticsConnector.umd.js",
+  "module": "dist/analyticsConnector.esm.js",
+  "es2015": "dist/analyticsConnector.es2015.js",
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist"

--- a/packages/analyticsConnector/rollup.config.js
+++ b/packages/analyticsConnector/rollup.config.js
@@ -23,18 +23,17 @@ const getCommonBrowserConfig = (target) => ({
     json(),
     commonjs(),
     typescript({
-      target: target,
+      ...(target === 'es2015' ? { target: 'es2015' } : {}),
       declaration: true,
       declarationDir: 'dist/types',
       include: tsConfig.include,
       rootDir: '.',
     }),
     babel({
-      configFile: pathResolve(
-        __dirname,
-        '../..',
-        target === 'es2015' ? 'babel.es2015.config.js' : 'babel.config.js',
-      ),
+      configFile:
+        target === 'es2015'
+          ? pathResolve(__dirname, '../..', 'babel.es2015.config.js')
+          : undefined,
       babelHelpers: 'bundled',
       exclude: ['node_modules/**'],
     }),

--- a/packages/analyticsConnector/rollup.config.js
+++ b/packages/analyticsConnector/rollup.config.js
@@ -1,3 +1,5 @@
+import { resolve as pathResolve } from 'path';
+
 import babel from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
@@ -7,19 +9,11 @@ import typescript from '@rollup/plugin-typescript';
 
 import tsConfig from './tsconfig.json';
 
-const browserConfig = {
+const getCommonBrowserConfig = (target) => ({
   input: 'src/index.ts',
-  output: {
-    dir: 'dist',
-    entryFileNames: 'analyticsConnector.umd.js',
-    exports: 'named',
-    format: 'umd',
-    name: 'Experiment',
-  },
   treeshake: {
     moduleSideEffects: 'no-external',
   },
-  external: [],
   plugins: [
     replace({
       preventAssignment: true,
@@ -29,18 +23,63 @@ const browserConfig = {
     json(),
     commonjs(),
     typescript({
+      target: target,
       declaration: true,
       declarationDir: 'dist/types',
       include: tsConfig.include,
       rootDir: '.',
     }),
     babel({
+      configFile: pathResolve(
+        __dirname,
+        '../..',
+        target === 'es2015' ? 'babel.es2015.config.js' : 'babel.config.js',
+      ),
       babelHelpers: 'bundled',
       exclude: ['node_modules/**'],
     }),
   ],
-};
+});
 
-const configs = [browserConfig];
+const getOutputConfig = (outputOptions) => ({
+  output: {
+    dir: 'dist',
+    name: 'Experiment',
+    ...outputOptions,
+  },
+});
+
+const configs = [
+  // legacy build for field "main" - ie8, umd, es5 syntax
+  {
+    ...getCommonBrowserConfig('es5'),
+    ...getOutputConfig({
+      entryFileNames: 'analyticsConnector.umd.js',
+      exports: 'named',
+      format: 'umd',
+    }),
+    external: [],
+  },
+
+  // tree shakable build for field "module" - ie8, esm, es5 syntax
+  {
+    ...getCommonBrowserConfig('es5'),
+    ...getOutputConfig({
+      entryFileNames: 'analyticsConnector.esm.js',
+      format: 'esm',
+    }),
+    external: ['@amplitude/ua-parser-js'],
+  },
+
+  // modern build for field "es2015" - not ie, esm, es2015 syntax
+  {
+    ...getCommonBrowserConfig('es2015'),
+    ...getOutputConfig({
+      entryFileNames: 'analyticsConnector.es2015.js',
+      format: 'esm',
+    }),
+    external: ['@amplitude/ua-parser-js'],
+  },
+];
 
 export default configs;

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -3,6 +3,8 @@
   "version": "1.5.3",
   "description": "Javascript Client SDK for Amplitude Experiment",
   "main": "dist/experiment.umd.js",
+  "module": "dist/experiment.esm.js",
+  "es2015": "dist/experiment.es2015.js",
   "types": "dist/types/src/index.d.ts",
   "files": [
     "dist"

--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -1,3 +1,5 @@
+import { resolve as pathResolve } from 'path';
+
 import babel from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
@@ -7,19 +9,11 @@ import typescript from '@rollup/plugin-typescript';
 
 import tsConfig from './tsconfig.json';
 
-const browserConfig = {
+const getCommonBrowserConfig = (target) => ({
   input: 'src/index.ts',
-  output: {
-    dir: 'dist',
-    entryFileNames: 'experiment.umd.js',
-    exports: 'named',
-    format: 'umd',
-    name: 'Experiment',
-  },
   treeshake: {
     moduleSideEffects: 'no-external',
   },
-  external: [],
   plugins: [
     replace({
       preventAssignment: true,
@@ -29,18 +23,63 @@ const browserConfig = {
     json(),
     commonjs(),
     typescript({
+      target: target,
       declaration: true,
       declarationDir: 'dist/types',
       include: tsConfig.include,
       rootDir: '.',
     }),
     babel({
+      configFile: pathResolve(
+        __dirname,
+        '../..',
+        target === 'es2015' ? 'babel.es2015.config.js' : 'babel.config.js',
+      ),
       babelHelpers: 'bundled',
       exclude: ['node_modules/**'],
     }),
   ],
-};
+});
 
-const configs = [browserConfig];
+const getOutputConfig = (outputOptions) => ({
+  output: {
+    dir: 'dist',
+    name: 'Experiment',
+    ...outputOptions,
+  },
+});
+
+const configs = [
+  // legacy build for field "main" - ie8, umd, es5 syntax
+  {
+    ...getCommonBrowserConfig('es5'),
+    ...getOutputConfig({
+      entryFileNames: 'experiment.umd.js',
+      exports: 'named',
+      format: 'umd',
+    }),
+    external: [],
+  },
+
+  // tree shakable build for field "module" - ie8, esm, es5 syntax
+  {
+    ...getCommonBrowserConfig('es5'),
+    ...getOutputConfig({
+      entryFileNames: 'experiment.esm.js',
+      format: 'esm',
+    }),
+    external: ['@amplitude/ua-parser-js'],
+  },
+
+  // modern build for field "es2015" - not ie, esm, es2015 syntax
+  {
+    ...getCommonBrowserConfig('es2015'),
+    ...getOutputConfig({
+      entryFileNames: 'experiment.es2015.js',
+      format: 'esm',
+    }),
+    external: ['@amplitude/ua-parser-js'],
+  },
+];
 
 export default configs;

--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -67,7 +67,7 @@ const configs = [
       entryFileNames: 'experiment.esm.js',
       format: 'esm',
     }),
-    external: ['@amplitude/ua-parser-js'],
+    external: ['@amplitude/ua-parser-js', '@amplitude/analytics-connector'],
   },
 
   // modern build for field "es2015" - not ie, esm, es2015 syntax
@@ -77,7 +77,7 @@ const configs = [
       entryFileNames: 'experiment.es2015.js',
       format: 'esm',
     }),
-    external: ['@amplitude/ua-parser-js'],
+    external: ['@amplitude/ua-parser-js', '@amplitude/analytics-connector'],
   },
 ];
 

--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -23,18 +23,17 @@ const getCommonBrowserConfig = (target) => ({
     json(),
     commonjs(),
     typescript({
-      target: target,
+      ...(target === 'es2015' ? { target: 'es2015' } : {}),
       declaration: true,
       declarationDir: 'dist/types',
       include: tsConfig.include,
       rootDir: '.',
     }),
     babel({
-      configFile: pathResolve(
-        __dirname,
-        '../..',
-        target === 'es2015' ? 'babel.es2015.config.js' : 'babel.config.js',
-      ),
+      configFile:
+        target === 'es2015'
+          ? pathResolve(__dirname, '../..', 'babel.es2015.config.js')
+          : undefined,
       babelHelpers: 'bundled',
       exclude: ['node_modules/**'],
     }),


### PR DESCRIPTION
fixes https://github.com/amplitude/experiment-js-client/issues/37

* keep existing umd build untouched to not break existing usages
* add `{ "module": "dist/<package>.esm.js" }` with `es5` syntax and es modules
* add `{ "es2015": "dist/<package>.es2015.js" }` with `es2015` syntax and es modules

So you can reuse modules from amplitude (instead of e.g. having `@amplitude/ua-parser-js` 3 times in your build) and if you don't care about IE11, can use the smaller es2015 syntax.

![CleanShot 2022-07-11 at 19 02 56@2x](https://user-images.githubusercontent.com/905328/178318823-08ef729f-0df5-472b-b4ef-c8833bc7ca5e.png)
