### PR TITLE
fix: update removeQueryParams to support hash-based routing

### DIFF
--- a/packages/experiment-tag/src/util/url.ts
+++ b/packages/experiment-tag/src/util/url.ts
@@ -25,11 +25,28 @@ export const removeQueryParams = (
   url: string,
   paramsToRemove: string[],
 ): string => {
-  const urlObj = new URL(url);
-  for (const param of paramsToRemove) {
-    urlObj.searchParams.delete(param);
+  const hashIndex = url.indexOf('#');
+  const hasHashPath =
+    hashIndex !== -1 && url.substring(hashIndex + 1).startsWith('/');
+
+  if (!hasHashPath) {
+    const urlObj = new URL(url);
+    for (const param of paramsToRemove) {
+      urlObj.searchParams.delete(param);
+    }
+    return urlObj.toString();
   }
-  return urlObj.toString();
+
+  // Hash-based routing handling
+  const [urlWithoutHash, hash] = url.split('#');
+  const hashObj = new URL(`http://dummy.com/${hash}`);
+
+  for (const param of paramsToRemove) {
+    hashObj.searchParams.delete(param);
+  }
+
+  const newHash = hashObj.pathname.substring(1) + hashObj.search;
+  return `${urlWithoutHash}#${newHash}`;
 };
 
 export const matchesUrl = (urlArray: string[], urlString: string): boolean => {


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

- Updated `removeQueryParams` function to handle URLs with hash fragments, allowing for the removal of query parameters in both standard and hash-based routing scenarios.
- Added comprehensive unit tests for various cases, including edge cases and hash-based routes, ensuring robust functionality.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> No
