### PR TITLE
fix: Catch error in getUrlParam() in DefaultUserProvider

### DIFF
--- a/packages/experiment-browser/src/providers/default.ts
+++ b/packages/experiment-browser/src/providers/default.ts
@@ -119,14 +119,20 @@ export class DefaultUserProvider implements ExperimentUserProvider {
 
   private getUrlParam(): Record<string, string | string[]> {
     if (!this.globalScope) {
-      return {};
+      return undefined;
     }
 
     const params: Record<string, string[]> = {};
-    for (const [name, value] of new URL(this.globalScope?.location?.href)
-      .searchParams) {
-      params[name] = [...(params[name] ?? []), ...value.split(',')];
+
+    try {
+      const url = new URL(this.globalScope.location.href);
+      for (const [name, value] of url.searchParams) {
+        params[name] = [...(params[name] ?? []), ...value.split(',')];
+      }
+    } catch (error) {
+      return undefined;
     }
+
     return Object.entries(params).reduce<Record<string, string | string[]>>(
       (acc, [name, value]) => {
         acc[name] = value.length == 1 ? value[0] : value;


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

Catch error from getUrlParam() in DefaultUserProvider when `new URL(this.globalScope.location.href)` throws an error.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
