### PR TITLE
fix: add MessageEvent origin check for visual editor initialization

### DIFF
--- a/packages/experiment-tag/src/messenger.ts
+++ b/packages/experiment-tag/src/messenger.ts
@@ -12,7 +12,7 @@ export class WindowMessenger {
         }>,
       ) => {
         const match = /^.*\.amplitude\.com$/;
-        if (!match.test(new URL(e.origin).hostname)) {
+        if (!e.origin || !match.test(new URL(e.origin).hostname)) {
           return;
         }
         if (e.data.type === 'OpenOverlay') {


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

Add origin check for MessageEvent that triggers visual editor initialization in Web Experimentation.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
