### PR TITLE
fix(experiment-tag): load overlay after shell is built in mobile mode

### DIFF
--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -238,11 +238,14 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
 
     // if in visual edit mode, remove the query param
     if (this.isVisualEditorMode) {
-      WindowMessenger.setup();
-
       if (isMobileModeActive()) {
-        buildShell(this.globalScope);
+        // In mobile mode, build the shell first and load the overlay after.
+        // The overlay must render into the already-built shell to avoid a
+        // race where buildShell restructures the DOM while the overlay's
+        // React 18 concurrent render is in-flight.
+        await buildShell(this.globalScope);
       }
+      WindowMessenger.setup();
 
       const veSource =
         urlParams[VISUAL_EDITOR_PARAM] === 'true'

--- a/packages/experiment-tag/src/util/shell.ts
+++ b/packages/experiment-tag/src/util/shell.ts
@@ -99,11 +99,16 @@ function observeIframeSpaNav(
  *
  * Waits for document.readyState === 'complete' before modifying the DOM so
  * that SSR frameworks (e.g. Next.js) can finish hydration first. Uses
- * setTimeout polling instead of window.addEventListener('load') because
- * third-party scripts can proxy addEventListener and suppress load handlers.
- * setTimeout is not affected by such proxies.
+ * requestAnimationFrame polling instead of window.addEventListener('load')
+ * because third-party scripts can proxy addEventListener and suppress load
+ * handlers. Polling readyState directly is not affected by such proxies.
+ *
+ * Returns a Promise that resolves after the shell is built. In mobile mode,
+ * the overlay script should be loaded after awaiting this promise to
+ * guarantee it renders into the already-built shell rather than racing with
+ * DOM restructuring.
  */
-export function buildShell(globalScope: typeof globalThis): void {
+export function buildShell(globalScope: typeof globalThis): Promise<void> {
   const doc = globalScope.document;
 
   const run = () => {
@@ -117,9 +122,6 @@ export function buildShell(globalScope: typeof globalThis): void {
       `{ display: none !important; }`;
     doc.head.appendChild(shellGuard);
 
-    // Preserve the overlay shadow host if it was already attached (the
-    // overlay script may have loaded before buildShell ran).
-    const existingOverlay = doc.getElementById(OVERLAY_HOST_ID);
     while (doc.body.firstChild) {
       doc.body.removeChild(doc.body.firstChild);
     }
@@ -173,21 +175,22 @@ export function buildShell(globalScope: typeof globalThis): void {
 
     container.appendChild(iframe);
     doc.body.appendChild(container);
-    if (existingOverlay) {
-      doc.body.appendChild(existingOverlay);
-    }
   };
 
-  if (doc.readyState === 'complete' && doc.body) {
-    run();
-  } else {
-    const waitUntilReady = () => {
-      if (doc.readyState === 'complete' && doc.body) {
-        run();
-      } else {
-        globalScope.requestAnimationFrame(waitUntilReady);
-      }
-    };
-    globalScope.requestAnimationFrame(waitUntilReady);
-  }
+  return new Promise<void>((resolve) => {
+    if (doc.readyState === 'complete' && doc.body) {
+      run();
+      resolve();
+    } else {
+      const waitUntilReady = () => {
+        if (doc.readyState === 'complete' && doc.body) {
+          run();
+          resolve();
+        } else {
+          globalScope.requestAnimationFrame(waitUntilReady);
+        }
+      };
+      globalScope.requestAnimationFrame(waitUntilReady);
+    }
+  });
 }

--- a/packages/experiment-tag/src/util/shell.ts
+++ b/packages/experiment-tag/src/util/shell.ts
@@ -97,10 +97,11 @@ function observeIframeSpaNav(
  * Replaces the page DOM with a shell container that loads the customer site
  * in a same-origin iframe.
  *
- * We avoid deferring to window.load or DOMContentLoaded because third-party
- * scripts (e.g. Cloudflare Rocket Loader) proxy those events and can suppress
- * our listeners. Instead we check for document.body directly and fall back to
- * requestAnimationFrame polling if it doesn't exist yet.
+ * Waits for document.readyState === 'complete' before modifying the DOM so
+ * that SSR frameworks (e.g. Next.js) can finish hydration first. Uses
+ * setTimeout polling instead of window.addEventListener('load') because
+ * third-party scripts can proxy addEventListener and suppress load handlers.
+ * setTimeout is not affected by such proxies.
  */
 export function buildShell(globalScope: typeof globalThis): void {
   const doc = globalScope.document;
@@ -116,6 +117,9 @@ export function buildShell(globalScope: typeof globalThis): void {
       `{ display: none !important; }`;
     doc.head.appendChild(shellGuard);
 
+    // Preserve the overlay shadow host if it was already attached (the
+    // overlay script may have loaded before buildShell ran).
+    const existingOverlay = doc.getElementById(OVERLAY_HOST_ID);
     while (doc.body.firstChild) {
       doc.body.removeChild(doc.body.firstChild);
     }
@@ -169,18 +173,21 @@ export function buildShell(globalScope: typeof globalThis): void {
 
     container.appendChild(iframe);
     doc.body.appendChild(container);
+    if (existingOverlay) {
+      doc.body.appendChild(existingOverlay);
+    }
   };
 
-  if (doc.body) {
+  if (doc.readyState === 'complete' && doc.body) {
     run();
   } else {
-    const waitForBody = () => {
-      if (doc.body) {
+    const waitUntilReady = () => {
+      if (doc.readyState === 'complete' && doc.body) {
         run();
       } else {
-        globalScope.requestAnimationFrame(waitForBody);
+        globalScope.requestAnimationFrame(waitUntilReady);
       }
     };
-    globalScope.requestAnimationFrame(waitForBody);
+    globalScope.requestAnimationFrame(waitUntilReady);
   }
 }


### PR DESCRIPTION
## Summary

- In mobile mode, `buildShell` now completes before the overlay loads, eliminating a race condition where DOM restructuring disrupted the overlay's React 18 concurrent render
- `buildShell` returns a `Promise` that resolves after the shell is built; `experiment.ts` awaits it before calling `WindowMessenger.setup()`
- `buildShell` waits for `document.readyState === 'complete'` via `requestAnimationFrame` polling to avoid SSR hydration errors, without relying on `window.addEventListener('load')` which third-party scripts can suppress

Follows up on #299 which removed the `window.load` dependency from `asyncLoadScript`.

## Test plan

- [x] Visual editor desktop-to-mobile switch on SSR site (Next.js) — shell + overlay both render, no hydration errors
- [x] Visual editor desktop-to-mobile switch on non-SSR site — shell + overlay both render
- [x] Visual editor on Rocket Loader site — overlay loads on first attempt
- [x] MPA navigation with visual editor open — overlay reloads via stored session
- [x] Desktop mode visual editor — no regression, overlay loads normally