### PR TITLE
feat: remove @analytics/ua-parser as dependency of @amplitude/analyti…

### DIFF
--- a/packages/analytics-connector/package.json
+++ b/packages/analytics-connector/package.json
@@ -27,9 +27,7 @@
   "bugs": {
     "url": "https://github.com/amplitude/experiment-js-client/issues"
   },
-  "dependencies": {
-    "@amplitude/ua-parser-js": "^0.7.31"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/amplitude-js": "^8.0.2",
     "amplitude-js": "^8.12.0"

--- a/packages/analytics-connector/rollup.config.js
+++ b/packages/analytics-connector/rollup.config.js
@@ -71,7 +71,7 @@ const configs = [
       entryFileNames: 'analytics-connector.esm.js',
       format: 'esm',
     }),
-    external: ['@amplitude/ua-parser-js'],
+    external: [],
   },
 
   // modern build for field "es2015" - not ie, esm, es2015 syntax
@@ -81,7 +81,7 @@ const configs = [
       entryFileNames: 'analytics-connector.es2015.js',
       format: 'esm',
     }),
-    external: ['@amplitude/ua-parser-js'],
+    external: [],
   },
 ];
 

--- a/packages/analytics-connector/src/applicationContextProvider.ts
+++ b/packages/analytics-connector/src/applicationContextProvider.ts
@@ -1,5 +1,3 @@
-import { UAParser } from '@amplitude/ua-parser-js';
-
 export type ApplicationContext = {
   versionName?: string;
   language?: string;
@@ -16,30 +14,17 @@ export interface ApplicationContextProvider {
 export class ApplicationContextProviderImpl
   implements ApplicationContextProvider
 {
-  private readonly ua = new UAParser(
-    typeof navigator !== 'undefined' ? navigator.userAgent : null,
-  ).getResult();
   public versionName: string;
   getApplicationContext(): ApplicationContext {
     return {
       versionName: this.versionName,
       language: getLanguage(),
       platform: 'Web',
-      os: getOs(this.ua),
-      deviceModel: getDeviceModel(this.ua),
+      os: undefined,
+      deviceModel: undefined,
     };
   }
 }
-
-const getOs = (ua: UAParser): string => {
-  return [ua.browser?.name, ua.browser?.major]
-    .filter((e) => e !== null && e !== undefined)
-    .join(' ');
-};
-
-const getDeviceModel = (ua: UAParser): string => {
-  return ua.os?.name;
-};
 
 const getLanguage = (): string => {
   return (

--- a/packages/experiment-browser/package.json
+++ b/packages/experiment-browser/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@amplitude/analytics-connector": "^1.4.7",
+    "@amplitude/ua-parser-js": "^0.7.31",
     "base64-js": "1.5.1",
     "unfetch": "4.1.0"
   },

--- a/packages/experiment-browser/rollup.config.js
+++ b/packages/experiment-browser/rollup.config.js
@@ -71,7 +71,7 @@ const configs = [
       entryFileNames: 'experiment.esm.js',
       format: 'esm',
     }),
-    external: ['@amplitude/ua-parser-js', '@amplitude/analytics-connector'],
+    external: ['@amplitude/analytics-connector'],
   },
 
   // modern build for field "es2015" - not ie, esm, es2015 syntax
@@ -81,7 +81,7 @@ const configs = [
       entryFileNames: 'experiment.es2015.js',
       format: 'esm',
     }),
-    external: ['@amplitude/ua-parser-js', '@amplitude/analytics-connector'],
+    external: ['@amplitude/analytics-connector'],
   },
 ];
 


### PR DESCRIPTION
### Summary

* Removes `@analytics/ua-parser` as dependency of @amplitude/analytics-connector
* Adds `@analytics/ua-parser` as dependency of @amplitude/experiment-js-client

The ultimate goal is to remove `@analytics/ua-parser` as direct/indirect dependency of `@amplitude/analytics-browser`.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
