### PR TITLE
feat: Add reapplyVariants API

### DIFF
--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -124,6 +124,7 @@ export const initializeExperiment = (apiKey: string, initialFlags: string) => {
   globalScope.experimentIntegration.type = 'integration';
   globalScope.webExperiment.addPlugin(globalScope.experimentIntegration);
   globalScope.webExperiment.setUser(user);
+  globalScope.webExperiment.reapplyVariants = reapplyVariants;
 
   const variants = globalScope.webExperiment.all();
 
@@ -223,6 +224,16 @@ const revertMutations = () => {
   }
 };
 
+export const reapplyVariants = () => {
+  const globalScope = getGlobalScope();
+  if (!globalScope) {
+    return;
+  }
+
+  revertMutations();
+  applyVariants(globalScope.webExperiment.all());
+};
+
 const handleInject = (action, key: string, variant: Variant) => {
   const globalScope = getGlobalScope();
   if (!globalScope) {
@@ -303,8 +314,7 @@ export const setUrlChangeListener = () => {
   }
   // Add URL change listener for back/forward navigation
   globalScope.addEventListener('popstate', () => {
-    revertMutations();
-    applyVariants(globalScope.webExperiment.all());
+    reapplyVariants();
   });
 
   // Create wrapper functions for pushState and replaceState
@@ -317,8 +327,7 @@ export const setUrlChangeListener = () => {
       // Call the original pushState
       const result = originalPushState.apply(this, args);
       // Revert mutations and apply variants
-      revertMutations();
-      applyVariants(globalScope.webExperiment.all());
+      reapplyVariants();
       previousUrl = globalScope.location.href;
       return result;
     };
@@ -328,8 +337,7 @@ export const setUrlChangeListener = () => {
       // Call the original replaceState
       const result = originalReplaceState.apply(this, args);
       // Revert mutations and apply variants
-      revertMutations();
-      applyVariants(globalScope.webExperiment.all());
+      reapplyVariants();
       previousUrl = globalScope.location.href;
       return result;
     };


### PR DESCRIPTION
### Summary

#### Add `reapplyVariants` Function to Web Experimentation SDK

#### Problem

The Web Experimentation SDK currently lacks a way to manually **refresh** experiment variants on a page without requiring a full page reload. This becomes problematic in scenarios such as:
- Runtime changes in single-page applications
- Custom routing events that don't trigger normal navigation
- Testing and debugging experiments

These are relatively common use cases in client-side applications and can block Web Experimentation usage and adoption.

#### Solution

Add a new public method `reapplyVariants()` to the Web Experimentation SDK that safely **re**verts existing mutations and re**applies** current **variants**. This method will be exposed on the global `webExperiment` object.

Example usage:

```javascript
// Revert and reapply all experiment variants
window.webExperiment.reapplyVariants();
```

This method can be an **escape hatch** for more advanced use cases, allowing developers to implement support for Web Experimentation in cases where the current `<script>` usage limits them.

<hr>

#### Implementation

The implementation uses existing internal functions `revertMutations` and `applyVariants` to safely handle the refresh operation:

```javascript
export const reapplyVariants = () => {
  const globalScope = getGlobalScope();
  if (!globalScope) {
    return;
  }

  revertMutations();
  applyVariants(globalScope.webExperiment.all());
};
```

```javascript
// Expose on global scope
globalScope.webExperiment.reapplyVariants = reapplyVariants;
```

**Note** that by refresh, I mean (at least) the following actions:
1. Revert current experiment variants
2. Retrieve fresh local context
3. Evaluate all variants
4. Apply variants

#### Use Cases

##### Runtime Changes: Localization

Consider an element change (text) web experiment in a Vue application that uses a Cookie to [target](https://amplitude.com/docs/web-experiment/targeting#audience-targeting) users based on their `locale`:

1. Initial state (English):
```html
<!-- Original button in Vue template -->
<button>Sign Up</button>

<!-- After experiment applies (targeting locale=en users) -->
<button>Join Now - Special Offer!</button>
```

2. User changes language:
```javascript
// LanguageSelector.vue
const switchToSpanish = async () => {
  // Update locale cookie used by experiment targeting (some i18n plugins do this automatically)
  document.cookie = 'locale=es;path=/';
  
  // Update app language reactively (no page reload)
  await setLocale('es');
  
  // Without reapplyVariants():
  // Button would still show English experiment text "Join Now - Special Offer!"
  // even though user is no longer in the English-targeted segment
  
  // With reapplyVariants():
  window.webExperiment.reapplyVariants();
  // Button reverts to original "Registrarse" since user 
  // no longer matches English locale targeting
};
```

##### Custom Navigation

For applications with custom routing that doesn't trigger normal navigation events:

```javascript
const customNavigate = (route) => {
  updateRoute(route);
  // Refresh experiments for new route
  window.webExperiment.reapplyVariants();
};
```

##### Testing and Debugging

During development and testing, to manually refresh experiments:

```javascript
// Dev tools console
window.webExperiment.reapplyVariants();
```

#### Notes

To test the Amplitude Web Experimentation feature set, I created a [demo project](https://github.com/do-adams/amp-web-exp-csr). It reproduces one of the problematic scenarios: **stale experiment variant application due to localization runtime changes**.

https://github.com/user-attachments/assets/dbfb1839-c2ba-4a4c-9388-30e08c66bbb3

The `reapplyVariants` API would allow for refreshing the experiment variants without reloading the page and losing client-side state.

Here is a production example where the treatment variant is targeting users with a `locale` cookie value of `en`:

https://github.com/user-attachments/assets/f49edab7-dd19-497d-82f3-83b52445ddac

The `Language` input updates the `locale` cookie with a value of `en` or `es`. However, since there is no way to reapply the variants in response to user input, the only option is to refresh the page which is not a good user experience.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change? *No*
