### PR TITLE
fix: Web Experiment - Control variant condition

### DIFF
--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -359,8 +359,10 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
           if (this.isActionActiveOnPage(key, undefined)) {
             this.exposureWithDedupe(key, variant);
           }
-          // revert all applied mutations and injections
-          this.revertVariants({ flagKeys: [key] });
+          if (variant.key === 'off') {
+            // revert all applied mutations and injections
+            this.revertVariants({ flagKeys: [key] });
+          }
         }
 
         if (payloadIsArray) {

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -352,18 +352,15 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       if (isWebExperimentation) {
         const shouldTrackExposure =
           (variant.metadata?.['trackExposure'] as boolean) ?? true;
-        // if payload is falsy or empty array, consider it as control or off variant
         const payloadIsArray = Array.isArray(variant.payload);
-        // TODO(bgiori) this will need to change when we introduce control variant mutations
         const isControlOrOffPayload =
-          !variant.payload || (payloadIsArray && variant.payload.length === 0);
+          variant.key === 'control' || variant.key === 'off';
         if (shouldTrackExposure && isControlOrOffPayload) {
           if (this.isActionActiveOnPage(key, undefined)) {
             this.exposureWithDedupe(key, variant);
           }
           // revert all applied mutations and injections
           this.revertVariants({ flagKeys: [key] });
-          continue;
         }
 
         if (payloadIsArray) {


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

Updates the control variant condition, the existence of a payload is no longer valid as we will support mutations on the control variant.

The control variant should always trigger `exposureWithDedupe()`, and then apply any variant actions as necessary.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> No
