### PR TITLE
fix: catch flag fetch timeout error when not in debug mode

### DIFF
--- a/packages/experiment-browser/src/experimentClient.ts
+++ b/packages/experiment-browser/src/experimentClient.ts
@@ -711,8 +711,8 @@ export class ExperimentClient implements Client {
       this.flags.clear();
       this.flags.putAll(flags);
     } catch (e) {
-      if (this.config.debug && e instanceof TimeoutError) {
-        console.debug(e);
+      if (e instanceof TimeoutError) {
+        this.config.debug && console.debug(e);
       } else {
         throw e;
       }


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

Catch flag fetch timeout error even when the experiment client is not in debug logging mode.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
