### PR TITLE
WIP fix: use different umd variables

### DIFF
--- a/packages/analytics-connector/rollup.config.js
+++ b/packages/analytics-connector/rollup.config.js
@@ -19,6 +19,8 @@ const getCommonBrowserConfig = (target) => ({
     replace({
       preventAssignment: true,
       BUILD_BROWSER: true,
+      define: '__amplitude__define__',
+      require: '__amplitude__require__',
     }),
     resolve(),
     json(),

--- a/packages/experiment-browser/rollup.config.js
+++ b/packages/experiment-browser/rollup.config.js
@@ -19,6 +19,8 @@ const getCommonBrowserConfig = (target) => ({
     replace({
       preventAssignment: true,
       BUILD_BROWSER: true,
+      define: '__amplitude__define__',
+      require: '__amplitude__require__',
     }),
     resolve(),
     json(),

--- a/packages/experiment-core/rollup.config.js
+++ b/packages/experiment-core/rollup.config.js
@@ -3,6 +3,7 @@ import { resolve as pathResolve } from 'path';
 import babel from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
+import replace from '@rollup/plugin-replace';
 import typescript from '@rollup/plugin-typescript';
 
 const getCommonBrowserConfig = (target) => ({
@@ -23,6 +24,11 @@ const getCommonBrowserConfig = (target) => ({
           : undefined,
       babelHelpers: 'bundled',
       exclude: ['node_modules/**'],
+    }),
+    replace({
+      preventAssignment: true,
+      define: '__amplitude__define__',
+      require: '__amplitude__require__',
     }),
   ],
 });

--- a/packages/experiment-tag/rollup.config.js
+++ b/packages/experiment-tag/rollup.config.js
@@ -5,6 +5,7 @@ import babel from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import resolve from '@rollup/plugin-node-resolve';
+import replace from '@rollup/plugin-replace';
 import terser from '@rollup/plugin-terser';
 import typescript from '@rollup/plugin-typescript';
 import analyze from 'rollup-plugin-analyzer';
@@ -47,6 +48,11 @@ const getCommonBrowserConfig = (target) => ({
         output: join(__dirname, 'dist', 'LICENSES'),
       },
     }),
+    replace({
+      preventAssignment: true,
+      define: '__amplitude__define__',
+      require: '__amplitude__require__',
+    }),
   ],
 });
 
@@ -65,7 +71,7 @@ const configs = [
     ...config,
     ...getOutputConfig({
       entryFileNames: 'experiment-tag-min.js',
-      format: 'iife',
+      format: 'umd',
     }),
     plugins: [
       ...config.plugins,

--- a/packages/plugin-segment/rollup.config.js
+++ b/packages/plugin-segment/rollup.config.js
@@ -24,6 +24,8 @@ const getCommonBrowserConfig = (target) => ({
     replace({
       preventAssignment: true,
       BUILD_BROWSER: true,
+      define: '__amplitude__define__',
+      require: '__amplitude__require__',
     }),
     resolve(),
     json(),


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

test using different umd variables
This is to see if we can support umd and not conflict with the customer's global vars e.g. thehindugroup https://amplitude.atlassian.net/browse/SKY-8481 

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
