### PR TITLE
feat(experiment):Add support for overriding AmplitudeIntegrationPlugin timeout

### DIFF
--- a/packages/experiment-browser/src/factory.ts
+++ b/packages/experiment-browser/src/factory.ts
@@ -44,7 +44,7 @@ export const initializeWithAmplitudeAnalytics = (
     new AmplitudeIntegrationPlugin(
       apiKey,
       AnalyticsConnector.getInstance(getInstanceName(config)),
-      10000,
+      config?.fetchTimeoutMillis || 10000,
     );
   return _initialize(apiKey, config, plugin);
 };


### PR DESCRIPTION
With the current implementation `experiment.fetch()` always takes 10 seconds before finishing.

Having it configurable, or defaulting to the same value as `fetchTimeoutMillis` at least lets the user have some more control over how much time to wait for `fetch` to finish.

<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary
Sets timeout for `AmplitudeIntegrationPlugin` to `ExperimentConfig.fetchTimeoutMillis` if set, or else defaults to 10s as today

<!-- What does the PR do? -->

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No
