### PR TITLE
fix: expire marketing cookie after session

### DIFF
--- a/packages/experiment-tag/src/util/cookie.ts
+++ b/packages/experiment-tag/src/util/cookie.ts
@@ -9,7 +9,6 @@ import type { Campaign } from '@amplitude/analytics-core';
  */
 export async function setMarketingCookie(apiKey: string) {
   const storage = new CookieStorage<Campaign>({
-    expirationDays: 365,
     sameSite: 'Lax',
   });
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

Marketing cookies should expire after session, as they are only used to pass props to analytics SDK and should not be persisted.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
