### PR TITLE
fix: append all top level elements to a fragment before inject

### DIFF
--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -689,11 +689,14 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     }
     // Create HTML
     const rawHtml = action.data.html;
-    let html: Element | undefined;
+    let html: DocumentFragment | undefined;
     if (rawHtml) {
-      html =
-        new DOMParser().parseFromString(rawHtml, 'text/html').body
-          .firstElementChild ?? undefined;
+      const parsed = new DOMParser().parseFromString(rawHtml, 'text/html');
+      const fragment = this.globalScope.document.createDocumentFragment();
+      Array.from(parsed.body.childNodes).forEach((node) =>
+        fragment.appendChild(node),
+      );
+      html = fragment;
     }
     // Inject
     const utils = getInjectUtils();


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->

Instead of calling `.firstElementChild` on the parsed html payload, now appends each element to a `DocumentFragment` before injecting. This keeps all top level elements instead of the first one, whereas previously subsequent elements would be silently dropped.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> No
