### PR TITLE
feat: update dom-mutator

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3636,7 +3636,7 @@ dom-accessibility-api@^0.5.1:
 
 "dom-mutator@git+ssh://git@github.com:amplitude/dom-mutator#main":
   version "0.7.1"
-  resolved "git+ssh://git@github.com:amplitude/dom-mutator#20ef4fa76e5e35107efd74cac93baf659cd4cabb"
+  resolved "git+ssh://git@github.com:amplitude/dom-mutator#ef95c531a822bce55c197a6bf5e1d86d03bc086c"
 
 domexception@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

SKY-8129 

update dom-mutator in yarn.lock to point to latest commit with support for `after` position mutations.

The update https://github.com/amplitude/dom-mutator/pull/9 is a copy of the fork in https://github.com/amplitude/javascript/pull/79026/ 


<!-- What does the PR do? -->

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> no
