### PR TITLE
fix(deps): Use a range constraint for the ua-parser package

### DIFF
--- a/packages/analytics-connector/package.json
+++ b/packages/analytics-connector/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/amplitude/experiment-js-client/issues"
   },
   "dependencies": {
-    "@amplitude/ua-parser-js": "0.7.31"
+    "@amplitude/ua-parser-js": "^0.7.31"
   },
   "devDependencies": {
     "@types/amplitude-js": "^8.0.2",


### PR DESCRIPTION
### Summary

Given that the ua-parser package does not live in this mono-repo, its releases are not in sync. The exact version used here leads to installing 2 different versions of the ua-parser as part of the dependencies of the analytics-browser package, and both are part of the bundle, increasing the bundle size.

Closes https://github.com/amplitude/Amplitude-TypeScript/issues/373

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
