### PR TITLE
fix: persistent tracking queue flush when tracker set

### DIFF
--- a/packages/experiment-browser/src/integration/manager.ts
+++ b/packages/experiment-browser/src/integration/manager.ts
@@ -170,7 +170,6 @@ export class PersistentTrackingQueue {
   private readonly maxQueueSize: number;
   private readonly isLocalStorageAvailable = isLocalStorageAvailable();
   private inMemoryQueue: ExperimentEvent[] = [];
-  private poller: any | undefined;
   private tracker: ((event: ExperimentEvent) => boolean) | undefined;
 
   constructor(instanceName: string, maxQueueSize: number = MAX_QUEUE_SIZE) {
@@ -197,10 +196,6 @@ export class PersistentTrackingQueue {
       if (!this.tracker(event)) return;
     }
     this.inMemoryQueue = [];
-    if (this.poller) {
-      safeGlobal.clearInterval(this.poller);
-      this.poller = undefined;
-    }
   }
 
   private loadQueue(): void {

--- a/packages/experiment-browser/src/integration/manager.ts
+++ b/packages/experiment-browser/src/integration/manager.ts
@@ -61,17 +61,17 @@ export class IntegrationManager {
     if (integration.setup) {
       this.integration.setup(this.config, this.client).then(
         () => {
-          this.queue.tracker = this.integration.track.bind(integration);
+          this.queue.setTracker(this.integration.track.bind(integration));
           this.resolve();
         },
         (e) => {
           console.error('Integration setup failed.', e);
-          this.queue.tracker = this.integration.track.bind(integration);
+          this.queue.setTracker(this.integration.track.bind(integration));
           this.resolve();
         },
       );
     } else {
-      this.queue.tracker = this.integration.track.bind(integration);
+      this.queue.setTracker(this.integration.track.bind(integration));
       this.resolve();
     }
   }
@@ -171,19 +171,11 @@ export class PersistentTrackingQueue {
   private readonly isLocalStorageAvailable = isLocalStorageAvailable();
   private inMemoryQueue: ExperimentEvent[] = [];
   private poller: any | undefined;
-
-  tracker: ((event: ExperimentEvent) => boolean) | undefined;
+  private tracker: ((event: ExperimentEvent) => boolean) | undefined;
 
   constructor(instanceName: string, maxQueueSize: number = MAX_QUEUE_SIZE) {
     this.storageKey = `EXP_unsent_${instanceName}`;
     this.maxQueueSize = maxQueueSize;
-    this.loadQueue();
-    if (this.inMemoryQueue.length > 0) {
-      this.poller = safeGlobal.setInterval(() => {
-        this.loadFlushStore();
-      }, 1000);
-    }
-    this.loadFlushStore();
   }
 
   push(event: ExperimentEvent): void {
@@ -191,6 +183,11 @@ export class PersistentTrackingQueue {
     this.inMemoryQueue.push(event);
     this.flush();
     this.storeQueue();
+  }
+
+  setTracker(tracker: (event: ExperimentEvent) => boolean): void {
+    this.tracker = tracker;
+    this.loadFlushStore();
   }
 
   private flush(): void {

--- a/packages/experiment-browser/test/integration/manager.test.ts
+++ b/packages/experiment-browser/test/integration/manager.test.ts
@@ -323,10 +323,10 @@ describe('PersistentTrackingQueue', () => {
     const instanceName = '$default_instance';
     const queue = new PersistentTrackingQueue(instanceName);
     const trackedEvents: ExperimentEvent[] = [];
-    queue.tracker = (event) => {
+    queue.setTracker((event) => {
       trackedEvents.push(event);
       return false;
-    };
+    });
     const event: ExperimentEvent = {
       eventType: '$exposure',
       eventProperties: {
@@ -354,10 +354,10 @@ describe('PersistentTrackingQueue', () => {
     const instanceName = '$default_instance';
     const queue = new PersistentTrackingQueue(instanceName);
     const trackedEvents: ExperimentEvent[] = [];
-    queue.tracker = (event) => {
+    queue.setTracker((event) => {
       trackedEvents.push(event);
       return true;
-    };
+    });
     const event: ExperimentEvent = {
       eventType: '$exposure',
       eventProperties: {
@@ -399,10 +399,10 @@ describe('PersistentTrackingQueue', () => {
       JSON.stringify([event]),
     );
 
-    queue.tracker = (event) => {
+    queue.setTracker((event) => {
       trackedEvents.push(event);
       return true;
-    };
+    });
 
     queue.push(event);
     expect(queue['inMemoryQueue']).toEqual([]);


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
