### PR TITLE
feat: increase flag polling interval; add flag poller interval config

### DIFF
--- a/packages/experiment-browser/src/config.ts
+++ b/packages/experiment-browser/src/config.ts
@@ -89,6 +89,12 @@ export interface ExperimentConfig {
   pollOnStart?: boolean;
 
   /**
+   * The interval to poll local evaluation flag configurations on `start()`.
+   * Only used if `pollOnStart` is `true`. Minimum 60000.
+   */
+  flagConfigPollingIntervalMillis?: number;
+
+  /**
    * Explicitly enable or disable calling {@link fetch()} on {@link start()}:
    *
    *  - `true`:      fetch will always be called on start.
@@ -159,6 +165,7 @@ export interface ExperimentConfig {
  | **retryFailedAssignment**    | `true` |
  | **automaticExposureTracking** | `true` |
  | **pollOnStart** | `true` |
+ | **flagConfigPollingIntervalMillis** | `300000` |
  | **fetchOnStart** | `true` |
  | **automaticFetchOnAmplitudeIdentityChange** | `false` |
  | **userProvider**    | `null` |
@@ -182,6 +189,7 @@ export const Defaults: ExperimentConfig = {
   retryFetchOnFailure: true,
   automaticExposureTracking: true,
   pollOnStart: true,
+  flagConfigPollingIntervalMillis: 300000,
   fetchOnStart: true,
   automaticFetchOnAmplitudeIdentityChange: false,
   userProvider: null,

--- a/packages/experiment-browser/src/experimentClient.ts
+++ b/packages/experiment-browser/src/experimentClient.ts
@@ -57,7 +57,7 @@ const fetchBackoffAttempts = 8;
 const fetchBackoffMinMillis = 500;
 const fetchBackoffMaxMillis = 10000;
 const fetchBackoffScalar = 1.5;
-const flagPollerIntervalMillis = 60000;
+const minFlagPollerIntervalMillis = 60000;
 
 const euServerUrl = 'https://api.lab.eu.amplitude.com';
 const euFlagsServerUrl = 'https://flag.lab.eu.amplitude.com';
@@ -80,10 +80,7 @@ export class ExperimentClient implements Client {
   private userProvider: ExperimentUserProvider | undefined;
   private exposureTrackingProvider: ExposureTrackingProvider | undefined;
   private retriesBackoff: Backoff | undefined;
-  private poller: Poller = new Poller(
-    () => this.doFlags(),
-    flagPollerIntervalMillis,
-  );
+  private poller: Poller;
   private isRunning = false;
   private readonly integrationManager: IntegrationManager;
 
@@ -116,7 +113,18 @@ export class ExperimentClient implements Client {
         (config?.serverZone?.toLowerCase() === 'eu'
           ? euFlagsServerUrl
           : Defaults.flagsServerUrl),
+      // Force minimum flag config polling interval.
+      flagConfigPollingIntervalMillis:
+        config.flagConfigPollingIntervalMillis < minFlagPollerIntervalMillis
+          ? minFlagPollerIntervalMillis
+          : config.flagConfigPollingIntervalMillis
+          ? config.flagConfigPollingIntervalMillis
+          : Defaults.flagConfigPollingIntervalMillis,
     };
+    this.poller = new Poller(
+      () => this.doFlags(),
+      config.flagConfigPollingIntervalMillis,
+    );
     // Transform initialVariants
     if (this.config.initialVariants) {
       for (const flagKey in this.config.initialVariants) {

--- a/packages/experiment-browser/test/client.test.ts
+++ b/packages/experiment-browser/test/client.test.ts
@@ -1,5 +1,6 @@
 import { AnalyticsConnector } from '@amplitude/analytics-connector';
 import { FetchError, safeGlobal } from '@amplitude/experiment-core';
+import { Defaults } from 'src/config';
 import { ExperimentEvent, IntegrationPlugin } from 'src/types/plugin';
 
 import { version as PACKAGE_VERSION } from '../package.json';
@@ -1321,5 +1322,24 @@ describe('trackExposure variant metadata', () => {
     });
     client.exposure('flag');
     expect(providerExposure).toBeUndefined();
+  });
+});
+
+describe('flag config polling interval config', () => {
+  test('undefined, set to default', () => {
+    const client = new ExperimentClient('api_key', {});
+    expect(client['config'].flagConfigPollingIntervalMillis).toEqual(300000);
+  });
+  test('defined, less than minimum, set to minimum', () => {
+    const client = new ExperimentClient('api_key', {
+      flagConfigPollingIntervalMillis: 1000,
+    });
+    expect(client['config'].flagConfigPollingIntervalMillis).toEqual(60000);
+  });
+  test('defined, greater than minimum, set to configured value', () => {
+    const client = new ExperimentClient('api_key', {
+      flagConfigPollingIntervalMillis: 900000,
+    });
+    expect(client['config'].flagConfigPollingIntervalMillis).toEqual(900000);
   });
 });


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

* Set the default flag polling interval to 5 min
* Add polling interval config with min value of 1 min

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> no
