### PR TITLE
fix(subdomain): add await for storage

### DIFF
--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -798,7 +798,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       flagKey,
       variant,
       currentDomain,
-      redirectUrl
+      redirectUrl,
     );
 
     // set previous url - relevant for SPA if redirect happens before push/replaceState is complete

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -794,7 +794,12 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     }
 
     const currentDomain = getCookieDomain(this.globalScope.location.href);
-    await this.storeRedirectImpressions(flagKey, variant, currentDomain, redirectUrl);
+    await this.storeRedirectImpressions(
+      flagKey,
+      variant,
+      currentDomain,
+      redirectUrl
+    );
 
     // set previous url - relevant for SPA if redirect happens before push/replaceState is complete
     this.previousUrl = this.globalScope.location.href;

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -765,7 +765,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     }
   }
 
-  private handleRedirect(action, flagKey: string, variant: Variant) {
+  private async handleRedirect(action, flagKey: string, variant: Variant) {
     if (!this.isActionActiveOnPage(flagKey, action?.data?.metadata?.scope)) {
       return;
     }
@@ -794,11 +794,11 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     }
 
     const currentDomain = getCookieDomain(this.globalScope.location.href);
-    this.storeRedirectImpressions(flagKey, variant, currentDomain, redirectUrl);
+    await this.storeRedirectImpressions(flagKey, variant, currentDomain, redirectUrl);
 
     // set previous url - relevant for SPA if redirect happens before push/replaceState is complete
     this.previousUrl = this.globalScope.location.href;
-    setMarketingCookie(this.apiKey, currentDomain).then();
+    await setMarketingCookie(this.apiKey, currentDomain);
     // perform redirection
     if (this.customRedirectHandler) {
       this.customRedirectHandler(targetUrl);
@@ -1038,7 +1038,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     });
 
     const storageKey = `EXP_${this.apiKey.slice(0, 10)}_REDIRECT`;
-    storage
+    return storage
       .get(storageKey)
       .then((storedRedirects) => {
         const redirects = storedRedirects || {};


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

Add await so the cookie gets written before redirect

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the redirect execution path to await cookie writes before navigating, which can affect redirect timing and introduces async behavior in a user-navigation flow.
> 
> **Overview**
> Ensures redirect actions persist tracking state *before* navigation by making `handleRedirect` async and awaiting both `storeRedirectImpressions` and `setMarketingCookie`.
> 
> Updates `storeRedirectImpressions` to return the underlying `CookieStorage.get(...).then(...)` promise so callers can reliably await the cookie write.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d820442a8c64ede5cbe0d3370a555abbcb90734. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->