### PR TITLE
chore: Support search param sharing for split url experiments

### DIFF
--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -2,6 +2,7 @@ import { EvaluationFlag } from '@amplitude/experiment-core';
 import { Experiment, ExperimentUser } from '@amplitude/experiment-js-client';
 
 import {
+  concatenateQueryParamsOf,
   getGlobalScope,
   getUrlParams,
   isLocalStorageAvailable,
@@ -95,8 +96,12 @@ export const initializeExperiment = (apiKey: string, initialFlags: string) => {
               !matchesUrl([redirectUrl], currentUrl) &&
               currentUrl !== referrerUrl
             ) {
+              const targetUrl = concatenateQueryParamsOf(
+                globalScope.location.href,
+                redirectUrl,
+              );
               // perform redirection
-              globalScope.location.replace(redirectUrl);
+              globalScope.location.replace(targetUrl);
             } else {
               // if redirection is not required
               globalScope.experiment.exposure(key);
@@ -104,9 +109,7 @@ export const initializeExperiment = (apiKey: string, initialFlags: string) => {
           } else if (
             // if at the redirected page
             matchesUrl(urlExactMatch, referrerUrl) &&
-            (matchesUrl([redirectUrl], currentUrl) ||
-              // case when redirected url has query and anchor
-              matchesUrl([redirectUrl], globalScope.location.href))
+            matchesUrl([urlWithoutParamsAndAnchor(redirectUrl)], currentUrl)
           ) {
             globalScope.experiment.exposure(key);
           }

--- a/packages/experiment-tag/src/util.ts
+++ b/packages/experiment-tag/src/util.ts
@@ -94,3 +94,19 @@ export const isLocalStorageAvailable = (): boolean => {
   }
   return false;
 };
+
+export const concatenateQueryParamsOf = (
+  currentUrl: string,
+  redirectUrl: string,
+): string => {
+  const globalUrlObj = new URL(currentUrl);
+  const urlObj = new URL(redirectUrl);
+
+  globalUrlObj.searchParams.forEach((value, key) => {
+    if (!urlObj.searchParams.has(key)) {
+      urlObj.searchParams.set(key, value);
+    }
+  });
+
+  return urlObj.toString();
+};

--- a/packages/experiment-tag/test/util.test.ts
+++ b/packages/experiment-tag/test/util.test.ts
@@ -1,4 +1,9 @@
-import { getUrlParams, matchesUrl, urlWithoutParamsAndAnchor } from 'src/util';
+import {
+  concatenateQueryParamsOf,
+  getUrlParams,
+  matchesUrl,
+  urlWithoutParamsAndAnchor,
+} from 'src/util';
 import * as util from 'src/util';
 
 // Mock the getGlobalScope function
@@ -114,6 +119,35 @@ describe('getUrlParams', () => {
     spyGetGlobalScope.mockReturnValue(mockGlobal);
 
     expect(getUrlParams()).toEqual({});
+  });
+});
+
+describe('concateQueryParamsOf', () => {
+  it('should concatenate query params if only current url has', () => {
+    expect(
+      concatenateQueryParamsOf(
+        'https://test.com?utm_source=testing',
+        'https://test2.com',
+      ),
+    ).toBe('https://test2.com/?utm_source=testing');
+  });
+
+  it('should concatenate query params if only redirected url has', () => {
+    expect(
+      concatenateQueryParamsOf(
+        'https://test.com',
+        'https://test2.com?utm_source=testing',
+      ),
+    ).toBe('https://test2.com/?utm_source=testing');
+  });
+
+  it('should concatenate query params if both urls have', () => {
+    expect(
+      concatenateQueryParamsOf(
+        'https://test.com?utm_medium=new_url&utm_source=testing',
+        'https://test2.com?utm_source=testing2',
+      ),
+    ).toBe('https://test2.com/?utm_source=testing2&utm_medium=new_url');
   });
 });
 

--- a/packages/experiment-tag/test/util.test.ts
+++ b/packages/experiment-tag/test/util.test.ts
@@ -149,6 +149,24 @@ describe('concateQueryParamsOf', () => {
       ),
     ).toBe('https://test2.com/?utm_source=testing2&utm_medium=new_url');
   });
+
+  it('should not include anchors from current url', () => {
+    expect(
+      concatenateQueryParamsOf(
+        'https://test.com?utm_medium=new_url&utm_source=testing#anchor1',
+        'https://test2.com?utm_source=testing2',
+      ),
+    ).toBe('https://test2.com/?utm_source=testing2&utm_medium=new_url');
+  });
+
+  it('should include anchors from redirected url', () => {
+    expect(
+      concatenateQueryParamsOf(
+        'https://test.com?utm_medium=new_url&utm_source=testing',
+        'https://test2.com?utm_source=testing2#anchor2',
+      ),
+    ).toBe('https://test2.com/?utm_source=testing2&utm_medium=new_url#anchor2');
+  });
 });
 
 afterAll(() => {


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

Add support for search param sharing in split url experiments

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
