### PR TITLE
fix: dont re-add plugin; remove integration timout error log

### DIFF
--- a/packages/experiment-browser/src/factory.ts
+++ b/packages/experiment-browser/src/factory.ts
@@ -5,14 +5,11 @@ import { Defaults, ExperimentConfig } from './config';
 import { ExperimentClient } from './experimentClient';
 import { AmplitudeIntegrationPlugin } from './integration/amplitude';
 import { DefaultUserProvider } from './providers/default';
+import { ExperimentPlugin } from './types/plugin';
 
 // Global instances for debugging.
 safeGlobal.experimentInstances = {};
 const instances = safeGlobal.experimentInstances;
-
-const getInstanceName = (config: ExperimentConfig): string => {
-  return config?.instanceName || Defaults.instanceName;
-};
 
 /**
  * Initializes a singleton {@link ExperimentClient} identified by the configured
@@ -25,23 +22,7 @@ export const initialize = (
   apiKey: string,
   config?: ExperimentConfig,
 ): ExperimentClient => {
-  // Store instances by appending the instance name and api key. Allows for
-  // initializing multiple default instances for different api keys.
-  const instanceName = getInstanceName(config);
-  // The internal instance name prefix is used by web experiment to differentiate
-  // web and feature experiment sdks which use the same api key.
-  const internalInstanceNameSuffix = config?.['internalInstanceNameSuffix'];
-  const instanceKey = internalInstanceNameSuffix
-    ? `${instanceName}.${apiKey}.${internalInstanceNameSuffix}`
-    : `${instanceName}.${apiKey}`;
-  if (!instances[instanceKey]) {
-    config = {
-      ...config,
-      userProvider: new DefaultUserProvider(config?.userProvider, apiKey),
-    };
-    instances[instanceKey] = new ExperimentClient(apiKey, config);
-  }
-  return instances[instanceKey];
+  return _initialize(apiKey, config);
 };
 
 /**
@@ -59,15 +40,56 @@ export const initializeWithAmplitudeAnalytics = (
   apiKey: string,
   config?: ExperimentConfig,
 ): ExperimentClient => {
-  const instanceName = getInstanceName(config);
-  const client = initialize(apiKey, config);
-  client.addPlugin(
+  const plugin = () =>
     new AmplitudeIntegrationPlugin(
       apiKey,
-      AnalyticsConnector.getInstance(instanceName),
+      AnalyticsConnector.getInstance(getInstanceName(config)),
       10000,
-    ),
-  );
+    );
+  return _initialize(apiKey, config, plugin);
+};
+
+const getInstanceName = (config: ExperimentConfig): string => {
+  return config?.instanceName || Defaults.instanceName;
+};
+
+const getInstanceKey = (apiKey: string, config: ExperimentConfig): string => {
+  // Store instances by appending the instance name and api key. Allows for
+  // initializing multiple default instances for different api keys.
+  const instanceName = getInstanceName(config);
+  // The internal instance name prefix is used by web experiment to differentiate
+  // web and feature experiment sdks which use the same api key.
+  const internalInstanceNameSuffix = config?.['internalInstanceNameSuffix'];
+  return internalInstanceNameSuffix
+    ? `${instanceName}.${apiKey}.${internalInstanceNameSuffix}`
+    : `${instanceName}.${apiKey}`;
+};
+
+const newExperimentClient = (
+  apiKey: string,
+  config: ExperimentConfig,
+): ExperimentClient => {
+  return new ExperimentClient(apiKey, {
+    ...config,
+    userProvider: new DefaultUserProvider(config?.userProvider, apiKey),
+  });
+};
+
+const _initialize = (
+  apiKey: string,
+  config?: ExperimentConfig,
+  plugin?: () => ExperimentPlugin,
+): ExperimentClient => {
+  const instanceKey = getInstanceKey(apiKey, config);
+  let client = instances[instanceKey];
+  if (client) {
+    return client;
+  }
+  client = newExperimentClient(apiKey, config);
+  if (plugin) {
+    client.addPlugin(plugin());
+  }
+  instances[instanceKey] = client;
   return client;
 };
 

--- a/packages/experiment-browser/src/integration/manager.ts
+++ b/packages/experiment-browser/src/integration/manager.ts
@@ -64,8 +64,7 @@ export class IntegrationManager {
           this.queue.setTracker(this.integration.track.bind(integration));
           this.resolve();
         },
-        (e) => {
-          console.error('Integration setup failed.', e);
+        () => {
           this.queue.setTracker(this.integration.track.bind(integration));
           this.resolve();
         },

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -230,7 +230,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       this.globalScope.experimentIntegration = new AmplitudeIntegrationPlugin(
         this.apiKey,
         connector,
-        100,
+        1000,
       );
     }
     this.globalScope.experimentIntegration.type = 'integration';


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->

* Refactor the factory functions to only init and add the plugin when a singleton instance does not already exist.
* Remove error log on integration timeout because unified script calls this function for web experiment.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> no
