### PR TITLE
chore: fix UUID method for split-url experiment

### DIFF
--- a/packages/experiment-tag/src/util.ts
+++ b/packages/experiment-tag/src/util.ts
@@ -46,7 +46,7 @@ export const removeQueryParams = (
   return urlObj.toString();
 };
 
-export const UUID = function (a?: never): string {
+export const UUID = function (a?: any): string {
   return a // if the placeholder was passed, return
     ? // a random number from 0 to 15
       (
@@ -67,7 +67,7 @@ export const UUID = function (a?: never): string {
         .replace(
           // replacing
           /[018]/g, // zeroes, ones, and eights with
-          UUID(), // random hex digits
+          UUID, // random hex digits
         );
 };
 


### PR DESCRIPTION
### Summary
Fix UUID method to generate device id correctly. Currently this break the init of split url

### Checklist
* [ X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: NO
