### PR TITLE
feat: add feature experiment support in web script

### DIFF
--- a/packages/experiment-browser/src/factory.ts
+++ b/packages/experiment-browser/src/factory.ts
@@ -1,11 +1,14 @@
 import { AnalyticsConnector } from '@amplitude/analytics-connector';
+import { safeGlobal } from '@amplitude/experiment-core';
 
 import { Defaults, ExperimentConfig } from './config';
 import { ExperimentClient } from './experimentClient';
 import { AmplitudeIntegrationPlugin } from './integration/amplitude';
 import { DefaultUserProvider } from './providers/default';
 
-const instances = {};
+// Global instances for debugging.
+safeGlobal.experimentInstances = {};
+const instances = safeGlobal.experimentInstances;
 
 const getInstanceName = (config: ExperimentConfig): string => {
   return config?.instanceName || Defaults.instanceName;
@@ -18,7 +21,7 @@ const getInstanceName = (config: ExperimentConfig): string => {
  * @param apiKey The deployment API Key
  * @param config See {@link ExperimentConfig} for config options
  */
-const initialize = (
+export const initialize = (
   apiKey: string,
   config?: ExperimentConfig,
 ): ExperimentClient => {
@@ -52,7 +55,7 @@ const initialize = (
  * @param apiKey The deployment API Key
  * @param config See {@link ExperimentConfig} for config options
  */
-const initializeWithAmplitudeAnalytics = (
+export const initializeWithAmplitudeAnalytics = (
   apiKey: string,
   config?: ExperimentConfig,
 ): ExperimentClient => {

--- a/packages/experiment-browser/src/index.ts
+++ b/packages/experiment-browser/src/index.ts
@@ -11,7 +11,11 @@ export {
   AmplitudeAnalyticsProvider,
 } from './providers/amplitude';
 export { AmplitudeIntegrationPlugin } from './integration/amplitude';
-export { Experiment } from './factory';
+export {
+  Experiment,
+  initialize,
+  initializeWithAmplitudeAnalytics,
+} from './factory';
 export { StubExperimentClient } from './stubClient';
 export { ExperimentClient } from './experimentClient';
 export { Client, FetchOptions } from './types/client';

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -5,6 +5,7 @@ import {
   getGlobalScope,
   isLocalStorageAvailable,
 } from '@amplitude/experiment-core';
+import { safeGlobal } from '@amplitude/experiment-core';
 import {
   Experiment,
   ExperimentUser,
@@ -12,6 +13,7 @@ import {
   Variants,
   AmplitudeIntegrationPlugin,
 } from '@amplitude/experiment-js-client';
+import * as FeatureExperiment from '@amplitude/experiment-js-client';
 import mutate, { MutationController } from 'dom-mutator';
 
 import { getInjectUtils } from './inject-utils';
@@ -23,6 +25,8 @@ import {
   UUID,
   concatenateQueryParamsOf,
 } from './util';
+
+safeGlobal.Experiment = FeatureExperiment;
 
 const appliedInjections: Set<string> = new Set();
 const appliedMutations: MutationController[] = [];

--- a/packages/experiment-tag/test/experiment.test.ts
+++ b/packages/experiment-tag/test/experiment.test.ts
@@ -1,4 +1,5 @@
 import * as coreUtil from '@amplitude/experiment-core';
+import { safeGlobal } from '@amplitude/experiment-core';
 import { ExperimentClient } from '@amplitude/experiment-js-client';
 import { initializeExperiment } from 'src/experiment';
 import * as experiment from 'src/experiment';
@@ -735,4 +736,8 @@ describe('initializeExperiment', () => {
     );
     expect(mockExposure).not.toHaveBeenCalled();
   });
+});
+
+test('feature experiment on global Experiment object', () => {
+  expect(safeGlobal.Experiment).toBeDefined();
 });


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

1. Exports `initialize` and `initializeWithAmplitudeAnalytics` directly from the SDK module. This avoids Experiment.Experiment.initializeWithAmplitudeAnalytics when installing via script.
2. Sets `window.Experiment` equal to full feature experiment SDK package in web script. This allows customers to create feature experiment SDK instances using the web experiment script (one script for both feature and web).

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> no
