### PR TITLE
fix(experiment-core): match array user property values element-wise for non-set operators

### DIFF
--- a/packages/experiment-core/src/evaluation/evaluation.ts
+++ b/packages/experiment-core/src/evaluation/evaluation.ts
@@ -245,27 +245,36 @@ export class EvaluationEngine {
     condition: EvaluationCondition,
   ): boolean {
     const propValue = select(target, condition.selector);
-    // We need special matching for null properties and set type prop values
-    // and operators. All other values are matched as strings, since the
-    // filter values are always strings.
     if (propValue === undefined || propValue === null) {
       return this.matchNull(condition.op, condition.values);
-    } else if (this.isSetOperator(condition.op)) {
-      const propValueStringList = this.coerceStringArray(propValue);
-      if (!propValueStringList) {
-        return false;
-      }
-      return this.matchSet(propValueStringList, condition.op, condition.values);
     } else {
-      const propValueString = this.coerceString(propValue);
-      if (propValueString !== undefined) {
-        return this.matchString(
-          propValueString,
+      const propValueStringList = this.coerceStringArray(propValue);
+      if (this.isSetOperator(condition.op)) {
+        if (!propValueStringList) {
+          return false;
+        }
+        return this.matchSet(
+          propValueStringList,
+          condition.op,
+          condition.values,
+        );
+      } else if (propValueStringList) {
+        return this.matchStringsNonSet(
+          propValueStringList,
           condition.op,
           condition.values,
         );
       } else {
-        return false;
+        const propValueString = this.coerceString(propValue);
+        if (propValueString !== undefined) {
+          return this.matchString(
+            propValueString,
+            condition.op,
+            condition.values,
+          );
+        } else {
+          return false;
+        }
       }
     }
   }
@@ -411,6 +420,16 @@ export class EvaluationEngine {
     }
   }
 
+  private matchStringsNonSet(
+    propValues: string[],
+    op: string,
+    filterValues: string[],
+  ): boolean {
+    return propValues.some((element) =>
+      this.matchString(element, op, filterValues),
+    );
+  }
+
   private matchesIs(propValue: string, filterValues: string[]): boolean {
     if (this.containsBooleans(filterValues)) {
       const lower = propValue.toLowerCase();
@@ -552,20 +571,20 @@ export class EvaluationEngine {
         .filter(Boolean) as string[];
     }
     const stringValue = String(value);
+    if (!stringValue.startsWith('[')) {
+      return undefined;
+    }
     try {
       const parsedValue = JSON.parse(stringValue);
       if (Array.isArray(parsedValue)) {
-        const anyArray = value as unknown[];
-        return anyArray
+        return parsedValue
           .map((e) => this.coerceString(e))
           .filter(Boolean) as string[];
       } else {
-        const s = this.coerceString(stringValue);
-        return s ? [s] : undefined;
+        return undefined;
       }
     } catch {
-      const s = this.coerceString(stringValue);
-      return s ? [s] : undefined;
+      return undefined;
     }
   }
 

--- a/packages/experiment-core/test/evaluation/evaluation-array-values.test.ts
+++ b/packages/experiment-core/test/evaluation/evaluation-array-values.test.ts
@@ -1,0 +1,120 @@
+import {
+  EvaluationEngine,
+  EvaluationFlag,
+  EvaluationOperator,
+} from '../../src';
+
+const engine = new EvaluationEngine();
+
+const flagWithCondition = (op: string, values: string[]): EvaluationFlag[] => {
+  return [
+    {
+      key: 'test-flag',
+      variants: { on: { key: 'on' }, off: { key: 'off' } },
+      segments: [
+        {
+          conditions: [
+            [
+              {
+                selector: ['context', 'user', 'user_properties', 'test_prop'],
+                op,
+                values,
+              },
+            ],
+          ],
+          variant: 'on',
+        },
+      ],
+    },
+  ];
+};
+
+const contextWithProp = (value: unknown): Record<string, unknown> => ({
+  user: { user_properties: { test_prop: value } },
+});
+
+const evaluate = (
+  propValue: unknown,
+  op: string,
+  values: string[],
+): string | undefined => {
+  const flags = flagWithCondition(op, values);
+  const context = contextWithProp(propValue);
+  return engine.evaluate(context, flags)['test-flag']?.key;
+};
+
+const assertMatch = (propValue: unknown, op: string, values: string[]) => {
+  expect(evaluate(propValue, op, values)).toEqual('on');
+};
+
+const assertNoMatch = (propValue: unknown, op: string, values: string[]) => {
+  expect(evaluate(propValue, op, values)).toBeUndefined();
+};
+
+// Scalar values still work with non-set operators
+
+test('scalar string IS match', () => {
+  assertMatch('hello', EvaluationOperator.IS, ['hello']);
+});
+
+test('scalar string CONTAINS match', () => {
+  assertMatch('hello', EvaluationOperator.CONTAINS, ['ell']);
+});
+
+test('scalar string GREATER_THAN match', () => {
+  assertMatch('2', EvaluationOperator.GREATER_THAN, ['1']);
+});
+
+test('scalar string IS no match', () => {
+  assertNoMatch('world', EvaluationOperator.IS, ['hello']);
+});
+
+test('non-string scalar GREATER_THAN', () => {
+  assertMatch(42, EvaluationOperator.GREATER_THAN, ['1']);
+});
+
+test('non-string scalar IS', () => {
+  assertMatch(true, EvaluationOperator.IS, ['true']);
+});
+
+// JSON array strings with set operators (existing behavior)
+
+test('JSON array string + set operator', () => {
+  assertMatch('["a","b"]', EvaluationOperator.SET_CONTAINS, ['a']);
+});
+
+// JSON array strings with non-set operators (new behavior)
+
+test('JSON array string + non-set operator', () => {
+  assertMatch('["a","b"]', EvaluationOperator.IS, ['a']);
+});
+
+// Native arrays with set operators (existing behavior)
+
+test('collection + set operator', () => {
+  assertMatch(['a', 'b'], EvaluationOperator.SET_CONTAINS, ['a']);
+});
+
+// Native arrays with non-set operators (new behavior)
+
+test('collection + non-set operator', () => {
+  assertMatch(['a', 'b'], EvaluationOperator.IS, ['a']);
+});
+
+// Edge cases
+
+test('malformed JSON array falls through to scalar match', () => {
+  assertMatch('[broken', EvaluationOperator.IS, ['[broken']);
+});
+
+test('empty JSON array + set operator', () => {
+  assertNoMatch('[]', EvaluationOperator.SET_CONTAINS, ['a']);
+});
+
+test('leading whitespace not parsed as array', () => {
+  assertMatch(' ["a"]', EvaluationOperator.IS, [' ["a"]']);
+});
+
+test('leading whitespace not parsed as array (set)', () => {
+  assertNoMatch(' ["a"]', EvaluationOperator.SET_CONTAINS, ['a']);
+});

--- a/packages/experiment-core/test/evaluation/evaluation-integration.test.ts
+++ b/packages/experiment-core/test/evaluation/evaluation-integration.test.ts
@@ -2,7 +2,7 @@ import fetch from 'unfetch';
 
 import { EvaluationEngine, EvaluationFlag } from '../../src';
 
-const deploymentKey = 'server-NgJxxvg8OGwwBsWVXqyxQbdiflbhvugy';
+const deploymentKey = 'server-VVhLULXCxxY0xqmszXouXxiEzoeJWmSh';
 const engine = new EvaluationEngine();
 let flags: EvaluationFlag[];
 
@@ -499,6 +499,64 @@ test('test is with booleans', () => {
     false: 'false',
   });
   result = engine.evaluate(user, flags)['test-is-with-booleans'];
+  expect(result?.key).toEqual('on');
+});
+
+// Multi-value array property tests
+
+test('test set is with JSON array string', () => {
+  const user = userContext(undefined, undefined, undefined, {
+    key: '["1", "2", "3"]',
+  });
+  const result = engine.evaluate(user, flags)['test-set-is'];
+  expect(result?.key).toEqual('on');
+});
+
+test('test is with array (collection)', () => {
+  const user = userContext(undefined, undefined, undefined, {
+    key: ['value1', 'value2'],
+  });
+  const result = engine.evaluate(user, flags)['test-is-array'];
+  expect(result?.key).toEqual('on');
+});
+
+test('test is not with array', () => {
+  const user = userContext(undefined, undefined, undefined, {
+    key: ['value3', 'value4'],
+  });
+  const result = engine.evaluate(user, flags)['test-is-not-array'];
+  expect(result?.key).toEqual('on');
+});
+
+test('test contains with array', () => {
+  const user = userContext(undefined, undefined, undefined, {
+    key: ['has-target-value', 'has', 'value'],
+  });
+  const result = engine.evaluate(user, flags)['test-contains-array'];
+  expect(result?.key).toEqual('on');
+});
+
+test('test does not contain with array', () => {
+  const user = userContext(undefined, undefined, undefined, {
+    key: ['has-value', 'has', 'value'],
+  });
+  const result = engine.evaluate(user, flags)['test-does-not-contain-array'];
+  expect(result?.key).toEqual('on');
+});
+
+test('test is with JSON array string', () => {
+  const user = userContext(undefined, undefined, undefined, {
+    key: '["value1", "value2"]',
+  });
+  const result = engine.evaluate(user, flags)['test-is-array'];
+  expect(result?.key).toEqual('on');
+});
+
+test('test does not contain with JSON array string', () => {
+  const user = userContext(undefined, undefined, undefined, {
+    key: '["has-value", "has", "value"]',
+  });
+  const result = engine.evaluate(user, flags)['test-does-not-contain-array'];
   expect(result?.key).toEqual('on');
 });
 


### PR DESCRIPTION
## Summary
- Non-set operators (`is`, `contains`, `greater`, etc.) now match array user property values element-wise (any-match semantics) instead of stringifying the whole array, aligning with Amplitude analytics/charts behavior.
- Fixes a latent bug in `coerceStringArray` where `value` (not `parsedValue`) was iterated after a successful `JSON.parse`, and adds a `startsWith("[")` pre-check to skip the JSON parse for scalars.
- Switches the evaluation integration test deployment key to the VVhLULX superset deployment and adds coverage for array properties (both native arrays and JSON array strings) across `is`, `is not`, `contains`, `does not contain`, and `set is`.

## Test plan
- [x] `yarn build` passes (5 projects)
- [x] `yarn test` passes (141 tests across 8 suites in `experiment-core`, plus all other packages)
- [x] New unit tests in `packages/experiment-core/test/evaluation/evaluation-array-values.test.ts` (14 cases covering scalars, native arrays, JSON array strings, malformed JSON, empty arrays, leading whitespace)
- [x] 7 new integration tests inline with existing operator tests in `evaluation-integration.test.ts`

## Behavioral change
Consumers relying on the previous stringified-array behavior for non-set operators (e.g., matching `'["a","b"]'` literally against `'["a","b"]'` with `is`) will see different results. This is intentional — the new behavior matches the Amplitude analytics/charts contract.

[SKY-10281]: https://amplitude.atlassian.net/browse/SKY-10281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core flag/segment condition matching semantics for array-valued user properties, which can alter targeting outcomes for existing flags; mitigated by added unit/integration test coverage.
> 
> **Overview**
> Updates `EvaluationEngine.matchCondition` so **non-set operators** (e.g. `is`, `contains`, comparisons) treat array-valued properties (native arrays or JSON array strings) as *any-match element-wise* instead of matching against a stringified array.
> 
> Fixes `coerceStringArray` parsing to only attempt JSON parsing for strings that start with `[` and to iterate over the parsed array result, and adds new unit/integration tests covering array behavior and edge cases; the integration test deployment key is also updated to a deployment that includes the new flag fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baab8336969e3937f6c0b5117d5f1924c380b617. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->