### PR TITLE
feat(analytics-connector): add support for setting opt out in identity store

### DIFF
--- a/packages/analytics-connector/src/identityStore.ts
+++ b/packages/analytics-connector/src/identityStore.ts
@@ -21,6 +21,7 @@ export type Identity = {
   userId?: string;
   deviceId?: string;
   userProperties?: Record<string, unknown>;
+  optOut?: boolean;
 };
 
 export type IdentityListener = (identity: Identity) => void;
@@ -37,6 +38,7 @@ export interface IdentityEditor {
   setUserId(userId: string): IdentityEditor;
   setDeviceId(deviceId: string): IdentityEditor;
   setUserProperties(userProperties: Record<string, unknown>): IdentityEditor;
+  setOptOut(optOut: boolean): IdentityEditor;
   updateUserProperties(
     actions: Record<string, Record<string, unknown>>,
   ): IdentityEditor;
@@ -70,6 +72,11 @@ export class IdentityStoreImpl implements IdentityStore {
         userProperties: Record<string, unknown>,
       ): IdentityEditor {
         actingIdentity.userProperties = userProperties;
+        return this;
+      },
+
+      setOptOut(optOut: boolean): IdentityEditor {
+        actingIdentity.optOut = optOut;
         return this;
       },
 

--- a/packages/analytics-connector/test/identityStore.test.ts
+++ b/packages/analytics-connector/test/identityStore.test.ts
@@ -9,12 +9,14 @@ test('editIdentity, setUserId setDeviceId, success', async () => {
     .editIdentity()
     .setUserId('user_id')
     .setDeviceId('device_id')
+    .setOptOut(true)
     .commit();
   const identity = identityStore.getIdentity();
   expect(identity).toEqual({
     userId: 'user_id',
     deviceId: 'device_id',
     userProperties: {},
+    optOut: true,
   });
 });
 


### PR DESCRIPTION
### Summary

Add ability to set optOut in the analytics connector identity store

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
