### PR TITLE
fix: add patch to removeChild to address hydration errors

### DIFF
--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -27,6 +27,7 @@ import {
 } from './types';
 import { getInjectUtils } from './util/inject-utils';
 import { VISUAL_EDITOR_SESSION_KEY, WindowMessenger } from './util/messenger';
+import { patchRemoveChild } from './util/patch';
 import {
   getUrlParams,
   removeQueryParams,
@@ -179,6 +180,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     if (this.isRunning) {
       return;
     }
+    patchRemoveChild();
     const urlParams = getUrlParams();
     this.isVisualEditorMode =
       urlParams['VISUAL_EDITOR'] === 'true' ||

--- a/packages/experiment-tag/src/util/patch.ts
+++ b/packages/experiment-tag/src/util/patch.ts
@@ -1,0 +1,12 @@
+/**
+ * Patch removeChild to avoid errors when removing nodes that are added
+ * mutate/inject actions.
+ */
+export const patchRemoveChild = () => {
+  HTMLElement.prototype.removeChild = function <T extends Node>(n: T): T {
+    if (!n || n.parentNode === this) {
+      return Node.prototype.removeChild.call(this, n) as T;
+    }
+    return n;
+  };
+};


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

Patch `removeChild` to address errors stemming from NextJs hydration mismatch, which attempt to remove nodes created by dom-mutator when innerHTML is set.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No
