### PR TITLE
fix: fix cookie parsing for b64 strings

### DIFF
--- a/packages/experiment-browser/src/util/state.ts
+++ b/packages/experiment-browser/src/util/state.ts
@@ -26,14 +26,14 @@ export const parseAmplitudeCookie = (
   try {
     // New format
     if (newFormat) {
-      const decoding = Buffer.from(value, 'base64').toString('utf-8');
+      const decoding = atob(value);
       return JSON.parse(decodeURIComponent(decoding)) as AmplitudeState;
     }
     // Old format
     const values = value.split('.');
     let userId = undefined;
     if (values.length >= 2 && values[1]) {
-      userId = Buffer.from(values[1], 'base64').toString('utf-8');
+      userId = atob(values[1]);
     }
     return {
       deviceId: values[0],

--- a/packages/experiment-browser/src/util/state.ts
+++ b/packages/experiment-browser/src/util/state.ts
@@ -14,7 +14,7 @@ export const parseAmplitudeCookie = (
   let value: string | undefined = undefined;
   const cookies = safeGlobal.document.cookie.split('; ');
   for (const cookie of cookies) {
-    const [cookieKey, cookieValue] = cookie.split('=');
+    const [cookieKey, cookieValue] = cookie.split('=', 2);
     if (cookieKey === key) {
       value = decodeURIComponent(cookieValue);
     }


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->

When a base64 string has `=` padding at the end, the base64 parse would fail.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
