### PR TITLE
feat: Add ability to test and initiate overlay from the customer site directly

### DIFF
--- a/packages/experiment-tag/src/messenger.ts
+++ b/packages/experiment-tag/src/messenger.ts
@@ -12,7 +12,10 @@ export class WindowMessenger {
         }>,
       ) => {
         const match = /^.*\.amplitude\.com$/;
-        if (!match.test(new URL(e.origin).hostname)) {
+        if (
+          !match.test(new URL(e.origin).hostname) &&
+          new URL(window.origin).hostname !== new URL(e.origin).hostname
+        ) {
           return;
         }
         if (e.data.type === 'OpenOverlay') {


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->
This allows us to initialize the overlay from the customer site instead of limiting it to just Amplitude. This is for testing purposes for Cypress e2e tests.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
