### PR TITLE
feat: experiment plugin

### DIFF
--- a/examples/react-app/amplitude-integration/package.json
+++ b/examples/react-app/amplitude-integration/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@amplitude/analytics-browser": "^2.12.2",
+    "@amplitude/analytics-browser": "^2.15.0",
     "@amplitude/experiment-js-client": "^1.5.6",
     "@types/node": "^16.11.29",
     "@types/react": "^18.0.7",

--- a/examples/react-app/amplitude-integration/package.json
+++ b/examples/react-app/amplitude-integration/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@amplitude/analytics-browser": "2.12.2",
+    "@amplitude/analytics-browser": "^2.12.2",
     "@amplitude/experiment-js-client": "^1.5.6",
     "@types/node": "^16.11.29",
     "@types/react": "^18.0.7",

--- a/examples/react-app/amplitude-integration/package.json
+++ b/examples/react-app/amplitude-integration/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@amplitude/analytics-browser": "^1.12.1",
+    "@amplitude/analytics-browser": "2.12.2",
     "@amplitude/experiment-js-client": "^1.5.6",
     "@types/node": "^16.11.29",
     "@types/react": "^18.0.7",

--- a/examples/react-app/amplitude-integration/src/index.tsx
+++ b/examples/react-app/amplitude-integration/src/index.tsx
@@ -3,44 +3,58 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import * as amplitude from '@amplitude/analytics-browser';
-import { Experiment, experimentAnalyticsPlugin, ExperimentClient } from "@amplitude/experiment-js-client";
+import { ExperimentClient, ExperimentAnalyticsPlugin } from "@amplitude/experiment-js-client";
 import { AmplitudeBrowser } from "@amplitude/analytics-browser";
 
-// Module augmentation to add experiment variable at compile time
+// Module augmentation to add experiment at compile time
 declare module '@amplitude/analytics-browser' {
   interface AmplitudeBrowser {
+    /**
+     * Install the Amplitude Experiment plugin to the Amplitude Analytics instance
+     * by `client.add(new ExperimentAnalyticsPlugin());`
+     *
+     * Call experiment APIs by accessing the underlying experiment instance,
+     * for example, `client.experiment.fetch();`
+     *
+     * The user identity and user properties set in the analytics SDK will
+     * automatically be used by the Experiment SDK on fetch().
+     */
     experiment: ExperimentClient;
   }
 }
 
+// Add experiment property at run time
+Object.defineProperty(AmplitudeBrowser.prototype, 'experiment', {
+  get: function() {
+    return (
+      this.plugin(
+        'experiment-analytics-plugin',
+      ) as ExperimentAnalyticsPlugin
+    ).experiment;
+  },
+});
+
+
+// amplitude.init() is the result of object destructuring.
+// It's part of BrowserClient interface.
+// So has to use class here.
 /**
  * Initialize the Amplitude Analytics SDK.
  */
-amplitude.init('API_KEY', 'user@company.com');
-amplitude.identify(new amplitude.Identify().set('premium', true))
-
-// Add experiment plugin to existing Amplitude analytics SDK
-// and call experiment APIs.
-// amplitude.init is the result of object destructuring.
-// It's part of BrowserClient interface.
-// So has to create a real object.
 const client: AmplitudeBrowser = new amplitude.AmplitudeBrowser();
-client.init('API_KEY', 'user@company.com');
-client.add(experimentAnalyticsPlugin());
-void client.experiment.fetch();
-const variant = client.experiment.variant('FLAG_KEY');
-
-/**
- * Initialize the Amplitude Experiment SDK with the Amplitude Analytics
- * integration and export the initialized client.
- *
- * The user identity and user properties set in the analytics SDK will
- * automatically be used by the Experiment SDK on fetch().
- */
-export const experiment = Experiment.initializeWithAmplitudeAnalytics(
-  'DEPLOYMENT_KEY',
-  { debug: true }
-);
+client.init('API_KEY', 'user@company.com', {
+  logLevel: amplitude.Types.LogLevel.Debug,
+}).promise.then((_) => {
+  client.add(new ExperimentAnalyticsPlugin({ debug: true })).promise.then((_) => {
+    // Add experiment plugin to existing Amplitude analytics SDK
+    // and call experiment APIs.
+    // Experiment APIs are only available when
+    // 1. Amplitude instance has successfully setup
+    // 2. Experiment plugin has been installed successfully
+    void client.experiment.fetch();
+    const variant = client.experiment.variant('FLAG_KEY');
+  });
+});
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement

--- a/examples/react-app/amplitude-integration/src/index.tsx
+++ b/examples/react-app/amplitude-integration/src/index.tsx
@@ -3,8 +3,15 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import * as amplitude from '@amplitude/analytics-browser';
-import { Experiment, ExperimentAnalyticsPlugin } from '@amplitude/experiment-js-client';
+import { Experiment, experimentAnalyticsPlugin, ExperimentClient } from "@amplitude/experiment-js-client";
 import { AmplitudeBrowser } from "@amplitude/analytics-browser";
+
+// Module augmentation to add experiment variable at compile time
+declare module '@amplitude/analytics-browser' {
+  interface AmplitudeBrowser {
+    experiment: ExperimentClient;
+  }
+}
 
 /**
  * Initialize the Amplitude Analytics SDK.
@@ -19,7 +26,7 @@ amplitude.identify(new amplitude.Identify().set('premium', true))
 // So has to create a real object.
 const client: AmplitudeBrowser = new amplitude.AmplitudeBrowser();
 client.init('API_KEY', 'user@company.com');
-client.add(new ExperimentAnalyticsPlugin());
+client.add(experimentAnalyticsPlugin());
 void client.experiment.fetch();
 const variant = client.experiment.variant('FLAG_KEY');
 

--- a/examples/react-app/amplitude-integration/src/index.tsx
+++ b/examples/react-app/amplitude-integration/src/index.tsx
@@ -28,7 +28,7 @@ Object.defineProperty(AmplitudeBrowser.prototype, 'experiment', {
   get: function() {
     return (
       this.plugin(
-        'experiment-analytics-plugin',
+        ExperimentAnalyticsPlugin.pluginName,
       ) as ExperimentAnalyticsPlugin
     ).experiment;
   },

--- a/examples/react-app/amplitude-integration/src/index.tsx
+++ b/examples/react-app/amplitude-integration/src/index.tsx
@@ -3,13 +3,25 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import * as amplitude from '@amplitude/analytics-browser';
-import { Experiment } from '@amplitude/experiment-js-client';
+import { Experiment, ExperimentAnalyticsPlugin } from '@amplitude/experiment-js-client';
+import { AmplitudeBrowser } from "@amplitude/analytics-browser";
 
 /**
  * Initialize the Amplitude Analytics SDK.
  */
 amplitude.init('API_KEY', 'user@company.com');
 amplitude.identify(new amplitude.Identify().set('premium', true))
+
+// Add experiment plugin to existing Amplitude analytics SDK
+// and call experiment APIs.
+// amplitude.init is the result of object destructuring.
+// It's part of BrowserClient interface.
+// So has to create a real object.
+const client: AmplitudeBrowser = new amplitude.AmplitudeBrowser();
+client.init('API_KEY', 'user@company.com');
+client.add(new ExperimentAnalyticsPlugin());
+void client.experiment.fetch();
+const variant = client.experiment.variant('FLAG_KEY');
 
 /**
  * Initialize the Amplitude Experiment SDK with the Amplitude Analytics

--- a/examples/react-app/amplitude-integration/yarn.lock
+++ b/examples/react-app/amplitude-integration/yarn.lock
@@ -2,24 +2,34 @@
 # yarn lockfile v1
 
 
-"@amplitude/analytics-browser@^2.12.2":
-  version "2.12.2"
-  resolved "https://registry.yarnpkg.com/@amplitude/analytics-browser/-/analytics-browser-2.12.2.tgz#a2e8d945308f8f3bdafd11144c423dcba5f6915c"
-  integrity sha512-Z41NKTbda144yo3/lLGENlVQjrIV/4J8TZyoPlysHCAXQdGh78cv1j29RKy/zqc8nu6ieY1qoH/aDRdPC1UvEw==
+"@amplitude/analytics-browser@^2.15.0":
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-browser/-/analytics-browser-2.15.0.tgz#bf8c7e2e5b5f7c173e81915ff2e4956cf5dcb77c"
+  integrity sha512-g0YFLNVIw7WnWj2pZBh2l20noGbs932aN8GjsAg58gJiEBgLcCJ6La9C653tJbSLnUudS94fG9JqctymIF6WIw==
   dependencies:
-    "@amplitude/analytics-core" "^2.6.1"
+    "@amplitude/analytics-core" "^2.10.0"
     "@amplitude/analytics-remote-config" "^0.4.0"
-    "@amplitude/plugin-autocapture-browser" "^1.1.2"
-    "@amplitude/plugin-page-view-tracking-browser" "^2.3.12"
+    "@amplitude/plugin-autocapture-browser" "^1.1.8"
+    "@amplitude/plugin-page-view-tracking-browser" "^2.3.18"
     tslib "^2.4.1"
 
-"@amplitude/analytics-client-common@>=1 <3", "@amplitude/analytics-client-common@^2.3.11":
+"@amplitude/analytics-client-common@>=1 <3":
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/@amplitude/analytics-client-common/-/analytics-client-common-2.3.11.tgz#5e3641940b7a7b74b41970c2a0ae4c5f2c5ca98a"
   integrity sha512-1Q1obcN14R7lpK6+UfqFdhLIhmwWrxLgHoJhEV/FwDPq1YvwhENtzVGmNuQtUUWOPIuavltmZ6w1zdL18YIahQ==
   dependencies:
     "@amplitude/analytics-connector" "^1.4.8"
     "@amplitude/analytics-core" "^2.6.1"
+    "@amplitude/analytics-types" "^2.9.1"
+    tslib "^2.4.1"
+
+"@amplitude/analytics-client-common@^2.3.16":
+  version "2.3.16"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-client-common/-/analytics-client-common-2.3.16.tgz#f96e4ce2ff332f8bf4bf415b89fa871ef0127804"
+  integrity sha512-QQxTyU/1a2fVFFDqc8BhyFPxwNPksRZdqU5U15CZnG6mWCcTaVEFYxd8nsLxCKJtID+PqkLB9lXtpvwkRh41dA==
+  dependencies:
+    "@amplitude/analytics-connector" "^1.4.8"
+    "@amplitude/analytics-core" "^2.10.0"
     "@amplitude/analytics-types" "^2.9.1"
     tslib "^2.4.1"
 
@@ -39,6 +49,13 @@
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/@amplitude/analytics-core/-/analytics-core-2.6.1.tgz#30ab6898f1a2c8731a1249b0c3dafb60c5ff6b7c"
   integrity sha512-PaTs1T02j8/zGNsLuHsTrMh1kFjxtNxVaaUgGuqqM1dl2Jf5sPFQdwu8O/mqrgmV4vPSStvf7odSUpPNN1tFnQ==
+  dependencies:
+    tslib "^2.4.1"
+
+"@amplitude/analytics-core@^2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-core/-/analytics-core-2.10.0.tgz#2baf9505a40f02467eca535c5e514e6553aebcab"
+  integrity sha512-AxuElphIEJOhJR/Aq2bru0iwBTvkJI50vc8xhNbRmSUfXLX2PnHjc9Vfvm89kOIzMZ9tVhADE1h7OH3GMsCIWg==
   dependencies:
     tslib "^2.4.1"
 
@@ -66,21 +83,21 @@
     base64-js "1.5.1"
     unfetch "4.1.0"
 
-"@amplitude/plugin-autocapture-browser@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@amplitude/plugin-autocapture-browser/-/plugin-autocapture-browser-1.1.2.tgz#9f07039d6083e404274269451dc1fd42f9e9fa3b"
-  integrity sha512-/P5hX3FtcMgYlNn38bVbqElETN+BSwLvfopwXRoBTIjfaBS340QytbvfXlo18qfeq8mHU6bi4l8fVPZdessBZQ==
+"@amplitude/plugin-autocapture-browser@^1.1.8":
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/@amplitude/plugin-autocapture-browser/-/plugin-autocapture-browser-1.1.8.tgz#3e7d3f6b4abcddb21f1b799239480bc013157643"
+  integrity sha512-VpejNC1yLkMyc8fIC0IeBU5ub4ICQjBduNCyWnaLrnrzLtte2jL2Y9UNMfcDUadPB+mufGkzxC0wpmj77q8kbw==
   dependencies:
-    "@amplitude/analytics-core" "^2.6.1"
+    "@amplitude/analytics-core" "^2.10.0"
     rxjs "^7.8.1"
     tslib "^2.4.1"
 
-"@amplitude/plugin-page-view-tracking-browser@^2.3.12":
-  version "2.3.12"
-  resolved "https://registry.yarnpkg.com/@amplitude/plugin-page-view-tracking-browser/-/plugin-page-view-tracking-browser-2.3.12.tgz#e71a1fdcef290ac588d201bea7da53d959e297a8"
-  integrity sha512-vsfe4UqjrPvbJ9pS3X0x3bN8FL9Phlt/2BsC6SaHsZCqiScvJ+Hn+r5D36/wKbZp1XNrmc2YOjrOuWwzzdUsNA==
+"@amplitude/plugin-page-view-tracking-browser@^2.3.18":
+  version "2.3.18"
+  resolved "https://registry.yarnpkg.com/@amplitude/plugin-page-view-tracking-browser/-/plugin-page-view-tracking-browser-2.3.18.tgz#43f3ba9a54311ae99579143848c9bdfdda8e143e"
+  integrity sha512-em7ui1jYFHwX7Dl0PjIN1rgYofF0oZ0f1RAdQBdNTVXo4kOpC6OiS2SwFI6N3qp2Uf68A5Cbugy1ROecFg4LXg==
   dependencies:
-    "@amplitude/analytics-client-common" "^2.3.11"
+    "@amplitude/analytics-client-common" "^2.3.16"
     "@amplitude/analytics-types" "^2.9.1"
     tslib "^2.4.1"
 

--- a/examples/react-app/amplitude-integration/yarn.lock
+++ b/examples/react-app/amplitude-integration/yarn.lock
@@ -2,48 +2,60 @@
 # yarn lockfile v1
 
 
-"@amplitude/analytics-browser@^1.5.4":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@amplitude/analytics-browser/-/analytics-browser-1.9.4.tgz#f2dc8df6953c0935ebcc0b4c52cc22ea7bdc3eb5"
-  integrity sha512-r0Jp+WGD4SEdK1BRnvL0OOkUQXOGn8K2LodXCwttcEA285pUX8U8kfSkJltN49PZSR9TWD7HehOiXvLhxNujPA==
+"@amplitude/analytics-browser@^2.12.2":
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-browser/-/analytics-browser-2.12.2.tgz#a2e8d945308f8f3bdafd11144c423dcba5f6915c"
+  integrity sha512-Z41NKTbda144yo3/lLGENlVQjrIV/4J8TZyoPlysHCAXQdGh78cv1j29RKy/zqc8nu6ieY1qoH/aDRdPC1UvEw==
   dependencies:
-    "@amplitude/analytics-client-common" "^0.6.3"
-    "@amplitude/analytics-core" "^0.13.0"
-    "@amplitude/analytics-types" "^0.18.0"
-    "@amplitude/plugin-page-view-tracking-browser" "^0.7.0"
-    "@amplitude/plugin-web-attribution-browser" "^0.6.4"
-    "@amplitude/ua-parser-js" "^0.7.31"
+    "@amplitude/analytics-core" "^2.6.1"
+    "@amplitude/analytics-remote-config" "^0.4.0"
+    "@amplitude/plugin-autocapture-browser" "^1.1.2"
+    "@amplitude/plugin-page-view-tracking-browser" "^2.3.12"
     tslib "^2.4.1"
 
-"@amplitude/analytics-client-common@^0.6.3":
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/@amplitude/analytics-client-common/-/analytics-client-common-0.6.3.tgz#c85b82c24b1a0e57f8d307524f1f66b2d18009ba"
-  integrity sha512-tpRDPbsRywlAnFOEngVn7+IBkOY9K4seZpzoRMcPTYFCUxFO95VKrBmKbB61vRgAPZnXXXYw7Q7hiFmBf3saUw==
+"@amplitude/analytics-client-common@>=1 <3", "@amplitude/analytics-client-common@^2.3.11":
+  version "2.3.11"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-client-common/-/analytics-client-common-2.3.11.tgz#5e3641940b7a7b74b41970c2a0ae4c5f2c5ca98a"
+  integrity sha512-1Q1obcN14R7lpK6+UfqFdhLIhmwWrxLgHoJhEV/FwDPq1YvwhENtzVGmNuQtUUWOPIuavltmZ6w1zdL18YIahQ==
   dependencies:
-    "@amplitude/analytics-connector" "^1.4.5"
-    "@amplitude/analytics-core" "^0.13.0"
-    "@amplitude/analytics-types" "^0.18.0"
+    "@amplitude/analytics-connector" "^1.4.8"
+    "@amplitude/analytics-core" "^2.6.1"
+    "@amplitude/analytics-types" "^2.9.1"
     tslib "^2.4.1"
 
-"@amplitude/analytics-connector@^1.4.5", "@amplitude/analytics-connector@^1.4.6":
+"@amplitude/analytics-connector@^1.4.6":
   version "1.4.6"
   resolved "https://registry.yarnpkg.com/@amplitude/analytics-connector/-/analytics-connector-1.4.6.tgz#60a66eaf0bcdcd17db4f414ff340c69e63116a72"
   integrity sha512-6jD2pOosRD4y8DT8StUCz7yTd5ZDkdOU9/AWnlWKM5qk90Mz7sdZrdZ9H7sA/L3yOJEpQOYZgQplQdWWUzyWug==
   dependencies:
     "@amplitude/ua-parser-js" "0.7.31"
 
-"@amplitude/analytics-core@^0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@amplitude/analytics-core/-/analytics-core-0.13.0.tgz#dbfdd8e053b85b76319043965943eabc1d8e6e8d"
-  integrity sha512-L2fdqMHF1cSllJuiji8Bd42/4gCxcsut3Dvcbsm1cQg2yPdpqevrmfbuaSMT/8p1zfPO3OrjUhys51rHcPlFmw==
+"@amplitude/analytics-connector@^1.4.8":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-connector/-/analytics-connector-1.6.4.tgz#8a811ff5c8ee46bdfea0e8f61c7578769b5778ed"
+  integrity sha512-SpIv0IQMNIq6SH3UqFGiaZyGSc7PBZwRdq7lvP0pBxW8i4Ny+8zwI0pV+VMfMHQwWY3wdIbWw5WQphNjpdq1/Q==
+
+"@amplitude/analytics-core@>=1 <3", "@amplitude/analytics-core@^2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-core/-/analytics-core-2.6.1.tgz#30ab6898f1a2c8731a1249b0c3dafb60c5ff6b7c"
+  integrity sha512-PaTs1T02j8/zGNsLuHsTrMh1kFjxtNxVaaUgGuqqM1dl2Jf5sPFQdwu8O/mqrgmV4vPSStvf7odSUpPNN1tFnQ==
   dependencies:
-    "@amplitude/analytics-types" "^0.18.0"
     tslib "^2.4.1"
 
-"@amplitude/analytics-types@^0.18.0":
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/@amplitude/analytics-types/-/analytics-types-0.18.0.tgz#98f4460f1ce28cf5a02968c78024461bfa3aa93f"
-  integrity sha512-y4iWokq0BYBgi4B78Oi4Kjut4cQJlG4wE8vGQO9VWcEpPTwkSRKD4RkeNPPFMDo38J91ow+y9nZOV49lbwQllQ==
+"@amplitude/analytics-remote-config@^0.4.0":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-remote-config/-/analytics-remote-config-0.4.1.tgz#b62cf8aa82290f68b314197e20351b10ea44ae3e"
+  integrity sha512-BYl6kQ9qjztrCACsugpxO+foLaQIC0aSEzoXEAb/gwOzInmqkyyI+Ub+aWTBih4xgB/lhWlOcidWHAmNiTJTNw==
+  dependencies:
+    "@amplitude/analytics-client-common" ">=1 <3"
+    "@amplitude/analytics-core" ">=1 <3"
+    "@amplitude/analytics-types" ">=1 <3"
+    tslib "^2.4.1"
+
+"@amplitude/analytics-types@>=1 <3", "@amplitude/analytics-types@^2.9.1":
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-types/-/analytics-types-2.9.1.tgz#c28c54d957f8fda2725279add41fc1649d37c675"
+  integrity sha512-Hw0pgUQCDV6AgvZD8ymBF3mzyBnPrIvXiPxfTNTg/bAkg1h+GVNdJIL6VAXd53kYuO7Lx/vjdhZS54i+RYtgMA==
 
 "@amplitude/experiment-js-client@^1.5.6":
   version "1.7.3"
@@ -54,33 +66,28 @@
     base64-js "1.5.1"
     unfetch "4.1.0"
 
-"@amplitude/plugin-page-view-tracking-browser@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@amplitude/plugin-page-view-tracking-browser/-/plugin-page-view-tracking-browser-0.7.0.tgz#39653e11c6bebfd3000350e616ad97c8b03ccd14"
-  integrity sha512-K3rorUu8FJ8p8PfbTmXonTpwUrpVlssAbS1xai2P2IRLsWJ6lJa1tFEpzfRFn1DILykb7iwVPLMxaEZGMbf38Q==
+"@amplitude/plugin-autocapture-browser@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@amplitude/plugin-autocapture-browser/-/plugin-autocapture-browser-1.1.2.tgz#9f07039d6083e404274269451dc1fd42f9e9fa3b"
+  integrity sha512-/P5hX3FtcMgYlNn38bVbqElETN+BSwLvfopwXRoBTIjfaBS340QytbvfXlo18qfeq8mHU6bi4l8fVPZdessBZQ==
   dependencies:
-    "@amplitude/analytics-client-common" "^0.6.3"
-    "@amplitude/analytics-types" "^0.18.0"
+    "@amplitude/analytics-core" "^2.6.1"
+    rxjs "^7.8.1"
     tslib "^2.4.1"
 
-"@amplitude/plugin-web-attribution-browser@^0.6.4":
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/@amplitude/plugin-web-attribution-browser/-/plugin-web-attribution-browser-0.6.4.tgz#42ebc15eb4d3dbcc8fa1816693919d734115b80c"
-  integrity sha512-pZghO6FnC5mtA5xbhyP6iZkL30oGXMQe2N6qhL8kuHcP848Xdw+U7CaJ/E4gQ0vuohplZR0fnSFXPhy3xMJiGQ==
+"@amplitude/plugin-page-view-tracking-browser@^2.3.12":
+  version "2.3.12"
+  resolved "https://registry.yarnpkg.com/@amplitude/plugin-page-view-tracking-browser/-/plugin-page-view-tracking-browser-2.3.12.tgz#e71a1fdcef290ac588d201bea7da53d959e297a8"
+  integrity sha512-vsfe4UqjrPvbJ9pS3X0x3bN8FL9Phlt/2BsC6SaHsZCqiScvJ+Hn+r5D36/wKbZp1XNrmc2YOjrOuWwzzdUsNA==
   dependencies:
-    "@amplitude/analytics-client-common" "^0.6.3"
-    "@amplitude/analytics-types" "^0.18.0"
+    "@amplitude/analytics-client-common" "^2.3.11"
+    "@amplitude/analytics-types" "^2.9.1"
     tslib "^2.4.1"
 
 "@amplitude/ua-parser-js@0.7.31":
   version "0.7.31"
   resolved "https://registry.yarnpkg.com/@amplitude/ua-parser-js/-/ua-parser-js-0.7.31.tgz#749bf7cb633cfcc7ff3c10805bad7c5f6fbdbc61"
   integrity sha512-+z8UGRaj13Pt5NDzOnkTBy49HE2CX64jeL0ArB86HAtilpnfkPB7oqkigN7Lf2LxscMg4QhFD7mmCfedh3rqTg==
-
-"@amplitude/ua-parser-js@^0.7.31":
-  version "0.7.33"
-  resolved "https://registry.yarnpkg.com/@amplitude/ua-parser-js/-/ua-parser-js-0.7.33.tgz#26441a0fb2e956a64e4ede50fb80b848179bb5db"
-  integrity sha512-wKEtVR4vXuPT9cVEIJkYWnlF++Gx3BdLatPBM+SZ1ztVIvnhdGBZR/mn9x/PzyrMcRlZmyi6L56I2J3doVBnjA==
 
 "@ampproject/remapping@^2.2.0":
   version "2.2.1"
@@ -7410,7 +7417,7 @@ react-refresh@^0.11.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
 
-react-scripts@5.0.1:
+react-scripts@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/react-scripts/-/react-scripts-5.0.1.tgz#6285dbd65a8ba6e49ca8d651ce30645a6d980003"
   integrity sha512-8VAmEm/ZAwQzJ+GOMLbBsTdDKOpuZh7RPs0UymvBR2vRk4iZWCskjbFnxqjrzoIvlNNRZ3QJFx6/qDSi6zSnaQ==
@@ -7694,6 +7701,13 @@ run-parallel@^1.1.9:
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
+
+rxjs@^7.8.1:
+  version "7.8.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.2.tgz#955bc473ed8af11a002a2be52071bf475638607b"
+  integrity sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==
+  dependencies:
+    tslib "^2.1.0"
 
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -8476,6 +8490,11 @@ tslib@^2.0.3, tslib@^2.4.1:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
+
+tslib@^2.1.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tsutils@^3.21.0:
   version "3.21.0"

--- a/packages/experiment-browser/package.json
+++ b/packages/experiment-browser/package.json
@@ -34,6 +34,7 @@
     "url": "https://github.com/amplitude/experiment-js-client/issues"
   },
   "dependencies": {
+    "@amplitude/analytics-browser": "^2.12.2",
     "@amplitude/analytics-connector": "^1.6.4",
     "@amplitude/experiment-core": "^0.11.0",
     "@amplitude/ua-parser-js": "^0.7.31",

--- a/packages/experiment-browser/package.json
+++ b/packages/experiment-browser/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/amplitude/experiment-js-client/issues"
   },
   "dependencies": {
-    "@amplitude/analytics-browser": "^2.12.2",
+    "@amplitude/analytics-core": "^2.6.1",
     "@amplitude/analytics-connector": "^1.6.4",
     "@amplitude/experiment-core": "^0.11.0",
     "@amplitude/ua-parser-js": "^0.7.31",

--- a/packages/experiment-browser/src/experiment-analytics-plugin.ts
+++ b/packages/experiment-browser/src/experiment-analytics-plugin.ts
@@ -1,21 +1,26 @@
-import { AmplitudeBrowser, Types } from '@amplitude/analytics-browser';
+import {
+  AmplitudeCore,
+  EnrichmentPlugin,
+  CoreClient,
+  IConfig,
+} from '@amplitude/analytics-core';
 
 import { ExperimentClient } from './experimentClient';
 import { initializeWithAmplitudeAnalytics } from './factory';
 
 // Module augmentation to add experiment variable at compile time
-declare module '@amplitude/analytics-browser' {
-  interface AmplitudeBrowser {
+declare module '@amplitude/analytics-core' {
+  interface CoreClient {
     experiment: ExperimentClient;
   }
 }
 
-export class ExperimentAnalyticsPlugin implements Types.EnrichmentPlugin {
+export class ExperimentAnalyticsPlugin implements EnrichmentPlugin {
   name = 'experiment-analytics-plugin';
   experiment: ExperimentClient;
 
   constructor() {
-    Object.defineProperty(AmplitudeBrowser.prototype, 'experiment', {
+    Object.defineProperty(AmplitudeCore.prototype, 'experiment', {
       get: function () {
         return (
           this.plugin(
@@ -26,7 +31,7 @@ export class ExperimentAnalyticsPlugin implements Types.EnrichmentPlugin {
     });
   }
 
-  async setup(config: Types.BrowserConfig, client: Types.BrowserClient) {
+  async setup(config: IConfig, client: CoreClient) {
     this.experiment = initializeWithAmplitudeAnalytics(config.apiKey);
   }
 }

--- a/packages/experiment-browser/src/experiment-analytics-plugin.ts
+++ b/packages/experiment-browser/src/experiment-analytics-plugin.ts
@@ -11,12 +11,14 @@ import { ExperimentConfig } from './config';
 import { ExperimentClient } from './experimentClient';
 import { initializeWithAmplitudeAnalytics } from './factory';
 
+// TODO(xinyi): it'll be great if we could do the following
+//  so that customers do need to add module augmentation on their side.
 // Module augmentation to add experiment variable at compile time
-declare module '@amplitude/analytics-core' {
-  interface CoreClient {
-    experiment: ExperimentClient;
-  }
-}
+// declare module '@amplitude/analytics-core' {
+//   interface CoreClient {
+//     experiment: ExperimentClient;
+//   }
+// }
 
 class ExperimentAnalyticsPlugin
   implements EnrichmentPlugin<BrowserClient, BrowserConfig>
@@ -44,6 +46,8 @@ class ExperimentAnalyticsPlugin
   }
 }
 
-export const experimentAnalyticsPlugin = () => {
-  return new ExperimentAnalyticsPlugin();
+export const experimentAnalyticsPlugin = (
+  config?: ExperimentConfig,
+): EnrichmentPlugin<BrowserClient, BrowserConfig> => {
+  return new ExperimentAnalyticsPlugin(config);
 };

--- a/packages/experiment-browser/src/experiment-analytics-plugin.ts
+++ b/packages/experiment-browser/src/experiment-analytics-plugin.ts
@@ -17,7 +17,11 @@ export class ExperimentAnalyticsPlugin implements Types.EnrichmentPlugin {
   constructor() {
     Object.defineProperty(AmplitudeBrowser.prototype, 'experiment', {
       get: function () {
-        return this.plugin(ExperimentAnalyticsPlugin.name);
+        return (
+          this.plugin(
+            ExperimentAnalyticsPlugin.name,
+          ) as ExperimentAnalyticsPlugin
+        ).experiment;
       },
     });
   }

--- a/packages/experiment-browser/src/experiment-analytics-plugin.ts
+++ b/packages/experiment-browser/src/experiment-analytics-plugin.ts
@@ -1,0 +1,28 @@
+import { AmplitudeBrowser, Types } from '@amplitude/analytics-browser';
+
+import { ExperimentClient } from './experimentClient';
+import { initializeWithAmplitudeAnalytics } from './factory';
+
+// Module augmentation to add experiment variable at compile time
+declare module '@amplitude/analytics-browser' {
+  interface AmplitudeBrowser {
+    experiment: ExperimentClient;
+  }
+}
+
+export class ExperimentAnalyticsPlugin implements Types.EnrichmentPlugin {
+  name = 'experiment-analytics-plugin';
+  experiment: ExperimentClient;
+
+  constructor() {
+    Object.defineProperty(AmplitudeBrowser.prototype, 'experiment', {
+      get: function () {
+        return this.plugin(ExperimentAnalyticsPlugin.name);
+      },
+    });
+  }
+
+  async setup(config: Types.BrowserConfig, client: Types.BrowserClient) {
+    this.experiment = initializeWithAmplitudeAnalytics(config.apiKey);
+  }
+}

--- a/packages/experiment-browser/src/experiment-analytics-plugin.ts
+++ b/packages/experiment-browser/src/experiment-analytics-plugin.ts
@@ -3,8 +3,11 @@ import {
   EnrichmentPlugin,
   CoreClient,
   IConfig,
+  BrowserClient,
+  BrowserConfig,
 } from '@amplitude/analytics-core';
 
+import { ExperimentConfig } from './config';
 import { ExperimentClient } from './experimentClient';
 import { initializeWithAmplitudeAnalytics } from './factory';
 
@@ -15,11 +18,16 @@ declare module '@amplitude/analytics-core' {
   }
 }
 
-export class ExperimentAnalyticsPlugin implements EnrichmentPlugin {
+class ExperimentAnalyticsPlugin
+  implements EnrichmentPlugin<BrowserClient, BrowserConfig>
+{
   name = 'experiment-analytics-plugin';
   experiment: ExperimentClient;
+  config?: ExperimentConfig;
 
-  constructor() {
+  constructor(config?: ExperimentConfig) {
+    this.config = config;
+    // Add experiment property at run time
     Object.defineProperty(AmplitudeCore.prototype, 'experiment', {
       get: function () {
         return (
@@ -31,7 +39,11 @@ export class ExperimentAnalyticsPlugin implements EnrichmentPlugin {
     });
   }
 
-  async setup(config: IConfig, client: CoreClient) {
-    this.experiment = initializeWithAmplitudeAnalytics(config.apiKey);
+  async setup(config: IConfig, _client: CoreClient) {
+    this.experiment = initializeWithAmplitudeAnalytics(config.apiKey, config);
   }
 }
+
+export const experimentAnalyticsPlugin = () => {
+  return new ExperimentAnalyticsPlugin();
+};

--- a/packages/experiment-browser/src/experiment-analytics-plugin.ts
+++ b/packages/experiment-browser/src/experiment-analytics-plugin.ts
@@ -11,24 +11,27 @@ import { ExperimentConfig } from './config';
 import { ExperimentClient } from './experimentClient';
 import { initializeWithAmplitudeAnalytics } from './factory';
 
-// TODO(xinyi): it'll be great if we could do the following
+// TODO(xinyi): it'll be great if we can make sure the following work
 //  so that customers do need to add module augmentation on their side.
 // Module augmentation to add experiment variable at compile time
-// declare module '@amplitude/analytics-core' {
-//   interface CoreClient {
-//     experiment: ExperimentClient;
-//   }
-// }
+declare module '@amplitude/analytics-core' {
+  interface CoreClient {
+    experiment: ExperimentClient;
+  }
+}
 
-class ExperimentAnalyticsPlugin
+export class ExperimentAnalyticsPlugin
   implements EnrichmentPlugin<BrowserClient, BrowserConfig>
 {
-  name = 'experiment-analytics-plugin';
+  name = '@amplitude/experiment-analytics-plugin';
   experiment: ExperimentClient;
   config?: ExperimentConfig;
 
   constructor(config?: ExperimentConfig) {
     this.config = config;
+
+    // TODO(xinyi): it'll be great if we can make sure the following work
+    //  so that customers do need to add module augmentation on their side.
     // Add experiment property at run time
     Object.defineProperty(AmplitudeCore.prototype, 'experiment', {
       get: function () {
@@ -45,9 +48,3 @@ class ExperimentAnalyticsPlugin
     this.experiment = initializeWithAmplitudeAnalytics(config.apiKey, config);
   }
 }
-
-export const experimentAnalyticsPlugin = (
-  config?: ExperimentConfig,
-): EnrichmentPlugin<BrowserClient, BrowserConfig> => {
-  return new ExperimentAnalyticsPlugin(config);
-};

--- a/packages/experiment-browser/src/experiment-analytics-plugin.ts
+++ b/packages/experiment-browser/src/experiment-analytics-plugin.ts
@@ -23,7 +23,8 @@ declare module '@amplitude/analytics-core' {
 export class ExperimentAnalyticsPlugin
   implements EnrichmentPlugin<BrowserClient, BrowserConfig>
 {
-  name = '@amplitude/experiment-analytics-plugin';
+  static pluginName = '@amplitude/experiment-analytics-plugin';
+  name = ExperimentAnalyticsPlugin.pluginName;
   experiment: ExperimentClient;
   config?: ExperimentConfig;
 
@@ -37,7 +38,7 @@ export class ExperimentAnalyticsPlugin
       get: function () {
         return (
           this.plugin(
-            ExperimentAnalyticsPlugin.name,
+            ExperimentAnalyticsPlugin.pluginName,
           ) as ExperimentAnalyticsPlugin
         ).experiment;
       },

--- a/packages/experiment-browser/src/index.ts
+++ b/packages/experiment-browser/src/index.ts
@@ -16,7 +16,7 @@ export {
   initialize,
   initializeWithAmplitudeAnalytics,
 } from './factory';
-export { ExperimentAnalyticsPlugin } from './experiment-analytics-plugin';
+export { experimentAnalyticsPlugin } from './experiment-analytics-plugin';
 export { StubExperimentClient } from './stubClient';
 export { ExperimentClient } from './experimentClient';
 export { Client, FetchOptions } from './types/client';

--- a/packages/experiment-browser/src/index.ts
+++ b/packages/experiment-browser/src/index.ts
@@ -16,7 +16,7 @@ export {
   initialize,
   initializeWithAmplitudeAnalytics,
 } from './factory';
-export { experimentAnalyticsPlugin } from './experiment-analytics-plugin';
+export { ExperimentAnalyticsPlugin } from './experiment-analytics-plugin';
 export { StubExperimentClient } from './stubClient';
 export { ExperimentClient } from './experimentClient';
 export { Client, FetchOptions } from './types/client';

--- a/packages/experiment-browser/src/index.ts
+++ b/packages/experiment-browser/src/index.ts
@@ -16,6 +16,7 @@ export {
   initialize,
   initializeWithAmplitudeAnalytics,
 } from './factory';
+export { ExperimentAnalyticsPlugin } from './experiment-analytics-plugin';
 export { StubExperimentClient } from './stubClient';
 export { ExperimentClient } from './experimentClient';
 export { Client, FetchOptions } from './types/client';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,13 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
+"@amplitude/analytics-core@^2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-core/-/analytics-core-2.6.1.tgz#30ab6898f1a2c8731a1249b0c3dafb60c5ff6b7c"
+  integrity sha512-PaTs1T02j8/zGNsLuHsTrMh1kFjxtNxVaaUgGuqqM1dl2Jf5sPFQdwu8O/mqrgmV4vPSStvf7odSUpPNN1tFnQ==
+  dependencies:
+    tslib "^2.4.1"
+
 "@amplitude/types@^1.10.2":
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/@amplitude/types/-/types-1.10.2.tgz#8f3c6c3c9ee24f401ee037b351c3c67eb945eefc"
@@ -7959,16 +7966,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8027,14 +8025,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -8775,16 +8766,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

This PR depends on 
- https://github.com/amplitude/Amplitude-TypeScript/pull/1013
- https://github.com/amplitude/Amplitude-TypeScript/pull/1033

- Use module augmentation to add experiment variable at compile time.
- Use Object.defineProperty to add experiment getter for runtime.  

```ts
import * as amplitude from '@amplitude/analytics-browser';
// amplitude here refers to the module rather than an object.

// Object destructuring is used to assign init as the init of the default instance. 
amplitude.init('API_KEY', 'user@company.com');
amplitude.identify(new amplitude.Identify().set('premium', true));
// Ideally, we want to the following to work, 
// because it requires minimum changes.
// BUT, it's NOT supported.
amplitude.new ExperimentAnalyticsPlugin());
amplitude.experiment.fetch();

// To be able to get access to experiment,
// have to hold a reference to amplitude analytics instance.
const client: AmplitudeBrowser = new amplitude.AmplitudeBrowser();
client.init('API_KEY', 'user@company.com', {
  logLevel: amplitude.Types.LogLevel.Debug,
}).promise.then((_) => {
  client.add(new ExperimentAnalyticsPlugin({ debug: true })).promise.then((_) => {
    // Add experiment plugin to existing Amplitude analytics SDK
    // and call experiment APIs.
    // Experiment APIs are only available when
    // 1. Amplitude instance has successfully setup
    // 2. Experiment plugin has been installed successfully
    void client.experiment.fetch();
    const variant = client.experiment.variant('FLAG_KEY');
  });
});

```

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
