### PR TITLE
fix: wait for context before web experiment flags req

### DIFF
--- a/packages/experiment-browser/src/experimentClient.ts
+++ b/packages/experiment-browser/src/experimentClient.ts
@@ -710,16 +710,20 @@ export class ExperimentClient implements Client {
 
   private async doFlags(): Promise<void> {
     try {
+      // Web experiment adds a user to the flags request
       const isWebExperiment =
         this.config?.['internalInstanceNameSuffix'] === 'web';
-      const user = this.addContext(this.getUser());
+      let user: ExperimentUser;
+      if (isWebExperiment) {
+        user = await this.addContextOrWait(this.getUser());
+      }
       const flags = await this.flagApi.getFlags({
         libraryName: 'experiment-js-client',
         libraryVersion: PACKAGE_VERSION,
         timeoutMillis: this.config.fetchTimeoutMillis,
         deliveryMethod: isWebExperiment ? 'web' : undefined,
         user:
-          isWebExperiment && (user?.user_id || user?.device_id)
+          user?.user_id || user?.device_id
             ? { user_id: user?.user_id, device_id: user?.device_id }
             : undefined,
       });


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
