### PR TITLE
chore: fix Web Experimentation URL redirect preview max stack exceeded

### DIFF
--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -61,6 +61,13 @@ export const initializeExperiment = (apiKey: string, initialFlags: string) => {
     if (urlParams['PREVIEW']) {
       const parsedFlags = JSON.parse(initialFlags);
       parsedFlags.forEach((flag: EvaluationFlag) => {
+        // if in preview mode, strip query params
+        globalScope.history.replaceState(
+          {},
+          '',
+          removeQueryParams(globalScope.location.href, ['PREVIEW', flag.key]),
+        );
+
         if (flag.key in urlParams && urlParams[flag.key] in flag.variants) {
           flag.segments = [
             {
@@ -134,14 +141,6 @@ const handleRedirect = (action, key: string, variant: Variant) => {
       previousUrl || globalScope.document.referrer,
     );
     const redirectUrl = action?.data?.url;
-    // if in preview mode, strip query params
-    if (variant.metadata?.segmentName === 'preview') {
-      globalScope.history.replaceState(
-        {},
-        '',
-        removeQueryParams(globalScope.location.href, ['PREVIEW', key]),
-      );
-    }
     if (matchesUrl(urlExactMatch, currentUrl)) {
       if (
         !matchesUrl([redirectUrl], currentUrl) &&


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

Fix Web Experimentation URL redirect preview max stack exceeded

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
