### PR TITLE
fix: make storage synchronous

### DIFF
--- a/packages/experiment-browser/src/experimentClient.ts
+++ b/packages/experiment-browser/src/experimentClient.ts
@@ -149,8 +149,8 @@ export class ExperimentClient implements Client {
       storage,
     );
     this.flags = getFlagStorage(this.apiKey, this.config.instanceName, storage);
-    void this.flags.load();
-    void this.variants.load();
+    this.flags.load();
+    this.variants.load();
   }
 
   /**
@@ -688,7 +688,7 @@ export class ExperimentClient implements Client {
     });
     this.flags.clear();
     this.flags.putAll(flags);
-    await this.flags.store();
+    this.flags.store();
   }
 
   private async storeVariants(
@@ -707,7 +707,7 @@ export class ExperimentClient implements Client {
     for (const key in failedFlagKeys) {
       this.variants.remove(key);
     }
-    await this.variants.store();
+    this.variants.store();
     this.debug('[Experiment] Stored variants: ', variants);
   }
 

--- a/packages/experiment-browser/src/storage/cache.ts
+++ b/packages/experiment-browser/src/storage/cache.ts
@@ -71,8 +71,8 @@ export class LoadStoreCache<V> {
     this.cache = {};
   }
 
-  public async load(): Promise<void> {
-    const rawValues = await this.storage.get(this.namespace);
+  public async load() {
+    const rawValues = this.storage.get(this.namespace);
     let jsonValues: Record<string, unknown>;
     try {
       jsonValues = JSON.parse(rawValues) || {};
@@ -100,8 +100,8 @@ export class LoadStoreCache<V> {
     this.putAll(values);
   }
 
-  public async store(values: Record<string, V> = this.cache): Promise<void> {
-    await this.storage.put(this.namespace, JSON.stringify(values));
+  public async store(values: Record<string, V> = this.cache) {
+    this.storage.put(this.namespace, JSON.stringify(values));
   }
 }
 

--- a/packages/experiment-browser/src/storage/local-storage.ts
+++ b/packages/experiment-browser/src/storage/local-storage.ts
@@ -1,16 +1,14 @@
 import { Storage } from '../types/storage';
 export class LocalStorage implements Storage {
-  async get(key: string): Promise<string> {
+  get(key: string): string {
     return localStorage.getItem(key);
   }
 
-  async put(key: string, value: string): Promise<void> {
+  put(key: string, value: string): void {
     localStorage.setItem(key, value);
-    return;
   }
 
-  async delete(key: string): Promise<void> {
+  delete(key: string): void {
     localStorage.removeItem(key);
-    return;
   }
 }

--- a/packages/experiment-browser/src/types/storage.ts
+++ b/packages/experiment-browser/src/types/storage.ts
@@ -1,5 +1,5 @@
 export interface Storage {
-  get(key: string): Promise<string>;
-  put(key: string, value: string): Promise<void>;
-  delete(key: string): Promise<void>;
+  get(key: string): string;
+  put(key: string, value: string): void;
+  delete(key: string): void;
 }

--- a/packages/experiment-browser/test/util/mock.ts
+++ b/packages/experiment-browser/test/util/mock.ts
@@ -13,15 +13,15 @@ export const mockClientStorage = (client: Client) => {
 
 class MockStorage implements Storage {
   private store = {};
-  async delete(key: string): Promise<void> {
+  delete(key: string): void {
     delete this.store[key];
   }
 
-  async get(key: string): Promise<string> {
+  get(key: string): string {
     return this.store[key];
   }
 
-  async put(key: string, value: string): Promise<void> {
+  put(key: string, value: string): void {
     this.store[key] = value;
   }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->

Storage functions were needlessly async

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> no
