### PR TITLE
feat: migrate to use web_exp_id for web experiment device_id bucketing

### DIFF
--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -59,24 +59,20 @@ export const initializeExperiment = async (
     user = {};
   }
 
-  // create new user if it does not exist, or it does not have device_id or web_exp_id
-  if (Object.keys(user).length === 0 || !user.device_id || !user.web_exp_id) {
-    if (!user.device_id || !user.web_exp_id) {
-      // if user has device_id, migrate it to web_exp_id
-      if (user.device_id) {
-        user.web_exp_id = user.device_id;
-      } else if (user.web_exp_id) {
-        user.device_id = user.web_exp_id;
-      } else {
-        const uuid = UUID();
-        // both IDs are set for backwards compatibility, to be removed in future update
-        user = { device_id: uuid, web_exp_id: uuid };
-      }
-      globalScope.localStorage.setItem(
-        experimentStorageName,
-        JSON.stringify(user),
-      );
+  // create new user if it does not exist, or it does not have web_exp_id
+  if (Object.keys(user).length === 0 || !user.web_exp_id) {
+    // if user has device_id, migrate it to web_exp_id
+    if (user.device_id) {
+      user.web_exp_id = user.device_id;
+      delete user.device_id;
+    } else {
+      const uuid = UUID();
+      user = { web_exp_id: uuid };
     }
+    globalScope.localStorage.setItem(
+      experimentStorageName,
+      JSON.stringify(user),
+    );
   }
 
   const urlParams = getUrlParams();

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -59,16 +59,18 @@ export const initializeExperiment = async (
     user = {};
   }
 
-  // create new user if it does not exist, or it does not have web_exp_id
-  if (Object.keys(user).length === 0 || !user.web_exp_id) {
-    // if user has device_id, migrate it to web_exp_id
-    if (user.device_id) {
-      user.web_exp_id = user.device_id;
-      delete user.device_id;
-    } else {
-      const uuid = UUID();
-      user = { web_exp_id: uuid };
-    }
+  // migrate device_id to web_exp_id if it exists
+  // if web_exp_id does not exist, create a new one
+  // if both web_exp_id and device_id exist, remove device_id
+  if (!user.web_exp_id) {
+    user.web_exp_id = user.device_id || UUID();
+    delete user.device_id;
+    globalScope.localStorage.setItem(
+      experimentStorageName,
+      JSON.stringify(user),
+    );
+  } else if (user.web_exp_id && user.device_id) {
+    delete user.device_id;
     globalScope.localStorage.setItem(
       experimentStorageName,
       JSON.stringify(user),

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -59,9 +59,10 @@ export const initializeExperiment = async (
     user = {};
   }
 
-  // migrate device_id to web_exp_id if it exists
-  // if web_exp_id does not exist, create a new one
-  // if both web_exp_id and device_id exist, remove device_id
+  // if web_exp_id does not exist:
+  // 1. if device_id exists, migrate device_id to web_exp_id and remove device_id
+  // 2. if device_id does not exist, create a new web_exp_id
+  // 3. if both device_id and web_exp_id exist, remove device_id
   if (!user.web_exp_id) {
     user.web_exp_id = user.device_id || UUID();
     delete user.device_id;

--- a/packages/experiment-tag/test/experiment.test.ts
+++ b/packages/experiment-tag/test/experiment.test.ts
@@ -55,12 +55,11 @@ describe('initializeExperiment', () => {
   test('should initialize experiment with empty user', () => {
     initializeExperiment(stringify(apiKey), JSON.stringify([]));
     expect(ExperimentClient.prototype.setUser).toHaveBeenCalledWith({
-      device_id: 'mock',
       web_exp_id: 'mock',
     });
     expect(mockGlobal.localStorage.setItem).toHaveBeenCalledWith(
       'EXP_1',
-      JSON.stringify({ device_id: 'mock', web_exp_id: 'mock' }),
+      JSON.stringify({ web_exp_id: 'mock' }),
     );
   });
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

Necessary migration to use web_exp_id for web experiment device_id bucketing

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
