### PR TITLE
fix: variant() debug log

### DIFF
--- a/packages/experiment-browser/src/experimentClient.ts
+++ b/packages/experiment-browser/src/experimentClient.ts
@@ -273,7 +273,7 @@ export class ExperimentClient implements Client {
       this.exposureInternal(key, sourceVariant);
     }
     this.debug(
-      `[Experiment] variant for ${key} is ${sourceVariant.variant?.value}`,
+      `[Experiment] variant for ${key} is ${sourceVariant.variant?.key || sourceVariant.variant?.value}`,
     );
     return sourceVariant.variant || {};
   }

--- a/packages/experiment-browser/src/experimentClient.ts
+++ b/packages/experiment-browser/src/experimentClient.ts
@@ -273,7 +273,9 @@ export class ExperimentClient implements Client {
       this.exposureInternal(key, sourceVariant);
     }
     this.debug(
-      `[Experiment] variant for ${key} is ${sourceVariant.variant?.key || sourceVariant.variant?.value}`,
+      `[Experiment] variant for ${key} is ${
+        sourceVariant.variant?.key || sourceVariant.variant?.value
+      }`,
     );
     return sourceVariant.variant || {};
   }


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

fix `variant()` debug log which was logging "variant is undefined" when `value` is undefined but `key` is defined.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
