### PR TITLE
feat: Support custom headers for fetch requests

### DIFF
--- a/packages/experiment-browser/src/config.ts
+++ b/packages/experiment-browser/src/config.ts
@@ -3,7 +3,7 @@ import { ExperimentAnalyticsProvider } from './types/analytics';
 import { ExposureTrackingProvider } from './types/exposure';
 import { ExperimentUserProvider } from './types/provider';
 import { Source } from './types/source';
-import { HttpClient } from './types/transport';
+import { CustomRequestHeaders, HttpClient } from './types/transport';
 import { Variant, Variants } from './types/variant';
 
 /**
@@ -157,6 +157,11 @@ export interface ExperimentConfig {
    * (Advanced) Use your own http client.
    */
   httpClient?: HttpClient;
+
+  /**
+   * (Advanced) Use custom request headers.
+   */
+  customRequestHeaders?: CustomRequestHeaders;
 }
 
 /**

--- a/packages/experiment-browser/src/experimentClient.ts
+++ b/packages/experiment-browser/src/experimentClient.ts
@@ -731,8 +731,18 @@ export class ExperimentClient implements Client {
     user = await this.addContextOrWait(user);
     user = this.cleanUserPropsForFetch(user);
     this.debug('[Experiment] Fetch variants for user: ', user);
+    let customHeaders = undefined;
+    if (this.config.customRequestHeaders) {
+      customHeaders = {};
+      Object.entries(this.config.customRequestHeaders).forEach(
+        ([key, value]) => {
+          customHeaders[key] = value();
+        },
+      );
+    }
     const results = await this.evaluationApi.getVariants(user, {
       timeoutMillis: timeoutMillis,
+      customHeaders: customHeaders,
       ...options,
     });
     const variants: Variants = {};

--- a/packages/experiment-browser/src/types/transport.ts
+++ b/packages/experiment-browser/src/types/transport.ts
@@ -12,3 +12,5 @@ export interface HttpClient {
     timeoutMillis?: number,
   ): Promise<SimpleResponse>;
 }
+
+export type CustomRequestHeaders = Record<string, () => string>;

--- a/packages/experiment-core/src/api/evaluation-api.ts
+++ b/packages/experiment-core/src/api/evaluation-api.ts
@@ -14,6 +14,7 @@ export type GetVariantsOptions = {
   deliveryMethod?: DeliveryMethod;
   evaluationMode?: EvaluationMode;
   timeoutMillis?: number;
+  customHeaders?: Record<string, string>;
 };
 
 export interface EvaluationApi {
@@ -43,7 +44,15 @@ export class SdkEvaluationApi implements EvaluationApi {
     options?: GetVariantsOptions,
   ): Promise<Record<string, EvaluationVariant>> {
     const userJsonBase64 = Base64.encodeURL(JSON.stringify(user));
-    const headers: Record<string, string> = {
+    let headers: Record<string, string> = {};
+    if (options?.customHeaders) {
+      headers = {
+        ...options.customHeaders,
+        ...headers,
+      };
+    }
+    headers = {
+      ...headers,
       Authorization: `Api-Key ${this.deploymentKey}`,
       'X-Amp-Exp-User': userJsonBase64,
     };

--- a/packages/experiment-core/src/api/flag-api.ts
+++ b/packages/experiment-core/src/api/flag-api.ts
@@ -10,6 +10,7 @@ export type GetFlagsOptions = {
   timeoutMillis?: number;
   user?: Record<string, unknown>;
   deliveryMethod?: string | undefined;
+  customHeaders?: Record<string, string>;
 };
 
 export interface FlagApi {
@@ -34,7 +35,15 @@ export class SdkFlagApi implements FlagApi {
   public async getFlags(
     options?: GetFlagsOptions,
   ): Promise<Record<string, EvaluationFlag>> {
-    const headers: Record<string, string> = {
+    let headers: Record<string, string> = {};
+    if (options?.customHeaders) {
+      headers = {
+        ...options.customHeaders,
+        ...headers,
+      };
+    }
+    headers = {
+      ...headers,
       Authorization: `Api-Key ${this.deploymentKey}`,
     };
     if (options?.libraryName && options?.libraryVersion) {


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

Configuration option for defining a custom function that can set custom headers on requests.

This update is meant to be a more generic implementation of [this](https://github.com/amplitude/experiment-js-client/pull/230), which supports specifically adding user context.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
