### PR TITLE
fix: clear cache if no flag keys so disabled flags are cleared

### DIFF
--- a/packages/experiment-browser/src/experimentClient.ts
+++ b/packages/experiment-browser/src/experimentClient.ts
@@ -407,7 +407,9 @@ export class ExperimentClient implements Client {
 
   private storeVariants(variants: Variants, options?: FetchOptions): void {
     let failedFlagKeys = options && options.flagKeys ? options.flagKeys : [];
-
+    if (failedFlagKeys.length === 0) {
+      this.storage.clear();
+    }
     for (const key in variants) {
       failedFlagKeys = failedFlagKeys.filter((flagKey) => flagKey !== key);
       this.storage.put(key, variants[key]);

--- a/packages/experiment-browser/test/client.test.ts
+++ b/packages/experiment-browser/test/client.test.ts
@@ -385,6 +385,16 @@ test('configure httpClient, success', async () => {
   expect(v).toEqual({ value: 'key' });
 });
 
+test('existing storage variant removed when fetch without flag keys response stored', async () => {
+  const client = new ExperimentClient(API_KEY, {});
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  client.storage.put('not-fetched-variant', { value: 'on' });
+  await client.fetch(testUser);
+  const variant = client.variant('not-fetched-variant');
+  expect(variant).toEqual({});
+});
+
 // Testing with local api server, need to updated to use the production data.
 const LOCAL_TEST_API = API_KEY; //'server-qz35UwzJ5akieoAdIgzM4m9MIiOLXLoz'; //'server-VY0FufBsdITI1Gv9y7RyUopLzk9m8t0n';
 const local_test_user = testUser; //{ user_id: 'brian.giori@amplitude.com' };


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->

Subset flags update introduced bug where disabled flags were not removed from storage. In practice the storage was strictly additive, unless specific flag keys were sent in the request.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> no
