### PR TITLE
feat: share query params when splitting url

### DIFF
--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -2,6 +2,7 @@ import { EvaluationFlag } from '@amplitude/experiment-core';
 import { Experiment, ExperimentUser } from '@amplitude/experiment-js-client';
 
 import {
+  concateQueryParamsOf,
   getGlobalScope,
   getUrlParams,
   isLocalStorageAvailable,
@@ -95,8 +96,13 @@ export const initializeExperiment = (apiKey: string, initialFlags: string) => {
               !matchesUrl([redirectUrl], currentUrl) &&
               currentUrl !== referrerUrl
             ) {
+              const targetUrl = concateQueryParamsOf(
+                globalScope.location.href,
+                redirectUrl,
+              );
+
               // perform redirection
-              globalScope.location.replace(redirectUrl);
+              globalScope.location.replace(targetUrl);
             } else {
               // if redirection is not required
               globalScope.experiment.exposure(key);

--- a/packages/experiment-tag/src/util.ts
+++ b/packages/experiment-tag/src/util.ts
@@ -46,6 +46,19 @@ export const removeQueryParams = (
   return urlObj.toString();
 };
 
+export const concateQueryParamsOf = (globalUrl: string, to: string): string => {
+  const globalUrlObj = new URL(globalUrl);
+  const urlObj = new URL(to);
+
+  globalUrlObj.searchParams.forEach((value, key) => {
+    if (!urlObj.searchParams.has(key)) {
+      urlObj.searchParams.set(key, value);
+    }
+  });
+
+  return urlObj.toString();
+};
+
 export const UUID = function (a?: any): string {
   return a // if the placeholder was passed, return
     ? // a random number from 0 to 15

--- a/packages/experiment-tag/test/util.test.ts
+++ b/packages/experiment-tag/test/util.test.ts
@@ -1,4 +1,9 @@
-import { getUrlParams, matchesUrl, urlWithoutParamsAndAnchor } from 'src/util';
+import {
+  getUrlParams,
+  matchesUrl,
+  urlWithoutParamsAndAnchor,
+  concateQueryParamsOf,
+} from 'src/util';
 import * as util from 'src/util';
 
 // Mock the getGlobalScope function
@@ -114,6 +119,35 @@ describe('getUrlParams', () => {
     spyGetGlobalScope.mockReturnValue(mockGlobal);
 
     expect(getUrlParams()).toEqual({});
+  });
+});
+
+describe('concateQueryParamsOf', () => {
+  it('should concatenate query params if only global has', () => {
+    expect(
+      concateQueryParamsOf(
+        'https://test.com?utm_source=testing',
+        'https://test2.com',
+      ),
+    ).toBe('https://test2.com/?utm_source=testing');
+  });
+
+  it('should concatenate query params if only target url has', () => {
+    expect(
+      concateQueryParamsOf(
+        'https://test.com',
+        'https://test2.com?utm_source=testing',
+      ),
+    ).toBe('https://test2.com/?utm_source=testing');
+  });
+
+  it('should concatenate query params if both url has', () => {
+    expect(
+      concateQueryParamsOf(
+        'https://test.com?utm_medium=new_url&utm_source=testing',
+        'https://test2.com?utm_source=testing2',
+      ),
+    ).toBe('https://test2.com/?utm_source=testing2&utm_medium=new_url');
   });
 });
 


### PR DESCRIPTION
### Summary
This PR seeks  share query params (such as UTM properties) when in Splitting URL. This is useful because allow marketing teams to attribute right the conversions 

### Checklist
* [ X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: NO
