### PR TITLE
feat: add clear method to clear flag configs

### DIFF
--- a/packages/experiment-browser/src/experimentClient.ts
+++ b/packages/experiment-browser/src/experimentClient.ts
@@ -183,7 +183,7 @@ export class ExperimentClient implements Client {
   }
 
   /**
-   * Clear the flag configs in storage.
+   * Clear all variants in the cache and storage.
    *
    */
   public clear(): void {

--- a/packages/experiment-browser/src/experimentClient.ts
+++ b/packages/experiment-browser/src/experimentClient.ts
@@ -183,6 +183,15 @@ export class ExperimentClient implements Client {
   }
 
   /**
+   * Clear the flag configs in storage.
+   *
+   */
+  public clear(): void {
+    this.storage.clear();
+    this.storage.save();
+  }
+
+  /**
    * Get a copy of the internal {@link ExperimentUser} object if it is set.
    *
    * @returns a copy of the internal user object if set.

--- a/packages/experiment-browser/src/stubClient.ts
+++ b/packages/experiment-browser/src/stubClient.ts
@@ -38,5 +38,7 @@ export class StubExperimentClient implements Client {
     return {};
   }
 
+  public clear(): void {}
+
   public exposure(key: string): void {}
 }

--- a/packages/experiment-browser/src/types/client.ts
+++ b/packages/experiment-browser/src/types/client.ts
@@ -10,6 +10,7 @@ export interface Client {
   fetch(user?: ExperimentUser): Promise<Client>;
   variant(key: string, fallback?: string | Variant): Variant;
   all(): Variants;
+  clear(): void;
   exposure(key: string): void;
   getUser(): ExperimentUser;
   setUser(user: ExperimentUser): void;

--- a/packages/experiment-browser/test/client.test.ts
+++ b/packages/experiment-browser/test/client.test.ts
@@ -163,6 +163,19 @@ test('ExperimentClient.all, initial variants returned', async () => {
 });
 
 /**
+ * Call clear() to clear the flag configs in storage..
+ */
+ test('ExperimentClient.clear, clear the variants in storage', async () => {
+  const client = new ExperimentClient(API_KEY, {});
+  await client.fetch(testUser);
+  const variant = client.variant('sdk-ci-test');
+  expect(variant).toEqual({ value: 'on', payload: 'payload' });
+  client.clear();
+  const clearedVariants = client.all();
+  expect(clearedVariants).toEqual({});
+});
+
+/**
  * Setting source to initial variants will prioritize variants in initial
  * variants over those stored in local storage.
  */

--- a/packages/experiment-browser/test/client.test.ts
+++ b/packages/experiment-browser/test/client.test.ts
@@ -165,7 +165,7 @@ test('ExperimentClient.all, initial variants returned', async () => {
 /**
  * Call clear() to clear the flag configs in storage..
  */
- test('ExperimentClient.clear, clear the variants in storage', async () => {
+test('ExperimentClient.clear, clear the variants in storage', async () => {
   const client = new ExperimentClient(API_KEY, {});
   await client.fetch(testUser);
   const variant = client.variant('sdk-ci-test');

--- a/packages/experiment-browser/test/client.test.ts
+++ b/packages/experiment-browser/test/client.test.ts
@@ -163,7 +163,7 @@ test('ExperimentClient.all, initial variants returned', async () => {
 });
 
 /**
- * Call clear() to clear the flag configs in storage..
+ * Call clear() to clear all variants in the cache and storage.
  */
 test('ExperimentClient.clear, clear the variants in storage', async () => {
   const client = new ExperimentClient(API_KEY, {});


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

Add functionality for manipulating the flag config cache
<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
