### PR TITLE
fix: check current url equal to redirection url before tracking redirect impression

### DIFF
--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -34,6 +34,7 @@ import {
   urlWithoutParamsAndAnchor,
   UUID,
   concatenateQueryParamsOf,
+  matchesUrl,
 } from './util';
 import { WebExperimentClient } from './web-experiment';
 
@@ -567,7 +568,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       return;
     }
 
-    this.storeRedirectImpressions(flagKey, variant);
+    this.storeRedirectImpressions(flagKey, variant, redirectUrl);
 
     // set previous url - relevant for SPA if redirect happens before push/replaceState is complete
     this.previousUrl = this.globalScope.location.href;
@@ -797,7 +798,11 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     return scope.some((pageId) => flagPages?.[pageId] ?? false);
   }
 
-  private storeRedirectImpressions(flagKey: string, variant: Variant) {
+  private storeRedirectImpressions(
+    flagKey: string,
+    variant: Variant,
+    redirectUrl: string,
+  ) {
     const redirectStorageKey = `EXP_${this.apiKey.slice(0, 10)}_REDIRECT`;
     // Store the current flag and variant for exposure tracking after redirect
     try {
@@ -805,7 +810,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
         this.globalScope.sessionStorage.getItem(redirectStorageKey) || '{}',
       );
 
-      storedRedirects[flagKey] = variant;
+      storedRedirects[flagKey] = { redirectUrl, variant };
 
       this.globalScope.sessionStorage.setItem(
         redirectStorageKey,
@@ -827,13 +832,29 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       // If we have stored redirects, track exposures for them
       if (Object.keys(storedRedirects).length > 0) {
         for (const storedFlagKey in storedRedirects) {
-          const storedVariant = storedRedirects[storedFlagKey];
-          // Force variant to ensure original evaluation result is tracked
-          this.exposureWithDedupe(storedFlagKey, storedVariant, true);
+          const { redirectUrl, variant } = storedRedirects[storedFlagKey];
+          const currentUrl = urlWithoutParamsAndAnchor(
+            this.globalScope.location.href,
+          );
+          const strippedRedirectUrl = urlWithoutParamsAndAnchor(redirectUrl);
+          if (matchesUrl([currentUrl], strippedRedirectUrl)) {
+            // Force variant to ensure original evaluation result is tracked
+            this.exposureWithDedupe(storedFlagKey, variant, true);
+
+            // Remove this flag from stored redirects
+            delete storedRedirects[storedFlagKey];
+          }
         }
 
-        // Clear the storage after tracking exposures
-        this.globalScope.sessionStorage.removeItem(redirectStorageKey);
+        // Update or clear the storage
+        if (Object.keys(storedRedirects).length > 0) {
+          this.globalScope.sessionStorage.setItem(
+            redirectStorageKey,
+            JSON.stringify(storedRedirects),
+          );
+        } else {
+          this.globalScope.sessionStorage.removeItem(redirectStorageKey);
+        }
       }
     } catch (error) {
       console.warn('Error processing stored redirects events:', error);

--- a/packages/experiment-tag/test/experiment.test.ts
+++ b/packages/experiment-tag/test/experiment.test.ts
@@ -44,7 +44,7 @@ const newMockGlobal = (overrides?: Record<string, unknown>) => {
     };
   };
 
-  // Create base global object first
+  // Base global object first
   const baseGlobal = {
     localStorage: createStorageMock(),
     sessionStorage: createStorageMock(),
@@ -78,7 +78,6 @@ const newMockGlobal = (overrides?: Record<string, unknown>) => {
     baseGlobal.location.href = url;
   });
 
-  // Apply overrides carefully
   if (overrides) {
     Object.keys(overrides).forEach((key) => {
       if (key === 'location' && typeof overrides[key] === 'object') {
@@ -94,7 +93,6 @@ const newMockGlobal = (overrides?: Record<string, unknown>) => {
           ...locationOverrides,
         };
 
-        // If no replace override provided, keep our smart replace function
         if (!locationOverrides.replace) {
           baseGlobal.location.replace = originalReplace;
         } else if (typeof locationOverrides.replace === 'function') {

--- a/packages/experiment-tag/test/experiment.test.ts
+++ b/packages/experiment-tag/test/experiment.test.ts
@@ -44,21 +44,7 @@ const newMockGlobal = (overrides?: Record<string, unknown>) => {
     };
   };
 
-  const mockLocation = {
-    href: 'http://test.com',
-    search: '',
-    replace: jest.fn((url) => {
-      // Update href when replace is called to simulate navigation
-      mockLocation.href = url;
-    }),
-    // Add other location properties that might be accessed
-    hostname: 'test.com',
-    pathname: '/',
-    protocol: 'http:',
-    port: '',
-    host: 'test.com',
-  };
-
+  // Create base global object first
   const baseGlobal = {
     localStorage: createStorageMock(),
     sessionStorage: createStorageMock(),
@@ -76,16 +62,49 @@ const newMockGlobal = (overrides?: Record<string, unknown>) => {
         };
       },
     },
-    location: mockLocation,
+    location: {
+      href: 'http://test.com',
+      search: '',
+      hostname: 'test.com',
+      pathname: '/',
+      protocol: 'http:',
+      port: '',
+      host: 'test.com',
+      replace: jest.fn(),
+    },
   };
+
+  baseGlobal.location.replace = jest.fn((url) => {
+    baseGlobal.location.href = url;
+  });
+
+  // Apply overrides carefully
   if (overrides) {
     Object.keys(overrides).forEach((key) => {
       if (key === 'location' && typeof overrides[key] === 'object') {
-        // Merge location properties instead of replacing the entire object
+        // Merge location properties but preserve the replace function reference
+        const locationOverrides = overrides[key] as any;
+
+        // Store the original replace function
+        const originalReplace = baseGlobal.location.replace;
+
+        // Merge properties
         baseGlobal.location = {
           ...baseGlobal.location,
-          ...(overrides[key] as any),
+          ...locationOverrides,
         };
+
+        // If no replace override provided, keep our smart replace function
+        if (!locationOverrides.replace) {
+          baseGlobal.location.replace = originalReplace;
+        } else if (typeof locationOverrides.replace === 'function') {
+          // If override provided a replace function, enhance it to update href
+          const customReplace = locationOverrides.replace;
+          baseGlobal.location.replace = jest.fn((url) => {
+            baseGlobal.location.href = url;
+            return customReplace(url);
+          });
+        }
       } else {
         baseGlobal[key] = overrides[key];
       }
@@ -318,7 +337,6 @@ describe('initializeExperiment', () => {
     const mockGlobal = newMockGlobal({
       location: {
         href: 'http://test.com/',
-        replace: jest.fn(),
         search: '?test=treatment&PREVIEW=true',
       },
     });
@@ -1146,7 +1164,11 @@ describe('initializeExperiment', () => {
 
   test('applyVariants should fire stored redirect impressions', () => {
     // Create a fresh mock global
-    const mockGlobal = newMockGlobal();
+    const mockGlobal = newMockGlobal({
+      location: {
+        href: 'http://test.com/2',
+      },
+    });
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     mockGetGlobalScope.mockReturnValue(mockGlobal);
@@ -1155,7 +1177,10 @@ describe('initializeExperiment', () => {
 
     // Set up stored redirect data in sessionStorage
     const storedRedirects = {
-      'test-redirect': { key: 'treatment' },
+      'test-redirect': {
+        variant: { key: 'treatment' },
+        redirectUrl: 'http://test.com/2',
+      },
     };
     mockGlobal.sessionStorage.setItem(
       redirectStorageKey,


### PR DESCRIPTION


<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
