### PR TITLE
fix: convert initial variants so experiment key is tracked correctly

### DIFF
--- a/packages/experiment-browser/src/experimentClient.ts
+++ b/packages/experiment-browser/src/experimentClient.ts
@@ -23,7 +23,7 @@ import { DefaultUserProvider } from './integration/default';
 import {
   getFlagStorage,
   getVariantStorage,
-  LoadStoreCache,
+  LoadStoreCache, transformVariantFromStorage
 } from './storage/cache';
 import { LocalStorage } from './storage/local-storage';
 import { FetchHttpClient, WrapperClient } from './transport/http';
@@ -114,6 +114,14 @@ export class ExperimentClient implements Client {
           ? euFlagsServerUrl
           : Defaults.flagsServerUrl),
     };
+    // Transform initialVariants
+    if (this.config.initialVariants) {
+      for (const flagKey in this.config.initialVariants) {
+        this.config.initialVariants[flagKey] = transformVariantFromStorage(
+          this.config.initialVariants[flagKey],
+        );
+      }
+    }
     if (this.config.userProvider) {
       this.userProvider = this.config.userProvider;
     }

--- a/packages/experiment-browser/src/experimentClient.ts
+++ b/packages/experiment-browser/src/experimentClient.ts
@@ -23,7 +23,8 @@ import { DefaultUserProvider } from './integration/default';
 import {
   getFlagStorage,
   getVariantStorage,
-  LoadStoreCache, transformVariantFromStorage
+  LoadStoreCache,
+  transformVariantFromStorage,
 } from './storage/cache';
 import { LocalStorage } from './storage/local-storage';
 import { FetchHttpClient, WrapperClient } from './transport/http';

--- a/packages/experiment-browser/test/client.test.ts
+++ b/packages/experiment-browser/test/client.test.ts
@@ -34,10 +34,10 @@ const testUser: ExperimentUser = { user_id: 'test_user' };
 
 const serverKey = 'sdk-ci-test';
 const serverVariant: Variant = { key: 'on', value: 'on', payload: 'payload' };
-const serverOffVariant: Variant = { value: 'off' };
+const serverOffVariant: Variant = { key: 'off', value: 'off' };
 
 const initialKey = 'initial-key';
-const initialVariant: Variant = { value: 'initial' };
+const initialVariant: Variant = { key: 'initial', value: 'initial' };
 
 const initialVariants: Variants = {
   'sdk-ci-test': serverOffVariant,
@@ -1130,4 +1130,34 @@ describe('fetch retry with different response codes', () => {
       expect(retryMock).toHaveBeenCalledTimes(retryCalled);
     },
   );
+});
+
+test('test bootstrapping with v2 variants', async () => {
+  let exposureObject: Exposure;
+  const client = new ExperimentClient(API_KEY, {
+    initialVariants: {
+      'test-v1': {
+        key: 'control',
+        value: 'control',
+        expKey: 'exp-1',
+      },
+      'test-v2': {
+        key: 'control',
+        value: 'control',
+        metadata: {
+          experimentKey: 'exp-2',
+        },
+      },
+    },
+    source: Source.InitialVariants,
+    exposureTrackingProvider: {
+      track(exposure: Exposure) {
+        exposureObject = exposure;
+      },
+    },
+  });
+  client.exposure('test-v1');
+  expect(exposureObject.experiment_key).toEqual('exp-1');
+  client.exposure('test-v2');
+  expect(exposureObject.experiment_key).toEqual('exp-2');
 });


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
