### PR TITLE
fix: attach timestamp to impression events upon variant action

### DIFF
--- a/packages/experiment-browser/src/experimentClient.ts
+++ b/packages/experiment-browser/src/experimentClient.ts
@@ -899,6 +899,9 @@ export class ExperimentClient implements Client {
     }
 
     if (metadata) exposure.metadata = metadata;
+    if (this.isWebExperiment) {
+      exposure.time = Date.now();
+    }
 
     // Add current URL for web experiments
     if (this.isWebExperiment) {

--- a/packages/experiment-browser/src/types/exposure.ts
+++ b/packages/experiment-browser/src/types/exposure.ts
@@ -45,6 +45,10 @@ export type Exposure = {
    * evaluation for the user. Used for system purposes.
    */
   metadata?: Record<string, unknown>;
+  /**
+   * (Optional) The time the exposure occurred.
+   */
+  time?: number;
 };
 
 /**


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

This fix will attach a timestamp to impression events when variant action is applied. This will ensure that the event time is dependent on when the variant is actually displayed, rather than when the event is processed by the Amplitude Analytics SDK.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
