### PR TITLE
feat: Add support for defining custom headers

### DIFF
--- a/packages/experiment-browser/src/config.ts
+++ b/packages/experiment-browser/src/config.ts
@@ -3,7 +3,7 @@ import { ExperimentAnalyticsProvider } from './types/analytics';
 import { ExposureTrackingProvider } from './types/exposure';
 import { ExperimentUserProvider } from './types/provider';
 import { Source } from './types/source';
-import { HttpClient } from './types/transport';
+import { CustomRequestHeaders, HttpClient } from './types/transport';
 import { Variant, Variants } from './types/variant';
 
 /**
@@ -157,6 +157,11 @@ export interface ExperimentConfig {
    * (Advanced) Use your own http client.
    */
   httpClient?: HttpClient;
+
+  /**
+   * (Advanced) Use custom request headers.
+   */
+  customRequestHeaders?: CustomRequestHeaders;
 }
 
 /**

--- a/packages/experiment-browser/src/experimentClient.ts
+++ b/packages/experiment-browser/src/experimentClient.ts
@@ -733,6 +733,9 @@ export class ExperimentClient implements Client {
     this.debug('[Experiment] Fetch variants for user: ', user);
     const results = await this.evaluationApi.getVariants(user, {
       timeoutMillis: timeoutMillis,
+      customHeaders: this.config.customRequestHeaders
+        ? this.config.customRequestHeaders(user)
+        : undefined,
       ...options,
     });
     const variants: Variants = {};
@@ -758,6 +761,11 @@ export class ExperimentClient implements Client {
           user?.user_id || user?.device_id
             ? { user_id: user?.user_id, device_id: user?.device_id }
             : undefined,
+        customHeaders: this.config.customRequestHeaders
+          ? this.config.customRequestHeaders(
+              this.cleanUserPropsForFetch(this.getUser()),
+            )
+          : undefined,
       });
       this.flags.clear();
       this.flags.putAll(flags);

--- a/packages/experiment-browser/src/types/transport.ts
+++ b/packages/experiment-browser/src/types/transport.ts
@@ -1,3 +1,5 @@
+import { ExperimentUser } from './user';
+
 export interface SimpleResponse {
   status: number;
   body: string;
@@ -12,3 +14,7 @@ export interface HttpClient {
     timeoutMillis?: number,
   ): Promise<SimpleResponse>;
 }
+
+export type CustomRequestHeaders = (
+  user: ExperimentUser,
+) => Record<string, string> | undefined;

--- a/packages/experiment-core/src/api/evaluation-api.ts
+++ b/packages/experiment-core/src/api/evaluation-api.ts
@@ -14,6 +14,7 @@ export type GetVariantsOptions = {
   deliveryMethod?: DeliveryMethod;
   evaluationMode?: EvaluationMode;
   timeoutMillis?: number;
+  customHeaders?: Record<string, string>;
 };
 
 export interface EvaluationApi {
@@ -43,7 +44,15 @@ export class SdkEvaluationApi implements EvaluationApi {
     options?: GetVariantsOptions,
   ): Promise<Record<string, EvaluationVariant>> {
     const userJsonBase64 = Base64.encodeURL(JSON.stringify(user));
-    const headers: Record<string, string> = {
+    let headers: Record<string, string> = {};
+    if (options?.customHeaders) {
+      headers = {
+        ...options.customHeaders,
+        ...headers,
+      };
+    }
+    headers = {
+      ...headers,
       Authorization: `Api-Key ${this.deploymentKey}`,
       'X-Amp-Exp-User': userJsonBase64,
     };

--- a/packages/experiment-core/src/api/flag-api.ts
+++ b/packages/experiment-core/src/api/flag-api.ts
@@ -10,6 +10,7 @@ export type GetFlagsOptions = {
   timeoutMillis?: number;
   user?: Record<string, unknown>;
   deliveryMethod?: string | undefined;
+  customHeaders?: Record<string, string>;
 };
 
 export interface FlagApi {
@@ -34,7 +35,15 @@ export class SdkFlagApi implements FlagApi {
   public async getFlags(
     options?: GetFlagsOptions,
   ): Promise<Record<string, EvaluationFlag>> {
-    const headers: Record<string, string> = {
+    let headers: Record<string, string> = {};
+    if (options?.customHeaders) {
+      headers = {
+        ...options.customHeaders,
+        ...headers,
+      };
+    }
+    headers = {
+      ...headers,
       Authorization: `Api-Key ${this.deploymentKey}`,
     };
     if (options?.libraryName && options?.libraryVersion) {


### PR DESCRIPTION
Configuration option for defining a custom function that can set custom headers on requests. Useful when using a custom proxy that might have additional requirement.

<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

Adds a configuration option for defining a custom function that can set custom headers on requests. Useful when using a custom proxy that might have additional requirements.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
