### PR TITLE
fix: waitForElement should wait for SPA re-render and disconnect mutationObserver after revert

### DIFF
--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -703,7 +703,8 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
           .firstElementChild ?? undefined;
     }
     // Inject
-    const utils = getInjectUtils();
+    const state = { cancelled: false };
+    const utils = getInjectUtils(state);
     this.appliedInjections.add(id);
     try {
       const fn = this.globalScope[id];
@@ -725,6 +726,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     // Push the mutation
     this.appliedMutations[flagKey][variantKey][INJECT_ACTION][id] = {
       revert: () => {
+        state.cancelled = true;
         utils.remove?.();
         style?.remove();
         script?.remove();


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
