### PR TITLE
fix: unwrap default user provider before connector

### DIFF
--- a/packages/experiment-browser/src/experimentClient.ts
+++ b/packages/experiment-browser/src/experimentClient.ts
@@ -7,6 +7,7 @@ import { version as PACKAGE_VERSION } from '../package.json';
 
 import { ExperimentConfig, Defaults } from './config';
 import { ConnectorUserProvider } from './integration/connector';
+import { DefaultUserProvider } from './integration/default';
 import { LocalStorage } from './storage/localStorage';
 import { exposureEvent } from './types/analytics';
 import { Client, FetchOptions } from './types/client';
@@ -23,7 +24,6 @@ import { urlSafeBase64Encode } from './util/base64';
 import { randomString } from './util/randomstring';
 import { SessionAnalyticsProvider } from './util/sessionAnalyticsProvider';
 import { SessionExposureTrackingProvider } from './util/sessionExposureTrackingProvider';
-import { DefaultUserProvider } from "./integration/default";
 
 // Configs which have been removed from the public API.
 // May be added back in the future.

--- a/packages/experiment-browser/src/experimentClient.ts
+++ b/packages/experiment-browser/src/experimentClient.ts
@@ -23,6 +23,7 @@ import { urlSafeBase64Encode } from './util/base64';
 import { randomString } from './util/randomstring';
 import { SessionAnalyticsProvider } from './util/sessionAnalyticsProvider';
 import { SessionExposureTrackingProvider } from './util/sessionExposureTrackingProvider';
+import { DefaultUserProvider } from "./integration/default";
 
 // Configs which have been removed from the public API.
 // May be added back in the future.
@@ -462,9 +463,12 @@ export class ExperimentClient implements Client {
     user: ExperimentUser,
     ms: number,
   ): Promise<ExperimentUser> {
-    if (this.userProvider instanceof ConnectorUserProvider) {
-      await this.userProvider.identityReady(ms);
+    if (this.userProvider instanceof DefaultUserProvider) {
+      if (this.userProvider.userProvider instanceof ConnectorUserProvider) {
+        await this.userProvider.userProvider.identityReady(ms);
+      }
     }
+
     return this.addContext(user);
   }
 

--- a/packages/experiment-browser/src/integration/default.ts
+++ b/packages/experiment-browser/src/integration/default.ts
@@ -5,7 +5,7 @@ import { ExperimentUser } from '../types/user';
 
 export class DefaultUserProvider implements ExperimentUserProvider {
   private readonly contextProvider: ApplicationContextProvider;
-  private readonly userProvider: ExperimentUserProvider | undefined;
+  public readonly userProvider: ExperimentUserProvider | undefined;
   constructor(
     applicationContextProvider: ApplicationContextProvider,
     userProvider?: ExperimentUserProvider,


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->

Fix regression in device info fix. Unwrap the default user provider to access connector user provider.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> no
