### PR TITLE
fix: do not treat falsy values like 0 and false as undefined

### DIFF
--- a/packages/experiment-core/src/evaluation/evaluation.ts
+++ b/packages/experiment-core/src/evaluation/evaluation.ts
@@ -116,7 +116,7 @@ export class EvaluationEngine {
     // We need special matching for null properties and set type prop values
     // and operators. All other values are matched as strings, since the
     // filter values are always strings.
-    if (!propValue) {
+    if (propValue === undefined || propValue === null) {
       return this.matchNull(condition.op, condition.values);
     } else if (this.isSetOperator(condition.op)) {
       const propValueStringList = this.coerceStringArray(propValue);

--- a/packages/experiment-core/src/evaluation/select.ts
+++ b/packages/experiment-core/src/evaluation/select.ts
@@ -11,7 +11,7 @@ export const select = (
     }
     selectable = (selectable as Record<string, unknown>)[selectorElement];
   }
-  if (!selectable) {
+  if (selectable === undefined || selectable === null) {
     return undefined;
   } else {
     return selectable;


### PR DESCRIPTION
### Summary

My earlier fix (#143 ) was not complete. This removes remaining instances of early returns when a property value evaluates to false. This allows to correctly evaluate comparisons like `0==0` or `0<1` or `false=false`.

However, we need to make sure that this isn't expected behavior for some use cases. Atm, comparing the `(none)` value that you can select in the conditions builder to number value `0` or boolean value `false` would evaluate to `true` which changes with this PR. 

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
