### PR TITLE
fix: remove duplicated user agent parser from build

### DIFF
--- a/packages/experiment-browser/rollup.config.js
+++ b/packages/experiment-browser/rollup.config.js
@@ -71,7 +71,7 @@ const configs = [
       entryFileNames: 'experiment.esm.js',
       format: 'esm',
     }),
-    external: ['@amplitude/analytics-connector'],
+    external: ['@amplitude/ua-parser-js', '@amplitude/analytics-connector'],
   },
 
   // modern build for field "es2015" - not ie, esm, es2015 syntax
@@ -81,7 +81,7 @@ const configs = [
       entryFileNames: 'experiment.es2015.js',
       format: 'esm',
     }),
-    external: ['@amplitude/analytics-connector'],
+    external: ['@amplitude/ua-parser-js', '@amplitude/analytics-connector'],
   },
 ];
 


### PR DESCRIPTION
### Summary

Exclude @amplitude/ua-parser-js from bundle. This dependency will be installed by consumer and will be used by this package.

cc @stof 

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
