### PR TITLE
fix: change integration timeout to 100ms

### DIFF
--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -223,7 +223,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       this.globalScope.experimentIntegration = new AmplitudeIntegrationPlugin(
         this.apiKey,
         connector,
-        0,
+        100,
       );
     }
     this.globalScope.experimentIntegration.type = 'integration';


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->

0ms timeout meant remote eval will not wait for setup before making the call. 

* use a 100ms timeout to wait for initial identity info

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
