### PR TITLE
fix: shorten behavioral targeting storage key

### DIFF
--- a/packages/experiment-tag/src/behavioral-targeting/event-storage.ts
+++ b/packages/experiment-tag/src/behavioral-targeting/event-storage.ts
@@ -39,7 +39,7 @@ export class EventStorageManager {
     sessionManager: SessionManager,
     persistedEvents?: Set<string>,
   ) {
-    this.storageKey = `EXP_${apiKey}_rtbt_events`;
+    this.storageKey = `EXP_${apiKey.slice(0, 10)}_rtbt_events`;
     this.sessionManager = sessionManager;
     this.persistedEvents = persistedEvents;
 

--- a/packages/experiment-tag/src/behavioral-targeting/session-manager.ts
+++ b/packages/experiment-tag/src/behavioral-targeting/session-manager.ts
@@ -8,7 +8,7 @@ export class SessionManager {
   private sessionStartTime?: number;
 
   constructor(apiKey: string) {
-    this.storageKey = `EXP_${apiKey}_rtbt_session`;
+    this.storageKey = `EXP_${apiKey.slice(0, 10)}_rtbt_session`;
   }
 
   /**

--- a/packages/experiment-tag/test/behavioral-targeting/event-storage.test.ts
+++ b/packages/experiment-tag/test/behavioral-targeting/event-storage.test.ts
@@ -5,6 +5,8 @@ describe('EventStorageManager', () => {
   let eventStorage: EventStorageManager;
   let sessionManager: SessionManager;
   const testApiKey = 'test-api-key';
+  // Storage key uses first 10 characters of API key
+  const storageKey = `EXP_${testApiKey.slice(0, 10)}_rtbt_events`; // 'EXP_test-api-ke_rtbt_events'
 
   beforeEach(() => {
     // Clear storage before each test
@@ -48,7 +50,7 @@ describe('EventStorageManager', () => {
       eventStorage.addEvent('click', { button: 'submit' });
       eventStorage.flush(); // Flush debounced write for testing
 
-      const stored = localStorage.getItem('EXP_test-api-key_rtbt_events');
+      const stored = localStorage.getItem(storageKey);
       expect(stored).not.toBeNull();
 
       if (stored) {
@@ -99,7 +101,7 @@ describe('EventStorageManager', () => {
     });
 
     test('should handle invalid JSON in localStorage', () => {
-      localStorage.setItem('EXP_test-api-key_rtbt_events', 'invalid json');
+      localStorage.setItem(storageKey, 'invalid json');
 
       eventStorage.addEvent('click');
 
@@ -357,7 +359,7 @@ describe('EventStorageManager', () => {
       eventStorage.addEvent('click');
       eventStorage.clearEvents();
 
-      const stored = localStorage.getItem('EXP_test-api-key_rtbt_events');
+      const stored = localStorage.getItem(storageKey);
       expect(stored).not.toBeNull();
 
       if (stored) {

--- a/packages/experiment-tag/test/behavioral-targeting/event-storage.test.ts
+++ b/packages/experiment-tag/test/behavioral-targeting/event-storage.test.ts
@@ -5,8 +5,7 @@ describe('EventStorageManager', () => {
   let eventStorage: EventStorageManager;
   let sessionManager: SessionManager;
   const testApiKey = 'test-api-key';
-  // Storage key uses first 10 characters of API key
-  const storageKey = `EXP_${testApiKey.slice(0, 10)}_rtbt_events`; // 'EXP_test-api-ke_rtbt_events'
+  const storageKey = `EXP_${testApiKey.slice(0, 10)}_rtbt_events`;
 
   beforeEach(() => {
     // Clear storage before each test

--- a/packages/experiment-tag/test/behavioral-targeting/integration.test.ts
+++ b/packages/experiment-tag/test/behavioral-targeting/integration.test.ts
@@ -8,6 +8,7 @@ describe('Behavioral Targeting Integration', () => {
   let eventStorage: EventStorageManager;
   let evaluator: BehavioralTargetingEvaluator;
   const testApiKey = 'test-api-key';
+  const storageKey = `EXP_${testApiKey.slice(0, 10)}_rtbt_events`;
 
   beforeEach(() => {
     localStorage.clear();
@@ -565,7 +566,7 @@ describe('Behavioral Targeting Integration', () => {
       eventStorage.addEvent('click');
 
       // Corrupt localStorage
-      localStorage.setItem('EXP_test-api-key_rtbt_events', 'invalid json');
+      localStorage.setItem(storageKey, 'invalid json');
 
       // Create new instances (simulates page reload)
       const newSessionManager = new SessionManager(testApiKey);

--- a/packages/experiment-tag/test/behavioral-targeting/session-manager.test.ts
+++ b/packages/experiment-tag/test/behavioral-targeting/session-manager.test.ts
@@ -3,7 +3,7 @@ import { SessionManager } from 'src/behavioral-targeting/session-manager';
 describe('SessionManager', () => {
   let sessionManager: SessionManager;
   const testApiKey = 'test-api-key';
-
+  const storageKey = `EXP_${testApiKey.slice(0, 10)}_rtbt_session`;
   beforeEach(() => {
     // Clear sessionStorage before each test
     sessionStorage.clear();
@@ -33,7 +33,7 @@ describe('SessionManager', () => {
     test('should persist session ID in sessionStorage', () => {
       const sessionId = sessionManager.getOrCreateSessionId();
 
-      const stored = sessionStorage.getItem('EXP_test-api-key_rtbt_session');
+      const stored = sessionStorage.getItem(storageKey);
       expect(stored).not.toBeNull();
 
       if (stored) {
@@ -65,7 +65,7 @@ describe('SessionManager', () => {
     });
 
     test('should handle invalid JSON in sessionStorage', () => {
-      sessionStorage.setItem('EXP_test-api-key_rtbt_session', 'invalid json');
+      sessionStorage.setItem(storageKey, 'invalid json');
 
       const sessionId = sessionManager.getOrCreateSessionId();
 
@@ -119,7 +119,7 @@ describe('SessionManager', () => {
       sessionManager.getOrCreateSessionId();
       sessionManager.clearSession();
 
-      const stored = sessionStorage.getItem('EXP_test-api-key_rtbt_session');
+      const stored = sessionStorage.getItem(storageKey);
       expect(stored).toBeNull();
     });
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

Use first 10 characters of API key for RTBT sessionStorage and localStorage key. This is consistent with the formatting of other storage keys used for web and feature experiment.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `localStorage`/`sessionStorage` key format for behavioral targeting, which may cause previously persisted RTBT events/sessions to be ignored after upgrade. Logic changes are small but affect persistence and cross-page/session behavior.
> 
> **Overview**
> Behavioral targeting persistence keys are shortened by using only the first 10 characters of the API key when constructing the RTBT `localStorage` (`..._rtbt_events`) and `sessionStorage` (`..._rtbt_session`) keys.
> 
> Tests are updated to assert against the new key format (via a shared `storageKey` constant) in event storage, session manager, and integration scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e926a3a57f2824f4e11db80486b050bf8a19cb58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->