### PR TITLE
fix: store remote flags in session storage for reuse within session

### DIFF
--- a/packages/experiment-tag/test/experiment.test.ts
+++ b/packages/experiment-tag/test/experiment.test.ts
@@ -641,7 +641,7 @@ describe('initializeExperiment', () => {
     });
     test('evaluated, applied, and impression tracked, start updates flag in storage, applied, impression deduped', async () => {
       const apiKey = 'api1';
-      const storageKey = `amp-exp-$default_instance-${apiKey}-flags`;
+      const storageKey = `amp-exp-$default_instance-web-${apiKey}-flags`;
       // Create mock session storage with initial value
       const storedFlag = createFlag('test', 'treatment', 'local', false, {
         flagVersion: 2,
@@ -698,7 +698,7 @@ describe('initializeExperiment', () => {
     });
     test('evaluated, applied, and impression tracked, start updates flag in storage, applied, impression re-tracked', async () => {
       const apiKey = 'api2';
-      const storageKey = `amp-exp-$default_instance-${apiKey}-flags`;
+      const storageKey = `amp-exp-$default_instance-web-${apiKey}-flags`;
       // Create mock session storage with initial value
       const storedFlag = createFlag('test', 'treatment', 'local', false, {
         flagVersion: 2,

--- a/packages/experiment-tag/test/util/create-flag.ts
+++ b/packages/experiment-tag/test/util/create-flag.ts
@@ -1,3 +1,5 @@
+import { EvaluationFlag } from '@amplitude/experiment-core';
+
 export const createRedirectFlag = (
   flagKey = 'test',
   variant: 'treatment' | 'control' | 'off',
@@ -5,7 +7,7 @@ export const createRedirectFlag = (
   controlUrl: string | undefined = undefined,
   segments: any[] = [],
   evaluationMode: 'local' | 'remote' = 'local',
-) => {
+): EvaluationFlag => {
   const controlPayload = controlUrl
     ? [
         {
@@ -61,15 +63,33 @@ export const createRedirectFlag = (
   };
 };
 
+export const createFlag = (
+  flagKey = 'test',
+  variant: 'treatment' | 'control' | 'off',
+  evaluationMode: 'local' | 'remote' = 'local',
+  blockingEvaluation = true,
+  metadata: Record<string, any> = {},
+): EvaluationFlag => {
+  return createMutateFlag(
+    flagKey,
+    variant,
+    [],
+    [],
+    evaluationMode,
+    blockingEvaluation,
+    metadata,
+  );
+};
+
 export const createMutateFlag = (
   flagKey = 'test',
   variant: 'treatment' | 'control' | 'off',
   treatmentMutations: any[] = [],
-  controlMutations: any[] = [],
   segments: any[] = [],
   evaluationMode: 'local' | 'remote' = 'local',
   blockingEvaluation = true,
-) => {
+  metadata: Record<string, any> = {},
+): EvaluationFlag => {
   return {
     key: flagKey,
     metadata: {
@@ -78,6 +98,7 @@ export const createMutateFlag = (
       flagType: 'experiment',
       deliveryMethod: 'web',
       blockingEvaluation: evaluationMode === 'remote' && blockingEvaluation,
+      ...metadata,
     },
     segments: [
       ...segments,
@@ -91,14 +112,7 @@ export const createMutateFlag = (
     variants: {
       control: {
         key: 'control',
-        payload: [
-          {
-            action: 'mutate',
-            data: {
-              mutations: controlMutations,
-            },
-          },
-        ],
+        payload: [],
         value: 'control',
       },
       off: {


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->

Store flags fetched from network in session storage and re-use the flags when applying local flags before re-fetching from remote.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
