### PR TITLE
fix: always track control impression when on active page

### DIFF
--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -351,20 +351,15 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       const isWebExperimentation = variant.metadata?.deliveryMethod === 'web';
       if (isWebExperimentation) {
         const payloadIsArray = Array.isArray(variant.payload);
-        const payloadArrayIsEmpty =
-          payloadIsArray && variant.payload.length === 0;
-        const payloadIsNotArrayOrIsEmpty =
-          !payloadIsArray || payloadArrayIsEmpty;
-        if (
-          variant.key === 'off' ||
-          (variant.key === 'control' && payloadIsNotArrayOrIsEmpty)
-        ) {
+        if (variant.key === 'off' || variant.key === 'control') {
           if (this.isActionActiveOnPage(key, undefined)) {
             this.exposureWithDedupe(key, variant);
           }
-          // revert all applied mutations and injections
-          this.revertVariants({ flagKeys: [key] });
-          continue;
+          if (variant.key === 'off') {
+            // revert all applied mutations and injections
+            this.revertVariants({ flagKeys: [key] });
+            continue;
+          }
         }
 
         if (payloadIsArray) {


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

Fix for control `$impression` tracking - event should be fired regardless of whether control variant actions occur.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
