### PR TITLE
fix: optimize variant cache access, legacy exposure

### DIFF
--- a/packages/experiment-browser/src/experimentClient.ts
+++ b/packages/experiment-browser/src/experimentClient.ts
@@ -517,7 +517,7 @@ export class ExperimentClient implements Client {
   ): SourceVariant {
     let defaultSourceVariant: SourceVariant = {};
     // Local storage
-    const localStorageVariant = this.variants.getAll()[key];
+    const localStorageVariant = this.variants.get(key);
     const isLocalStorageDefault = localStorageVariant?.metadata
       ?.default as boolean;
     if (!isNullOrUndefined(localStorageVariant) && !isLocalStorageDefault) {
@@ -588,7 +588,7 @@ export class ExperimentClient implements Client {
       };
     }
     // Local storage
-    const localStorageVariant = this.variants.getAll()[key];
+    const localStorageVariant = this.variants.get(key);
     const isLocalStorageDefault = localStorageVariant?.metadata
       ?.default as boolean;
     if (!isNullOrUndefined(localStorageVariant) && !isLocalStorageDefault) {
@@ -839,13 +839,15 @@ export class ExperimentClient implements Client {
     variant: Variant | undefined,
     source: VariantSource | undefined,
   ): void {
-    const user = this.addContext(this.getUser());
-    const event = exposureEvent(user, key, variant, source);
-    if (isFallback(source) || !variant?.value) {
-      this.analyticsProvider?.unsetUserProperty?.(event);
-    } else if (variant?.value) {
-      this.analyticsProvider?.setUserProperty?.(event);
-      this.analyticsProvider?.track(event);
+    if (this.analyticsProvider) {
+      const user = this.addContext(this.getUser());
+      const event = exposureEvent(user, key, variant, source);
+      if (isFallback(source) || !variant?.value) {
+        this.analyticsProvider?.unsetUserProperty?.(event);
+      } else if (variant?.value) {
+        this.analyticsProvider?.setUserProperty?.(event);
+        this.analyticsProvider?.track(event);
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->
* Call `get()` for accessing the variant rather than `getAll()[key]`
* Check if there is a legacy exposure tracker before adding context to the user

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> No
