### PR TITLE
chore: ignore grep when outputting exit code 1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
         id: check-experiment-tag
         if: ${{ github.event.inputs.dryRun == 'false'}}
         run: |
-          UPDATED_PACKAGES=$(git diff --name-only HEAD~1 HEAD | grep "packages/experiment-tag/")
+          UPDATED_PACKAGES=$(git diff --name-only HEAD~1 HEAD | grep "packages/experiment-tag/" || true)
           if [ -n "$UPDATED_PACKAGES" ]; then
             echo "experiment_tag_updated=true" >> $GITHUB_OUTPUT
           else
@@ -107,7 +107,7 @@ jobs:
         id: check-experiment-plugin
         if: ${{ github.event.inputs.dryRun == 'false'}}
         run: |
-          UPDATED_PACKAGES=$(git diff --name-only HEAD~1 HEAD | grep "packages/plugin-segment/")
+          UPDATED_PACKAGES=$(git diff --name-only HEAD~1 HEAD | grep "packages/plugin-segment/" || true)
           if [ -n "$UPDATED_PACKAGES" ]; then
             echo "experiment_plugin_updated=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

The GH Action exits early if exit code 1 is outputted.

Now we ignore exit code and `experiment_plugin_updated=false` will still get output when no matches are detected.


See for fix
https://unix.stackexchange.com/questions/330660/preventing-grep-from-causing-premature-termination-of-bash-e-script

<!-- What does the PR do? -->

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
