### PR TITLE
fix: set marketing cookie on landing page before redirect

### DIFF
--- a/packages/experiment-tag/package.json
+++ b/packages/experiment-tag/package.json
@@ -27,6 +27,7 @@
     "url": "https://github.com/amplitude/experiment-js-client/issues"
   },
   "dependencies": {
+    "@amplitude/analytics-core": "^2.21.0",
     "@amplitude/experiment-core": "^0.11.0",
     "@amplitude/experiment-js-client": "^1.16.2",
     "dom-mutator": "git+ssh://git@github.com:amplitude/dom-mutator#ef95c531a822bce55c197a6bf5e1d86d03bc086c",

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -30,6 +30,7 @@ import {
   PreviewVariantsOptions,
   RevertVariantsOptions,
 } from './types';
+import { setMarketingCookie } from './util/cookie';
 import { getInjectUtils } from './util/inject-utils';
 import { VISUAL_EDITOR_SESSION_KEY, WindowMessenger } from './util/messenger';
 import {
@@ -46,7 +47,6 @@ import {
 } from './util/url';
 import { UUID } from './util/uuid';
 import { convertEvaluationVariantToVariant } from './util/variant';
-import { setMarketingCookie } from './util/cookie';
 
 export const PREVIEW_SEGMENT_NAME = 'Preview';
 const MUTATE_ACTION = 'mutate';
@@ -603,10 +603,10 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
         ) {
           this.appliedMutations[flagKey]?.[variantKey]?.[MUTATE_ACTION]?.[
             index
-            ]?.revert();
+          ]?.revert();
           delete this.appliedMutations[flagKey][variantKey][MUTATE_ACTION][
             index
-            ];
+          ];
         }
       } else {
         // always track exposure if mutation is active
@@ -615,7 +615,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
         if (
           !this.appliedMutations[flagKey]?.[variantKey]?.[MUTATE_ACTION]?.[
             index
-            ]
+          ]
         ) {
           // Apply mutation
           mutationControllers[index] = mutate.declarative(m);
@@ -652,7 +652,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     if (!this.isActionActiveOnPage(flagKey, action?.metadata?.scope)) {
       this.appliedMutations[flagKey]?.[variantKey]?.[
         INJECT_ACTION
-        ]?.[0]?.revert();
+      ]?.[0]?.revert();
       return;
     }
     // Validate and transform ID
@@ -766,7 +766,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       s.innerText =
         '* { visibility: hidden !important; background-image: none !important; }';
       document.head.appendChild(s);
-      this.globalScope.window.setTimeout(function() {
+      this.globalScope.window.setTimeout(function () {
         s.remove();
       }, 1000);
     }

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -46,6 +46,7 @@ import {
 } from './util/url';
 import { UUID } from './util/uuid';
 import { convertEvaluationVariantToVariant } from './util/variant';
+import { setMarketingCookie } from './util/cookie';
 
 export const PREVIEW_SEGMENT_NAME = 'Preview';
 const MUTATE_ACTION = 'mutate';
@@ -574,7 +575,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
 
     // set previous url - relevant for SPA if redirect happens before push/replaceState is complete
     this.previousUrl = this.globalScope.location.href;
-
+    setMarketingCookie(this.apiKey).then();
     // perform redirection
     if (this.customRedirectHandler) {
       this.customRedirectHandler(targetUrl);
@@ -602,10 +603,10 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
         ) {
           this.appliedMutations[flagKey]?.[variantKey]?.[MUTATE_ACTION]?.[
             index
-          ]?.revert();
+            ]?.revert();
           delete this.appliedMutations[flagKey][variantKey][MUTATE_ACTION][
             index
-          ];
+            ];
         }
       } else {
         // always track exposure if mutation is active
@@ -614,7 +615,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
         if (
           !this.appliedMutations[flagKey]?.[variantKey]?.[MUTATE_ACTION]?.[
             index
-          ]
+            ]
         ) {
           // Apply mutation
           mutationControllers[index] = mutate.declarative(m);
@@ -651,7 +652,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     if (!this.isActionActiveOnPage(flagKey, action?.metadata?.scope)) {
       this.appliedMutations[flagKey]?.[variantKey]?.[
         INJECT_ACTION
-      ]?.[0]?.revert();
+        ]?.[0]?.revert();
       return;
     }
     // Validate and transform ID
@@ -765,7 +766,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       s.innerText =
         '* { visibility: hidden !important; background-image: none !important; }';
       document.head.appendChild(s);
-      this.globalScope.window.setTimeout(function () {
+      this.globalScope.window.setTimeout(function() {
         s.remove();
       }, 1000);
     }

--- a/packages/experiment-tag/src/util/cookie.ts
+++ b/packages/experiment-tag/src/util/cookie.ts
@@ -13,13 +13,8 @@ export async function setMarketingCookie(apiKey: string) {
     sameSite: 'Lax',
   });
 
-  // Create parser instance
   const parser = new CampaignParser();
-
-  // Generate storage key
   const storageKey = `AMP_${apiKey.substring(0, 10)}_ORIGINAL_${MKTG}`;
-
-  // Parse campaign data and store it
   const campaign = await parser.parse();
   await storage.set(storageKey, campaign);
 }

--- a/packages/experiment-tag/src/util/cookie.ts
+++ b/packages/experiment-tag/src/util/cookie.ts
@@ -14,7 +14,7 @@ export async function setMarketingCookie(apiKey: string) {
   });
 
   const parser = new CampaignParser();
-  const storageKey = `AMP_${apiKey.substring(0, 10)}_ORIGINAL_${MKTG}`;
+  const storageKey = `AMP_${MKTG}_ORIGINAL_${apiKey.substring(0, 10)}`;
   const campaign = await parser.parse();
   await storage.set(storageKey, campaign);
 }

--- a/packages/experiment-tag/src/util/cookie.ts
+++ b/packages/experiment-tag/src/util/cookie.ts
@@ -1,0 +1,25 @@
+import { CampaignParser } from '@amplitude/analytics-core';
+import { CookieStorage } from '@amplitude/analytics-core';
+import { MKTG } from '@amplitude/analytics-core';
+import type { Campaign } from '@amplitude/analytics-core';
+
+/**
+ * Utility function to generate and set marketing cookie
+ * Parses current campaign data from URL and referrer, then stores it in the marketing cookie
+ */
+export async function setMarketingCookie(apiKey: string) {
+  const storage = new CookieStorage<Campaign>({
+    expirationDays: 365,
+    sameSite: 'Lax',
+  });
+
+  // Create parser instance
+  const parser = new CampaignParser();
+
+  // Generate storage key
+  const storageKey = `AMP_${apiKey.substring(0, 10)}_ORIGINAL_${MKTG}`;
+
+  // Parse campaign data and store it
+  const campaign = await parser.parse();
+  await storage.set(storageKey, campaign);
+}

--- a/packages/experiment-tag/src/util/cookie.ts
+++ b/packages/experiment-tag/src/util/cookie.ts
@@ -21,6 +21,5 @@ export async function setMarketingCookie(apiKey: string) {
 
   // Parse campaign data and store it
   const campaign = await parser.parse();
-  console.log(campaign);
   await storage.set(storageKey, campaign);
 }

--- a/packages/experiment-tag/src/util/cookie.ts
+++ b/packages/experiment-tag/src/util/cookie.ts
@@ -21,5 +21,6 @@ export async function setMarketingCookie(apiKey: string) {
 
   // Parse campaign data and store it
   const campaign = await parser.parse();
+  console.log(campaign);
   await storage.set(storageKey, campaign);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@amplitude/analytics-core@^2.21.0":
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-core/-/analytics-core-2.21.0.tgz#fb897006ef39215a858485ad1faaf1f0cfa6592a"
+  integrity sha512-Q3UaU8UwPCLIShc7q4L8BZna2Eo7CX3SnrTWu0Nf223Jh94BHLJbgsZhOHkxUQHPLLT3hEIBkXzwvNSjLlpB7Q==
+  dependencies:
+    "@amplitude/analytics-connector" "^1.6.4"
+    tslib "^2.4.1"
+
 "@amplitude/types@^1.10.2":
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/@amplitude/types/-/types-1.10.2.tgz#8f3c6c3c9ee24f401ee037b351c3c67eb945eefc"
@@ -8272,16 +8280,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8345,14 +8344,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9138,7 +9130,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -9151,15 +9143,6 @@ wrap-ansi@^6.0.1:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

Set analytics marketing cookie upon redirect action. This will ensure the analytics SDK has the correct campaign information about the original landing page. 

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
