### PR TITLE
Fix evaluation against the number value 0

### DIFF
--- a/packages/experiment-core/src/evaluation/evaluation.ts
+++ b/packages/experiment-core/src/evaluation/evaluation.ts
@@ -403,7 +403,7 @@ export class EvaluationEngine {
   }
 
   private coerceString(value: unknown | undefined): string | undefined {
-    if (!value) {
+    if (value === undefined || value === null) {
       return undefined;
     }
     if (typeof value === 'object') {


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

Fixes a small bug when comparing against the number `0`.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
