### PR TITLE
fix: Make AnalyticsConnector getInstance backwards compatible

### DIFF
--- a/packages/analytics-connector/src/analyticsConnector.ts
+++ b/packages/analytics-connector/src/analyticsConnector.ts
@@ -17,6 +17,16 @@ export class AnalyticsConnector {
       safeGlobal['analyticsConnectorInstances'][instanceName] =
         new AnalyticsConnector();
     }
-    return safeGlobal['analyticsConnectorInstances'][instanceName];
+    const instance = safeGlobal['analyticsConnectorInstances'][instanceName];
+    if (!instance.eventBridge.setInstanceName) {
+      const queue = instance.eventBridge.queue ?? [];
+      const receiver = instance.eventBridge.receiver;
+      instance.eventBridge = new EventBridgeImpl();
+      for (const event in queue) {
+        instance.eventBridge.logEvent(event);
+      }
+      instance.eventBridge.setEventReceiver(receiver);
+    }
+    return instance;
   }
 }

--- a/packages/analytics-connector/src/analyticsConnector.ts
+++ b/packages/analytics-connector/src/analyticsConnector.ts
@@ -24,7 +24,10 @@ export class AnalyticsConnector {
       const receiver = instance.eventBridge.receiver;
       instance.eventBridge = new EventBridgeImpl();
       instance.eventBridge.setInstanceName(instanceName);
-      instance.eventBridge.setEventReceiver(receiver);
+      // handle case when receiver was not set during previous initialization
+      if (receiver) {
+        instance.eventBridge.setEventReceiver(receiver);
+      }
       for (const event of queue) {
         instance.eventBridge.logEvent(event);
       }

--- a/packages/analytics-connector/src/analyticsConnector.ts
+++ b/packages/analytics-connector/src/analyticsConnector.ts
@@ -18,14 +18,16 @@ export class AnalyticsConnector {
         new AnalyticsConnector();
     }
     const instance = safeGlobal['analyticsConnectorInstances'][instanceName];
+    // If the eventBridge is using old implementation, update with new instance
     if (!instance.eventBridge.setInstanceName) {
       const queue = instance.eventBridge.queue ?? [];
       const receiver = instance.eventBridge.receiver;
       instance.eventBridge = new EventBridgeImpl();
-      for (const event in queue) {
+      instance.eventBridge.setInstanceName(instanceName);
+      instance.eventBridge.setEventReceiver(receiver);
+      for (const event of queue) {
         instance.eventBridge.logEvent(event);
       }
-      instance.eventBridge.setEventReceiver(receiver);
     }
     return instance;
   }


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

Make AnalyticsConnector getInstance backwards compatible between use in web experimentation script and feature experiment SDK

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
