### PR TITLE
feat: use initConfigs for web experiment initialization

### DIFF
--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -26,7 +26,7 @@ import {
 } from './subscriptions/subscriptions';
 import {
   Defaults,
-  initConfigs,
+  InitConfigs,
   WebExperimentClient,
   WebExperimentConfig,
   WebExperimentUser,
@@ -121,7 +121,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
 
   constructor(
     apiKey: string,
-    initConfigs: initConfigs,
+    initConfigs: InitConfigs,
     config: WebExperimentConfig = {},
   ) {
     const globalScope = getGlobalScope();
@@ -366,7 +366,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
    */
   static getInstance(
     apiKey: string,
-    initConfigs: initConfigs,
+    initConfigs: InitConfigs,
     config: WebExperimentConfig = {},
   ): DefaultWebExperimentClient {
     const globalScope = getGlobalScope();

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -26,6 +26,7 @@ import {
 } from './subscriptions/subscriptions';
 import {
   Defaults,
+  initConfigs,
   WebExperimentClient,
   WebExperimentConfig,
   WebExperimentUser,
@@ -120,8 +121,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
 
   constructor(
     apiKey: string,
-    initialFlags: string,
-    pageObjects: string,
+    initConfigs: initConfigs,
     config: WebExperimentConfig = {},
   ) {
     const globalScope = getGlobalScope();
@@ -132,8 +132,8 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     }
     this.globalScope = globalScope;
     this.apiKey = apiKey;
-    this.initialFlags = JSON.parse(initialFlags);
-    this.pageObjects = JSON.parse(pageObjects);
+    this.initialFlags = JSON.parse(initConfigs.initialFlags);
+    this.pageObjects = JSON.parse(initConfigs.pageObjects);
     // merge config with defaults and experimentConfig (if provided)
     this.config = {
       ...Defaults,
@@ -361,14 +361,12 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
    * Get singleton of the {@link DefaultWebExperimentClient} if it has already been initialized.
    * If not, initialize the client and return the instance.
    * @param apiKey
-   * @param initialFlags
-   * @param pageObjects
+   * @param initConfigs
    * @param config
    */
   static getInstance(
     apiKey: string,
-    initialFlags: string,
-    pageObjects: string,
+    initConfigs: initConfigs,
     config: WebExperimentConfig = {},
   ): DefaultWebExperimentClient {
     const globalScope = getGlobalScope();
@@ -390,8 +388,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     }
     const webExperiment = new DefaultWebExperimentClient(
       apiKey,
-      initialFlags,
-      pageObjects,
+      initConfigs,
       config,
     );
     // Set the real client instance

--- a/packages/experiment-tag/src/index.ts
+++ b/packages/experiment-tag/src/index.ts
@@ -4,7 +4,7 @@ import { getGlobalScope } from '@amplitude/experiment-core';
 import { DefaultWebExperimentClient } from './experiment';
 import { HttpClient } from './preview/http';
 import { SdkPreviewApi } from './preview/preview-api';
-import { WebExperimentConfig } from './types';
+import { initConfigs, WebExperimentConfig } from './types';
 import { applyAntiFlickerCss } from './util/anti-flicker';
 import { isPreviewMode } from './util/url';
 
@@ -15,8 +15,7 @@ const eventBuffer: Array<{
 
 export const initialize = (
   apiKey: string,
-  initialFlags: string,
-  pageObjects: string,
+  initConfigs: initConfigs,
   config: WebExperimentConfig,
 ): void => {
   const globalScope = getGlobalScope();
@@ -38,30 +37,29 @@ export const initialize = (
     // Fetch latest configs and create client
     fetchLatestConfigs(apiKey, config.serverZone)
       .then((previewState) => {
-        const flags = JSON.stringify(previewState.flags);
-        const objects = JSON.stringify(previewState.pageViewObjects);
-        startClient(apiKey, flags, objects, config);
+        const initialFlags = JSON.stringify(previewState.flags);
+        const pageObjects = JSON.stringify(previewState.pageViewObjects);
+        startClient(apiKey, { initialFlags, pageObjects }, config);
       })
       .catch((error) => {
         console.warn('Failed to fetch latest configs for preview:', error);
-        startClient(apiKey, initialFlags, pageObjects, config);
+        startClient(apiKey, initConfigs, config);
       })
       .finally(() => {
         // Remove anti-flicker css if it exists
         document.getElementById('amp-exp-css')?.remove();
       });
   } else {
-    startClient(apiKey, initialFlags, pageObjects, config);
+    startClient(apiKey, initConfigs, config);
   }
 };
 
 const startClient = (
   apiKey: string,
-  flags: string,
-  objects: string,
+  initConfigs: initConfigs,
   config: WebExperimentConfig,
 ): void => {
-  DefaultWebExperimentClient.getInstance(apiKey, flags, objects, config)
+  DefaultWebExperimentClient.getInstance(apiKey, initConfigs, config)
     .start()
     .finally(() => {
       // Remove anti-flicker css if it exists

--- a/packages/experiment-tag/src/index.ts
+++ b/packages/experiment-tag/src/index.ts
@@ -4,7 +4,7 @@ import { getGlobalScope } from '@amplitude/experiment-core';
 import { DefaultWebExperimentClient } from './experiment';
 import { HttpClient } from './preview/http';
 import { SdkPreviewApi } from './preview/preview-api';
-import { initConfigs, WebExperimentConfig } from './types';
+import { InitConfigs, WebExperimentConfig } from './types';
 import { applyAntiFlickerCss } from './util/anti-flicker';
 import { isPreviewMode } from './util/url';
 
@@ -15,7 +15,7 @@ const eventBuffer: Array<{
 
 export const initialize = (
   apiKey: string,
-  initConfigs: initConfigs,
+  initConfigs: InitConfigs,
   config: WebExperimentConfig,
 ): void => {
   const globalScope = getGlobalScope();
@@ -56,7 +56,7 @@ export const initialize = (
 
 const startClient = (
   apiKey: string,
-  initConfigs: initConfigs,
+  initConfigs: InitConfigs,
   config: WebExperimentConfig,
 ): void => {
   DefaultWebExperimentClient.getInstance(apiKey, initConfigs, config)

--- a/packages/experiment-tag/src/types.ts
+++ b/packages/experiment-tag/src/types.ts
@@ -156,7 +156,7 @@ export type WebExperimentUser = {
   web_exp_id?: string;
 } & ExperimentUser;
 
-export type initConfigs = {
+export type InitConfigs = {
   initialFlags: string;
   pageObjects: string;
 };

--- a/packages/experiment-tag/src/types.ts
+++ b/packages/experiment-tag/src/types.ts
@@ -155,3 +155,8 @@ export interface WebExperimentClient {
 export type WebExperimentUser = {
   web_exp_id?: string;
 } & ExperimentUser;
+
+export type initConfigs = {
+  initialFlags: string;
+  pageObjects: string;
+};

--- a/packages/experiment-tag/test/debug-state.test.ts
+++ b/packages/experiment-tag/test/debug-state.test.ts
@@ -55,8 +55,7 @@ describe('buildFlagDebugInfo audienceEvaluation', () => {
 
     const client = DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify(flags),
-      JSON.stringify({}),
+      { initialFlags: JSON.stringify(flags), pageObjects: JSON.stringify({}) },
     );
     await client.start();
 
@@ -125,8 +124,7 @@ describe('buildFlagDebugInfo audienceEvaluation', () => {
 
     const client = DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify(flags),
-      JSON.stringify({}),
+      { initialFlags: JSON.stringify(flags), pageObjects: JSON.stringify({}) },
     );
     await client.start();
 
@@ -168,8 +166,7 @@ describe('buildFlagDebugInfo audienceEvaluation', () => {
 
     const client = DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify(flags),
-      JSON.stringify({}),
+      { initialFlags: JSON.stringify(flags), pageObjects: JSON.stringify({}) },
     );
     await client.start();
 

--- a/packages/experiment-tag/test/debug-state.test.ts
+++ b/packages/experiment-tag/test/debug-state.test.ts
@@ -53,10 +53,10 @@ describe('buildFlagDebugInfo audienceEvaluation', () => {
       },
     ];
 
-    const client = DefaultWebExperimentClient.getInstance(
-      stringify(apiKey),
-      { initialFlags: JSON.stringify(flags), pageObjects: JSON.stringify({}) },
-    );
+    const client = DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+      initialFlags: JSON.stringify(flags),
+      pageObjects: JSON.stringify({}),
+    });
     await client.start();
 
     const state = client.getDebugState();
@@ -122,10 +122,10 @@ describe('buildFlagDebugInfo audienceEvaluation', () => {
       },
     ];
 
-    const client = DefaultWebExperimentClient.getInstance(
-      stringify(apiKey),
-      { initialFlags: JSON.stringify(flags), pageObjects: JSON.stringify({}) },
-    );
+    const client = DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+      initialFlags: JSON.stringify(flags),
+      pageObjects: JSON.stringify({}),
+    });
     await client.start();
 
     const state = client.getDebugState();
@@ -164,10 +164,10 @@ describe('buildFlagDebugInfo audienceEvaluation', () => {
       },
     ];
 
-    const client = DefaultWebExperimentClient.getInstance(
-      stringify(apiKey),
-      { initialFlags: JSON.stringify(flags), pageObjects: JSON.stringify({}) },
-    );
+    const client = DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+      initialFlags: JSON.stringify(flags),
+      pageObjects: JSON.stringify({}),
+    });
     await client.start();
 
     const state = client.getDebugState();

--- a/packages/experiment-tag/test/experiment.test.ts
+++ b/packages/experiment-tag/test/experiment.test.ts
@@ -63,10 +63,10 @@ describe('initializeExperiment', () => {
   });
 
   test('should initialize experiment with empty user', async () => {
-    await DefaultWebExperimentClient.getInstance(
-      stringify(apiKey),
-      { initialFlags: JSON.stringify([]), pageObjects: JSON.stringify({}) },
-    ).start();
+    await DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+      initialFlags: JSON.stringify([]),
+      pageObjects: JSON.stringify({}),
+    }).start();
     expect(ExperimentClient.prototype.setUser).toHaveBeenCalledWith({
       web_exp_id: 'mock',
     });
@@ -102,7 +102,10 @@ describe('initializeExperiment', () => {
 
     const client = DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      { initialFlags: JSON.stringify(initialFlags), pageObjects: JSON.stringify({}) },
+      {
+        initialFlags: JSON.stringify(initialFlags),
+        pageObjects: JSON.stringify({}),
+      },
       {
         httpClient: mockHttpClient,
       },
@@ -115,10 +118,10 @@ describe('initializeExperiment', () => {
       .spyOn(experimentCore, 'isLocalStorageAvailable')
       .mockReturnValue(false);
     try {
-      await DefaultWebExperimentClient.getInstance(
-        stringify(apiKey),
-        { initialFlags: JSON.stringify([]), pageObjects: JSON.stringify({}) },
-      ).start();
+      await DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+        initialFlags: JSON.stringify([]),
+        pageObjects: JSON.stringify({}),
+      }).start();
     } catch (error: any) {
       expect(error.message).toBe(
         'Amplitude Web Experiment Client could not be initialized.',
@@ -139,21 +142,18 @@ describe('initializeExperiment', () => {
     // Verify sessionStorage is empty before test
     expect(mockGlobal.sessionStorage.getItem(redirectStorageKey)).toBeNull();
 
-    const client = DefaultWebExperimentClient.getInstance(
-      stringify(apiKey),
-      {
-        initialFlags: JSON.stringify([
-          createRedirectFlag(
-            'test',
-            'treatment',
-            'http://test.com/2',
-            undefined,
-            DEFAULT_REDIRECT_SCOPE,
-          ),
-        ]),
-        pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
-      },
-    );
+    const client = DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+      initialFlags: JSON.stringify([
+        createRedirectFlag(
+          'test',
+          'treatment',
+          'http://test.com/2',
+          undefined,
+          DEFAULT_REDIRECT_SCOPE,
+        ),
+      ]),
+      pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+    });
 
     // Initialize the client to ensure messageBus is created
     await client.start();
@@ -197,15 +197,12 @@ describe('initializeExperiment', () => {
   });
 
   test('control variant on control page - should not redirect but call exposure', async () => {
-    await DefaultWebExperimentClient.getInstance(
-      stringify(apiKey),
-      {
-        initialFlags: JSON.stringify([
-          createRedirectFlag('test', 'control', 'http://test.com/2'),
-        ]),
-        pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
-      },
-    ).start();
+    await DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+      initialFlags: JSON.stringify([
+        createRedirectFlag('test', 'control', 'http://test.com/2'),
+      ]),
+      pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+    }).start();
 
     // No redirect should happen
     expect(mockGlobal.location.replace).toBeCalledTimes(0);
@@ -237,15 +234,12 @@ describe('initializeExperiment', () => {
     // @ts-ignore
     mockGetGlobalScope.mockReturnValue(mockGlobal);
 
-    await DefaultWebExperimentClient.getInstance(
-      stringify(apiKey),
-      {
-        initialFlags: JSON.stringify([
-          createRedirectFlag('test', 'treatment', 'http://test.com/2'),
-        ]),
-        pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
-      },
-    ).start();
+    await DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+      initialFlags: JSON.stringify([
+        createRedirectFlag('test', 'treatment', 'http://test.com/2'),
+      ]),
+      pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+    }).start();
     expect(mockGlobal.location.replace).toHaveBeenCalledTimes(0);
     expect(mockGlobal.history.replaceState).toHaveBeenCalledWith(
       {},
@@ -279,21 +273,18 @@ describe('initializeExperiment', () => {
 
     const redirectStorageKey = `EXP_${apiKey.toString().slice(0, 10)}_REDIRECT`;
 
-    const client = DefaultWebExperimentClient.getInstance(
-      stringify(apiKey),
-      {
-        initialFlags: JSON.stringify([
-          createRedirectFlag(
-            'test',
-            'control',
-            'http://test.com/2',
-            undefined,
-            DEFAULT_REDIRECT_SCOPE,
-          ),
-        ]),
-        pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
-      },
-    );
+    const client = DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+      initialFlags: JSON.stringify([
+        createRedirectFlag(
+          'test',
+          'control',
+          'http://test.com/2',
+          undefined,
+          DEFAULT_REDIRECT_SCOPE,
+        ),
+      ]),
+      pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+    });
 
     await client.start();
 
@@ -343,15 +334,12 @@ describe('initializeExperiment', () => {
     // @ts-ignore
     mockGetGlobalScope.mockReturnValue(mockGlobal);
 
-    const client = DefaultWebExperimentClient.getInstance(
-      stringify(apiKey),
-      {
-        initialFlags: JSON.stringify([
-          createRedirectFlag('test', 'treatment', 'http://test.com/2', undefined),
-        ]),
-        pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
-      },
-    );
+    const client = DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+      initialFlags: JSON.stringify([
+        createRedirectFlag('test', 'treatment', 'http://test.com/2', undefined),
+      ]),
+      pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+    });
 
     client.start().then();
 
@@ -378,21 +366,18 @@ describe('initializeExperiment', () => {
 
     const redirectStorageKey = `EXP_${apiKey.toString().slice(0, 10)}_REDIRECT`;
 
-    const client = DefaultWebExperimentClient.getInstance(
-      stringify(apiKey),
-      {
-        initialFlags: JSON.stringify([
-          createRedirectFlag(
-            'test',
-            'treatment',
-            'http://test.com/2?param3=c',
-            'http://test.com/',
-            DEFAULT_REDIRECT_SCOPE,
-          ),
-        ]),
-        pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
-      },
-    );
+    const client = DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+      initialFlags: JSON.stringify([
+        createRedirectFlag(
+          'test',
+          'treatment',
+          'http://test.com/2?param3=c',
+          'http://test.com/',
+          DEFAULT_REDIRECT_SCOPE,
+        ),
+      ]),
+      pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+    });
 
     await client.start();
 
@@ -431,21 +416,18 @@ describe('initializeExperiment', () => {
   });
 
   test('should behave as control variant when payload is empty', async () => {
-    await DefaultWebExperimentClient.getInstance(
-      stringify(apiKey),
-      {
-        initialFlags: JSON.stringify([
-          createRedirectFlag(
-            'test',
-            'control',
-            'http://test.com/2?param3=c',
-            undefined,
-            DEFAULT_REDIRECT_SCOPE,
-          ),
-        ]),
-        pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
-      },
-    ).start();
+    await DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+      initialFlags: JSON.stringify([
+        createRedirectFlag(
+          'test',
+          'control',
+          'http://test.com/2?param3=c',
+          undefined,
+          DEFAULT_REDIRECT_SCOPE,
+        ),
+      ]),
+      pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+    }).start();
 
     expect(mockGlobal.location.replace).not.toHaveBeenCalled();
     expect(mockExposure).toHaveBeenCalledWith('test');
@@ -468,21 +450,18 @@ describe('initializeExperiment', () => {
     // Verify sessionStorage is empty before test
     expect(mockGlobal.sessionStorage.getItem(redirectStorageKey)).toBeNull();
 
-    const client = DefaultWebExperimentClient.getInstance(
-      stringify(apiKey),
-      {
-        initialFlags: JSON.stringify([
-          createRedirectFlag(
-            'test',
-            'treatment',
-            'http://test.com/2',
-            undefined,
-            DEFAULT_REDIRECT_SCOPE,
-          ),
-        ]),
-        pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
-      },
-    );
+    const client = DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+      initialFlags: JSON.stringify([
+        createRedirectFlag(
+          'test',
+          'treatment',
+          'http://test.com/2',
+          undefined,
+          DEFAULT_REDIRECT_SCOPE,
+        ),
+      ]),
+      pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+    });
 
     // Initialize the client to ensure messageBus is created
     await client.start();
@@ -532,21 +511,18 @@ describe('initializeExperiment', () => {
       },
       writable: true,
     });
-    DefaultWebExperimentClient.getInstance(
-      stringify(apiKey),
-      {
-        initialFlags: JSON.stringify([
-          createRedirectFlag(
-            'test',
-            'treatment',
-            'http://test.com/2',
-            undefined,
-            DEFAULT_REDIRECT_SCOPE,
-          ),
-        ]),
-        pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
-      },
-    );
+    DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+      initialFlags: JSON.stringify([
+        createRedirectFlag(
+          'test',
+          'treatment',
+          'http://test.com/2',
+          undefined,
+          DEFAULT_REDIRECT_SCOPE,
+        ),
+      ]),
+      pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+    });
     expect(mockExposure).not.toHaveBeenCalled();
   });
 
@@ -563,7 +539,10 @@ describe('initializeExperiment', () => {
 
     DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      { initialFlags: JSON.stringify(initialFlags), pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS) },
+      {
+        initialFlags: JSON.stringify(initialFlags),
+        pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      },
       {
         httpClient: mockHttpClient,
       },
@@ -702,7 +681,10 @@ describe('initializeExperiment', () => {
 
     DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      { initialFlags: JSON.stringify(initialFlags), pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS) },
+      {
+        initialFlags: JSON.stringify(initialFlags),
+        pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      },
       {
         httpClient: mockHttpClient,
       },
@@ -741,7 +723,10 @@ describe('initializeExperiment', () => {
     );
     DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      { initialFlags: JSON.stringify(initialFlags), pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS) },
+      {
+        initialFlags: JSON.stringify(initialFlags),
+        pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      },
       {
         httpClient: mockHttpClient,
       },
@@ -786,7 +771,10 @@ describe('initializeExperiment', () => {
 
     const client = DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      { initialFlags: JSON.stringify(initialFlags), pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS) },
+      {
+        initialFlags: JSON.stringify(initialFlags),
+        pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      },
       {
         httpClient: mockHttpClient,
       },
@@ -839,10 +827,10 @@ describe('initializeExperiment', () => {
         [],
       ),
     ];
-    const client = DefaultWebExperimentClient.getInstance(
-      stringify(apiKey),
-      { initialFlags: JSON.stringify(initialFlags), pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS) },
-    );
+    const client = DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+      initialFlags: JSON.stringify(initialFlags),
+      pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+    });
     await client.start();
     expect(mockExposure).toHaveBeenCalledTimes(1);
     expect(mockExposure).toHaveBeenCalledWith('test');
@@ -867,18 +855,15 @@ describe('initializeExperiment', () => {
         { metadata: { scope: ['B'] } },
       ]),
     ];
-    const client = DefaultWebExperimentClient.getInstance(
-      stringify(apiKey),
-      {
-        initialFlags: JSON.stringify(initialFlags),
-        pageObjects: JSON.stringify({
-          test: {
-            ...createPageObject('A', 'url_change', undefined, 'http://test.com'),
-            ...createPageObject('B', 'url_change', undefined, 'http://test.com'),
-          },
-        }),
-      },
-    );
+    const client = DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+      initialFlags: JSON.stringify(initialFlags),
+      pageObjects: JSON.stringify({
+        test: {
+          ...createPageObject('A', 'url_change', undefined, 'http://test.com'),
+          ...createPageObject('B', 'url_change', undefined, 'http://test.com'),
+        },
+      }),
+    });
     await client.start();
     expect(mockExposure).toHaveBeenCalledTimes(1);
     expect(mockExposure).toHaveBeenCalledWith('test');
@@ -922,19 +907,16 @@ describe('initializeExperiment', () => {
       undefined,
       'http://B.com',
     );
-    const client = DefaultWebExperimentClient.getInstance(
-      stringify(apiKey),
-      {
-        initialFlags: JSON.stringify([
-          createMutateFlag('test-1', 'treatment', [{ metadata: {} }]),
-          createMutateFlag('test-2', 'treatment', [{ metadata: {} }]),
-        ]),
-        pageObjects: JSON.stringify({
-          'test-1': test1Page,
-          'test-2': test2Page,
-        }),
-      },
-    );
+    const client = DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+      initialFlags: JSON.stringify([
+        createMutateFlag('test-1', 'treatment', [{ metadata: {} }]),
+        createMutateFlag('test-2', 'treatment', [{ metadata: {} }]),
+      ]),
+      pageObjects: JSON.stringify({
+        'test-1': test1Page,
+        'test-2': test2Page,
+      }),
+    });
     client.start().then();
     let activePages = (client as any).activePages;
     expect(activePages).toEqual({ 'test-1': test1Page });
@@ -958,10 +940,10 @@ describe('initializeExperiment', () => {
         { metadata: { scope: ['A'] } },
       ]),
     ];
-    const client = DefaultWebExperimentClient.getInstance(
-      stringify(apiKey),
-      { initialFlags: JSON.stringify(initialFlags), pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS) },
-    );
+    const client = DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+      initialFlags: JSON.stringify(initialFlags),
+      pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+    });
     await client.start();
     expect(mockExposure).toHaveBeenCalledTimes(1);
     expect(mockExposure).toHaveBeenCalledWith('test');
@@ -989,10 +971,10 @@ describe('initializeExperiment', () => {
         { metadata: { scope: ['C'] } },
       ]),
     ];
-    const client = DefaultWebExperimentClient.getInstance(
-      stringify(apiKey),
-      { initialFlags: JSON.stringify(initialFlags), pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS) },
-    );
+    const client = DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+      initialFlags: JSON.stringify(initialFlags),
+      pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+    });
     client.start().then();
     expect(mockExposure).toHaveBeenCalledTimes(0);
     const appliedMutations = (client as any).appliedMutations;
@@ -1007,10 +989,10 @@ describe('initializeExperiment', () => {
         { metadata: { scope: ['B'] } },
       ]),
     ];
-    const client = DefaultWebExperimentClient.getInstance(
-      stringify(apiKey),
-      { initialFlags: JSON.stringify(initialFlags), pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS) },
-    );
+    const client = DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+      initialFlags: JSON.stringify(initialFlags),
+      pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+    });
     await client.start();
     expect(mockExposure).toHaveBeenCalledTimes(1);
     expect(mockExposure).toHaveBeenCalledWith('test');
@@ -1053,19 +1035,16 @@ describe('initializeExperiment', () => {
       undefined,
       'http://B.com',
     );
-    const client = DefaultWebExperimentClient.getInstance(
-      stringify(apiKey),
-      {
-        initialFlags: JSON.stringify([
-          createMutateFlag('test-1', 'treatment', [{ metadata: {} }]),
-          createMutateFlag('test-2', 'treatment', [{ metadata: {} }]),
-        ]),
-        pageObjects: JSON.stringify({
-          'test-1': test1Page,
-          'test-2': test2Page,
-        }),
-      },
-    );
+    const client = DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+      initialFlags: JSON.stringify([
+        createMutateFlag('test-1', 'treatment', [{ metadata: {} }]),
+        createMutateFlag('test-2', 'treatment', [{ metadata: {} }]),
+      ]),
+      pageObjects: JSON.stringify({
+        'test-1': test1Page,
+        'test-2': test2Page,
+      }),
+    });
     await client.start();
     expect(mockExposure).toHaveBeenCalledTimes(1);
     expect(mockExposure).toHaveBeenCalledWith('test-1');
@@ -1130,22 +1109,19 @@ describe('initializeExperiment', () => {
     );
 
     // Create client with some flags (not the stored redirect flag)
-    const client = DefaultWebExperimentClient.getInstance(
-      stringify(apiKey),
-      {
-        initialFlags: JSON.stringify([
-          createMutateFlag('other-flag', 'treatment', [DEFAULT_MUTATE_SCOPE]),
-        ]),
-        pageObjects: JSON.stringify({
-          'other-flag': createPageObject(
-            'A',
-            'url_change',
-            undefined,
-            'http://test.com',
-          ),
-        }),
-      },
-    );
+    const client = DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+      initialFlags: JSON.stringify([
+        createMutateFlag('other-flag', 'treatment', [DEFAULT_MUTATE_SCOPE]),
+      ]),
+      pageObjects: JSON.stringify({
+        'other-flag': createPageObject(
+          'A',
+          'url_change',
+          undefined,
+          'http://test.com',
+        ),
+      }),
+    });
 
     // Clear exposure tracking before test
     mockExposureInternal.mockClear();
@@ -1230,7 +1206,10 @@ describe('initializeExperiment', () => {
       ];
       const client = DefaultWebExperimentClient.getInstance(
         apiKey,
-        { initialFlags: JSON.stringify(initialFlags), pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS) },
+        {
+          initialFlags: JSON.stringify(initialFlags),
+          pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+        },
         {
           httpClient: new MockHttpClient(JSON.stringify(remoteFlags), 200),
         },
@@ -1311,7 +1290,10 @@ describe('initializeExperiment', () => {
       ];
       const client = DefaultWebExperimentClient.getInstance(
         apiKey,
-        { initialFlags: JSON.stringify(initialFlags), pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS) },
+        {
+          initialFlags: JSON.stringify(initialFlags),
+          pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+        },
         {
           httpClient: new MockHttpClient(JSON.stringify(remoteFlags), 200),
         },
@@ -1434,23 +1416,20 @@ describe('helper methods', () => {
         variant: 'treatment',
       },
     ];
-    const webExperiment = new DefaultWebExperimentClient(
-      stringify(apiKey),
-      {
-        initialFlags: JSON.stringify([
-          createRedirectFlag(
-            'flag-1',
-            'control',
-            '',
-            undefined,
-            {},
-            targetedSegment,
-          ),
-          createRedirectFlag('flag-2', 'control', '', undefined),
-        ]),
-        pageObjects: JSON.stringify({}),
-      },
-    );
+    const webExperiment = new DefaultWebExperimentClient(stringify(apiKey), {
+      initialFlags: JSON.stringify([
+        createRedirectFlag(
+          'flag-1',
+          'control',
+          '',
+          undefined,
+          {},
+          targetedSegment,
+        ),
+        createRedirectFlag('flag-2', 'control', '', undefined),
+      ]),
+      pageObjects: JSON.stringify({}),
+    });
     const variants = webExperiment.getVariants();
     expect(variants['flag-1'].key).toEqual('treatment');
     expect(variants['flag-2'].key).toEqual('control');

--- a/packages/experiment-tag/test/experiment.test.ts
+++ b/packages/experiment-tag/test/experiment.test.ts
@@ -65,8 +65,7 @@ describe('initializeExperiment', () => {
   test('should initialize experiment with empty user', async () => {
     await DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify([]),
-      JSON.stringify({}),
+      { initialFlags: JSON.stringify([]), pageObjects: JSON.stringify({}) },
     ).start();
     expect(ExperimentClient.prototype.setUser).toHaveBeenCalledWith({
       web_exp_id: 'mock',
@@ -103,8 +102,7 @@ describe('initializeExperiment', () => {
 
     const client = DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify(initialFlags),
-      JSON.stringify({}),
+      { initialFlags: JSON.stringify(initialFlags), pageObjects: JSON.stringify({}) },
       {
         httpClient: mockHttpClient,
       },
@@ -119,8 +117,7 @@ describe('initializeExperiment', () => {
     try {
       await DefaultWebExperimentClient.getInstance(
         stringify(apiKey),
-        JSON.stringify([]),
-        JSON.stringify({}),
+        { initialFlags: JSON.stringify([]), pageObjects: JSON.stringify({}) },
       ).start();
     } catch (error: any) {
       expect(error.message).toBe(
@@ -144,16 +141,18 @@ describe('initializeExperiment', () => {
 
     const client = DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify([
-        createRedirectFlag(
-          'test',
-          'treatment',
-          'http://test.com/2',
-          undefined,
-          DEFAULT_REDIRECT_SCOPE,
-        ),
-      ]),
-      JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      {
+        initialFlags: JSON.stringify([
+          createRedirectFlag(
+            'test',
+            'treatment',
+            'http://test.com/2',
+            undefined,
+            DEFAULT_REDIRECT_SCOPE,
+          ),
+        ]),
+        pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      },
     );
 
     // Initialize the client to ensure messageBus is created
@@ -200,10 +199,12 @@ describe('initializeExperiment', () => {
   test('control variant on control page - should not redirect but call exposure', async () => {
     await DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify([
-        createRedirectFlag('test', 'control', 'http://test.com/2'),
-      ]),
-      JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      {
+        initialFlags: JSON.stringify([
+          createRedirectFlag('test', 'control', 'http://test.com/2'),
+        ]),
+        pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      },
     ).start();
 
     // No redirect should happen
@@ -238,10 +239,12 @@ describe('initializeExperiment', () => {
 
     await DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify([
-        createRedirectFlag('test', 'treatment', 'http://test.com/2'),
-      ]),
-      JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      {
+        initialFlags: JSON.stringify([
+          createRedirectFlag('test', 'treatment', 'http://test.com/2'),
+        ]),
+        pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      },
     ).start();
     expect(mockGlobal.location.replace).toHaveBeenCalledTimes(0);
     expect(mockGlobal.history.replaceState).toHaveBeenCalledWith(
@@ -278,16 +281,18 @@ describe('initializeExperiment', () => {
 
     const client = DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify([
-        createRedirectFlag(
-          'test',
-          'control',
-          'http://test.com/2',
-          undefined,
-          DEFAULT_REDIRECT_SCOPE,
-        ),
-      ]),
-      JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      {
+        initialFlags: JSON.stringify([
+          createRedirectFlag(
+            'test',
+            'control',
+            'http://test.com/2',
+            undefined,
+            DEFAULT_REDIRECT_SCOPE,
+          ),
+        ]),
+        pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      },
     );
 
     await client.start();
@@ -340,10 +345,12 @@ describe('initializeExperiment', () => {
 
     const client = DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify([
-        createRedirectFlag('test', 'treatment', 'http://test.com/2', undefined),
-      ]),
-      JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      {
+        initialFlags: JSON.stringify([
+          createRedirectFlag('test', 'treatment', 'http://test.com/2', undefined),
+        ]),
+        pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      },
     );
 
     client.start().then();
@@ -373,16 +380,18 @@ describe('initializeExperiment', () => {
 
     const client = DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify([
-        createRedirectFlag(
-          'test',
-          'treatment',
-          'http://test.com/2?param3=c',
-          'http://test.com/',
-          DEFAULT_REDIRECT_SCOPE,
-        ),
-      ]),
-      JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      {
+        initialFlags: JSON.stringify([
+          createRedirectFlag(
+            'test',
+            'treatment',
+            'http://test.com/2?param3=c',
+            'http://test.com/',
+            DEFAULT_REDIRECT_SCOPE,
+          ),
+        ]),
+        pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      },
     );
 
     await client.start();
@@ -424,16 +433,18 @@ describe('initializeExperiment', () => {
   test('should behave as control variant when payload is empty', async () => {
     await DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify([
-        createRedirectFlag(
-          'test',
-          'control',
-          'http://test.com/2?param3=c',
-          undefined,
-          DEFAULT_REDIRECT_SCOPE,
-        ),
-      ]),
-      JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      {
+        initialFlags: JSON.stringify([
+          createRedirectFlag(
+            'test',
+            'control',
+            'http://test.com/2?param3=c',
+            undefined,
+            DEFAULT_REDIRECT_SCOPE,
+          ),
+        ]),
+        pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      },
     ).start();
 
     expect(mockGlobal.location.replace).not.toHaveBeenCalled();
@@ -459,16 +470,18 @@ describe('initializeExperiment', () => {
 
     const client = DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify([
-        createRedirectFlag(
-          'test',
-          'treatment',
-          'http://test.com/2',
-          undefined,
-          DEFAULT_REDIRECT_SCOPE,
-        ),
-      ]),
-      JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      {
+        initialFlags: JSON.stringify([
+          createRedirectFlag(
+            'test',
+            'treatment',
+            'http://test.com/2',
+            undefined,
+            DEFAULT_REDIRECT_SCOPE,
+          ),
+        ]),
+        pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      },
     );
 
     // Initialize the client to ensure messageBus is created
@@ -521,16 +534,18 @@ describe('initializeExperiment', () => {
     });
     DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify([
-        createRedirectFlag(
-          'test',
-          'treatment',
-          'http://test.com/2',
-          undefined,
-          DEFAULT_REDIRECT_SCOPE,
-        ),
-      ]),
-      JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      {
+        initialFlags: JSON.stringify([
+          createRedirectFlag(
+            'test',
+            'treatment',
+            'http://test.com/2',
+            undefined,
+            DEFAULT_REDIRECT_SCOPE,
+          ),
+        ]),
+        pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      },
     );
     expect(mockExposure).not.toHaveBeenCalled();
   });
@@ -548,8 +563,7 @@ describe('initializeExperiment', () => {
 
     DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify(initialFlags),
-      JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      { initialFlags: JSON.stringify(initialFlags), pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS) },
       {
         httpClient: mockHttpClient,
       },
@@ -586,21 +600,23 @@ describe('initializeExperiment', () => {
 
     await DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify(initialFlags),
-      JSON.stringify({
-        'test-1': createPageObject(
-          'A',
-          'url_change',
-          undefined,
-          'http://test.com',
-        ),
-        'test-2': createPageObject(
-          'A',
-          'url_change',
-          undefined,
-          'http://test.com',
-        ),
-      }),
+      {
+        initialFlags: JSON.stringify(initialFlags),
+        pageObjects: JSON.stringify({
+          'test-1': createPageObject(
+            'A',
+            'url_change',
+            undefined,
+            'http://test.com',
+          ),
+          'test-2': createPageObject(
+            'A',
+            'url_change',
+            undefined,
+            'http://test.com',
+          ),
+        }),
+      },
       {
         httpClient: mockHttpClient,
       },
@@ -643,21 +659,23 @@ describe('initializeExperiment', () => {
 
     await DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify(initialFlags),
-      JSON.stringify({
-        'test-1': createPageObject(
-          'A',
-          'url_change',
-          undefined,
-          'http://test.com',
-        ),
-        'test-2': createPageObject(
-          'A',
-          'url_change',
-          undefined,
-          'http://test.com',
-        ),
-      }),
+      {
+        initialFlags: JSON.stringify(initialFlags),
+        pageObjects: JSON.stringify({
+          'test-1': createPageObject(
+            'A',
+            'url_change',
+            undefined,
+            'http://test.com',
+          ),
+          'test-2': createPageObject(
+            'A',
+            'url_change',
+            undefined,
+            'http://test.com',
+          ),
+        }),
+      },
       {
         httpClient: mockHttpClient,
       },
@@ -684,8 +702,7 @@ describe('initializeExperiment', () => {
 
     DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify(initialFlags),
-      JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      { initialFlags: JSON.stringify(initialFlags), pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS) },
       {
         httpClient: mockHttpClient,
       },
@@ -724,8 +741,7 @@ describe('initializeExperiment', () => {
     );
     DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify(initialFlags),
-      JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      { initialFlags: JSON.stringify(initialFlags), pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS) },
       {
         httpClient: mockHttpClient,
       },
@@ -770,8 +786,7 @@ describe('initializeExperiment', () => {
 
     const client = DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify(initialFlags),
-      JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      { initialFlags: JSON.stringify(initialFlags), pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS) },
       {
         httpClient: mockHttpClient,
       },
@@ -826,8 +841,7 @@ describe('initializeExperiment', () => {
     ];
     const client = DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify(initialFlags),
-      JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      { initialFlags: JSON.stringify(initialFlags), pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS) },
     );
     await client.start();
     expect(mockExposure).toHaveBeenCalledTimes(1);
@@ -855,13 +869,15 @@ describe('initializeExperiment', () => {
     ];
     const client = DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify(initialFlags),
-      JSON.stringify({
-        test: {
-          ...createPageObject('A', 'url_change', undefined, 'http://test.com'),
-          ...createPageObject('B', 'url_change', undefined, 'http://test.com'),
-        },
-      }),
+      {
+        initialFlags: JSON.stringify(initialFlags),
+        pageObjects: JSON.stringify({
+          test: {
+            ...createPageObject('A', 'url_change', undefined, 'http://test.com'),
+            ...createPageObject('B', 'url_change', undefined, 'http://test.com'),
+          },
+        }),
+      },
     );
     await client.start();
     expect(mockExposure).toHaveBeenCalledTimes(1);
@@ -908,14 +924,16 @@ describe('initializeExperiment', () => {
     );
     const client = DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify([
-        createMutateFlag('test-1', 'treatment', [{ metadata: {} }]),
-        createMutateFlag('test-2', 'treatment', [{ metadata: {} }]),
-      ]),
-      JSON.stringify({
-        'test-1': test1Page,
-        'test-2': test2Page,
-      }),
+      {
+        initialFlags: JSON.stringify([
+          createMutateFlag('test-1', 'treatment', [{ metadata: {} }]),
+          createMutateFlag('test-2', 'treatment', [{ metadata: {} }]),
+        ]),
+        pageObjects: JSON.stringify({
+          'test-1': test1Page,
+          'test-2': test2Page,
+        }),
+      },
     );
     client.start().then();
     let activePages = (client as any).activePages;
@@ -942,8 +960,7 @@ describe('initializeExperiment', () => {
     ];
     const client = DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify(initialFlags),
-      JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      { initialFlags: JSON.stringify(initialFlags), pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS) },
     );
     await client.start();
     expect(mockExposure).toHaveBeenCalledTimes(1);
@@ -974,8 +991,7 @@ describe('initializeExperiment', () => {
     ];
     const client = DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify(initialFlags),
-      JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      { initialFlags: JSON.stringify(initialFlags), pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS) },
     );
     client.start().then();
     expect(mockExposure).toHaveBeenCalledTimes(0);
@@ -993,8 +1009,7 @@ describe('initializeExperiment', () => {
     ];
     const client = DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify(initialFlags),
-      JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      { initialFlags: JSON.stringify(initialFlags), pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS) },
     );
     await client.start();
     expect(mockExposure).toHaveBeenCalledTimes(1);
@@ -1040,14 +1055,16 @@ describe('initializeExperiment', () => {
     );
     const client = DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify([
-        createMutateFlag('test-1', 'treatment', [{ metadata: {} }]),
-        createMutateFlag('test-2', 'treatment', [{ metadata: {} }]),
-      ]),
-      JSON.stringify({
-        'test-1': test1Page,
-        'test-2': test2Page,
-      }),
+      {
+        initialFlags: JSON.stringify([
+          createMutateFlag('test-1', 'treatment', [{ metadata: {} }]),
+          createMutateFlag('test-2', 'treatment', [{ metadata: {} }]),
+        ]),
+        pageObjects: JSON.stringify({
+          'test-1': test1Page,
+          'test-2': test2Page,
+        }),
+      },
     );
     await client.start();
     expect(mockExposure).toHaveBeenCalledTimes(1);
@@ -1115,17 +1132,19 @@ describe('initializeExperiment', () => {
     // Create client with some flags (not the stored redirect flag)
     const client = DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify([
-        createMutateFlag('other-flag', 'treatment', [DEFAULT_MUTATE_SCOPE]),
-      ]),
-      JSON.stringify({
-        'other-flag': createPageObject(
-          'A',
-          'url_change',
-          undefined,
-          'http://test.com',
-        ),
-      }),
+      {
+        initialFlags: JSON.stringify([
+          createMutateFlag('other-flag', 'treatment', [DEFAULT_MUTATE_SCOPE]),
+        ]),
+        pageObjects: JSON.stringify({
+          'other-flag': createPageObject(
+            'A',
+            'url_change',
+            undefined,
+            'http://test.com',
+          ),
+        }),
+      },
     );
 
     // Clear exposure tracking before test
@@ -1211,8 +1230,7 @@ describe('initializeExperiment', () => {
       ];
       const client = DefaultWebExperimentClient.getInstance(
         apiKey,
-        JSON.stringify(initialFlags),
-        JSON.stringify(DEFAULT_PAGE_OBJECTS),
+        { initialFlags: JSON.stringify(initialFlags), pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS) },
         {
           httpClient: new MockHttpClient(JSON.stringify(remoteFlags), 200),
         },
@@ -1293,8 +1311,7 @@ describe('initializeExperiment', () => {
       ];
       const client = DefaultWebExperimentClient.getInstance(
         apiKey,
-        JSON.stringify(initialFlags),
-        JSON.stringify(DEFAULT_PAGE_OBJECTS),
+        { initialFlags: JSON.stringify(initialFlags), pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS) },
         {
           httpClient: new MockHttpClient(JSON.stringify(remoteFlags), 200),
         },
@@ -1377,29 +1394,31 @@ describe('helper methods', () => {
     jest.spyOn(experimentCore, 'getGlobalScope');
     const webExperiment = DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
-      JSON.stringify([
-        createMutateFlag(
-          'targeted',
-          'treatment',
-          [DEFAULT_MUTATE_SCOPE],
-          [],
-          'local',
-        ),
-      ]),
-      JSON.stringify({
-        targeted: createPageObject(
-          'A',
-          'url_change',
-          undefined,
-          'http://test.com',
-        ),
-        'non-targeted': createPageObject(
-          'A',
-          'url_change',
-          undefined,
-          'http://not-targeted.com',
-        ),
-      }),
+      {
+        initialFlags: JSON.stringify([
+          createMutateFlag(
+            'targeted',
+            'treatment',
+            [DEFAULT_MUTATE_SCOPE],
+            [],
+            'local',
+          ),
+        ]),
+        pageObjects: JSON.stringify({
+          targeted: createPageObject(
+            'A',
+            'url_change',
+            undefined,
+            'http://test.com',
+          ),
+          'non-targeted': createPageObject(
+            'A',
+            'url_change',
+            undefined,
+            'http://not-targeted.com',
+          ),
+        }),
+      },
     );
     await webExperiment.start();
     const activeExperiments = webExperiment.getActiveExperiments();
@@ -1417,18 +1436,20 @@ describe('helper methods', () => {
     ];
     const webExperiment = new DefaultWebExperimentClient(
       stringify(apiKey),
-      JSON.stringify([
-        createRedirectFlag(
-          'flag-1',
-          'control',
-          '',
-          undefined,
-          {},
-          targetedSegment,
-        ),
-        createRedirectFlag('flag-2', 'control', '', undefined),
-      ]),
-      JSON.stringify({}),
+      {
+        initialFlags: JSON.stringify([
+          createRedirectFlag(
+            'flag-1',
+            'control',
+            '',
+            undefined,
+            {},
+            targetedSegment,
+          ),
+          createRedirectFlag('flag-2', 'control', '', undefined),
+        ]),
+        pageObjects: JSON.stringify({}),
+      },
     );
     const variants = webExperiment.getVariants();
     expect(variants['flag-1'].key).toEqual('treatment');

--- a/packages/experiment-tag/test/manual/test-debug.html
+++ b/packages/experiment-tag/test/manual/test-debug.html
@@ -508,8 +508,10 @@
 
       WebExperiment.initialize(
         'test-api-key',
-        JSON.stringify(FLAGS),
-        JSON.stringify(PAGE_OBJECTS),
+        {
+          initialFlags: JSON.stringify(FLAGS),
+          pageObjects: JSON.stringify(PAGE_OBJECTS),
+        },
         {},
       );
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

Update web experiment initialization to take in `initConfigs` instead of individual strings. This makes initialization easier to extend with new configs.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public initialization/getInstance API to take an `InitConfigs` object instead of separate `initialFlags`/`pageObjects` strings, which can break existing callers and requires coordinated updates across integrations.
> 
> **Overview**
> **Web Experiment initialization now takes a single `InitConfigs` object** (with `initialFlags` and `pageObjects`) instead of two separate string parameters.
> 
> This updates `DefaultWebExperimentClient` (constructor + `getInstance`), the top-level `initialize`/client startup flow (including preview config fetch handling), and introduces the `InitConfigs` type in `types.ts`. Tests and the manual debug page are updated to use the new init shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73a9481dfd40694ba06bccc8079df955eb22a879. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->