### PR TITLE
fix: export EvaluationOperator as const, use it for behavioral targeting op type

### DIFF
--- a/packages/experiment-core/src/evaluation/flag.ts
+++ b/packages/experiment-core/src/evaluation/flag.ts
@@ -88,4 +88,4 @@ export const EvaluationOperator = {
   SET_DOES_NOT_CONTAIN_ANY: 'set does not contain any',
   REGEX_MATCH: 'regex match',
   REGEX_DOES_NOT_MATCH: 'regex does not match',
-};
+} as const;

--- a/packages/experiment-tag/src/behavioral-targeting/evaluator.ts
+++ b/packages/experiment-tag/src/behavioral-targeting/evaluator.ts
@@ -1,6 +1,7 @@
 import {
   EvaluationCondition,
   EvaluationEngine,
+  EvaluationOperator,
 } from '@amplitude/experiment-core';
 
 import { EventRecord, EventStorageManager } from './event-storage';
@@ -115,17 +116,17 @@ export class BehavioralTargetingEvaluator {
     threshold: number,
   ): boolean {
     switch (operator) {
-      case '>=':
+      case EvaluationOperator.GREATER_THAN_EQUALS:
         return count >= threshold;
-      case '>':
+      case EvaluationOperator.GREATER_THAN:
         return count > threshold;
-      case '=':
+      case EvaluationOperator.IS:
         return count === threshold;
-      case '<':
+      case EvaluationOperator.LESS_THAN:
         return count < threshold;
-      case '<=':
+      case EvaluationOperator.LESS_THAN_EQUALS:
         return count <= threshold;
-      case '!=':
+      case EvaluationOperator.IS_NOT:
         return count !== threshold;
       default:
         return false;

--- a/packages/experiment-tag/src/behavioral-targeting/types.ts
+++ b/packages/experiment-tag/src/behavioral-targeting/types.ts
@@ -26,13 +26,13 @@ export interface BehavioralConditionSet {
 export interface BehavioralCondition {
   type: 'event';
   event_type: string; // Event name
-  op:
-    | (typeof EvaluationOperator)['GREATER_THAN_EQUALS']
-    | (typeof EvaluationOperator)['GREATER_THAN']
-    | (typeof EvaluationOperator)['IS']
-    | (typeof EvaluationOperator)['LESS_THAN']
-    | (typeof EvaluationOperator)['LESS_THAN_EQUALS']
-    | (typeof EvaluationOperator)['IS_NOT'];
+  op: (typeof EvaluationOperator)[
+    | 'GREATER_THAN_EQUALS'
+    | 'GREATER_THAN'
+    | 'IS'
+    | 'LESS_THAN'
+    | 'LESS_THAN_EQUALS'
+    | 'IS_NOT'];
   value: number; // Count threshold
   time_type: 'current_session' | 'rolling';
   time_value: number;

--- a/packages/experiment-tag/src/behavioral-targeting/types.ts
+++ b/packages/experiment-tag/src/behavioral-targeting/types.ts
@@ -1,4 +1,7 @@
-import { EvaluationCondition } from '@amplitude/experiment-core';
+import {
+  EvaluationCondition,
+  EvaluationOperator,
+} from '@amplitude/experiment-core';
 
 /**
  * Behavioral targeting uses DNF (Disjunctive Normal Form): OR of ANDs
@@ -23,7 +26,13 @@ export interface BehavioralConditionSet {
 export interface BehavioralCondition {
   type: 'event';
   event_type: string; // Event name
-  op: '>=' | '>' | '=' | '<' | '<=' | '!=';
+  op:
+    | (typeof EvaluationOperator)['GREATER_THAN_EQUALS']
+    | (typeof EvaluationOperator)['GREATER_THAN']
+    | (typeof EvaluationOperator)['IS']
+    | (typeof EvaluationOperator)['LESS_THAN']
+    | (typeof EvaluationOperator)['LESS_THAN_EQUALS']
+    | (typeof EvaluationOperator)['IS_NOT'];
   value: number; // Count threshold
   time_type: 'current_session' | 'rolling';
   time_value: number;

--- a/packages/experiment-tag/test/behavioral-targeting/evaluator.test.ts
+++ b/packages/experiment-tag/test/behavioral-targeting/evaluator.test.ts
@@ -78,7 +78,7 @@ describe('BehavioralTargetingEvaluator', () => {
                 condition: {
                   type: 'event',
                   event_type: 'click',
-                  op: operator as any,
+                  op: operator,
                   value: passingValue,
                   time_type: 'current_session',
                   time_value: 0,

--- a/packages/experiment-tag/test/behavioral-targeting/evaluator.test.ts
+++ b/packages/experiment-tag/test/behavioral-targeting/evaluator.test.ts
@@ -1,3 +1,4 @@
+import { EvaluationOperator } from '@amplitude/experiment-core';
 import { BehavioralTargetingEvaluator } from 'src/behavioral-targeting/evaluator';
 import { EventStorageManager } from 'src/behavioral-targeting/event-storage';
 import { SessionManager } from 'src/behavioral-targeting/session-manager';
@@ -32,37 +33,37 @@ describe('BehavioralTargetingEvaluator', () => {
 
     describe.each([
       {
-        operator: '>=',
+        operator: EvaluationOperator.GREATER_THAN_EQUALS,
         passingValue: 3,
         failingValue: 4,
         description: 'greater than or equal',
       },
       {
-        operator: '>',
+        operator: EvaluationOperator.GREATER_THAN,
         passingValue: 2,
         failingValue: 3,
         description: 'greater than',
       },
       {
-        operator: '=',
+        operator: EvaluationOperator.IS,
         passingValue: 3,
         failingValue: 2,
         description: 'equal to',
       },
       {
-        operator: '<',
+        operator: EvaluationOperator.LESS_THAN,
         passingValue: 4,
         failingValue: 3,
         description: 'less than',
       },
       {
-        operator: '<=',
+        operator: EvaluationOperator.LESS_THAN_EQUALS,
         passingValue: 3,
         failingValue: 2,
         description: 'less than or equal',
       },
       {
-        operator: '!=',
+        operator: EvaluationOperator.IS_NOT,
         passingValue: 5,
         failingValue: 3,
         description: 'not equal',
@@ -111,7 +112,7 @@ describe('BehavioralTargetingEvaluator', () => {
               condition: {
                 type: 'event',
                 event_type: 'click',
-                op: '>=',
+                op: EvaluationOperator.GREATER_THAN_EQUALS,
                 value: 1,
                 time_type: 'current_session',
                 time_value: 0,
@@ -154,7 +155,7 @@ describe('BehavioralTargetingEvaluator', () => {
               condition: {
                 type: 'event',
                 event_type: 'click',
-                op: '>=',
+                op: EvaluationOperator.GREATER_THAN_EQUALS,
                 value: 1,
                 time_type: 'rolling',
                 time_value: 1,
@@ -187,7 +188,7 @@ describe('BehavioralTargetingEvaluator', () => {
               condition: {
                 type: 'event',
                 event_type: 'click',
-                op: '>=',
+                op: EvaluationOperator.GREATER_THAN_EQUALS,
                 value: 1,
                 time_type: 'rolling',
                 time_value: 1,
@@ -226,7 +227,7 @@ describe('BehavioralTargetingEvaluator', () => {
             condition: {
               type: 'event',
               event_type: 'purchase',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 2,
               time_type: 'current_session',
               time_value: 0,
@@ -256,7 +257,7 @@ describe('BehavioralTargetingEvaluator', () => {
             condition: {
               type: 'event',
               event_type: 'purchase',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 1,
               time_type: 'current_session',
               time_value: 0,
@@ -291,7 +292,7 @@ describe('BehavioralTargetingEvaluator', () => {
             condition: {
               type: 'event',
               event_type: 'purchase',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 3,
               time_type: 'current_session',
               time_value: 0,
@@ -319,7 +320,7 @@ describe('BehavioralTargetingEvaluator', () => {
             condition: {
               type: 'event',
               event_type: 'click',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 5,
               time_type: 'current_session',
               time_value: 0,
@@ -332,7 +333,7 @@ describe('BehavioralTargetingEvaluator', () => {
             condition: {
               type: 'event',
               event_type: 'purchase',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 1,
               time_type: 'current_session',
               time_value: 0,
@@ -352,7 +353,7 @@ describe('BehavioralTargetingEvaluator', () => {
             condition: {
               type: 'event',
               event_type: 'click',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 1,
               time_type: 'current_session',
               time_value: 0,
@@ -362,7 +363,7 @@ describe('BehavioralTargetingEvaluator', () => {
             condition: {
               type: 'event',
               event_type: 'purchase',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 1,
               time_type: 'current_session',
               time_value: 0,
@@ -386,7 +387,7 @@ describe('BehavioralTargetingEvaluator', () => {
             condition: {
               type: 'event',
               event_type: 'click',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 10,
               time_type: 'current_session',
               time_value: 0,
@@ -398,7 +399,7 @@ describe('BehavioralTargetingEvaluator', () => {
             condition: {
               type: 'event',
               event_type: 'purchase',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 10,
               time_type: 'current_session',
               time_value: 0,
@@ -424,7 +425,7 @@ describe('BehavioralTargetingEvaluator', () => {
             condition: {
               type: 'event',
               event_type: 'click',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 3,
               time_type: 'current_session',
               time_value: 0,
@@ -451,7 +452,7 @@ describe('BehavioralTargetingEvaluator', () => {
             condition: {
               type: 'event',
               event_type: 'click',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 1,
               time_type: 'current_session',
               time_value: 0,
@@ -461,7 +462,7 @@ describe('BehavioralTargetingEvaluator', () => {
             condition: {
               type: 'event',
               event_type: 'purchase',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 1,
               time_type: 'current_session',
               time_value: 0,
@@ -494,7 +495,7 @@ describe('BehavioralTargetingEvaluator', () => {
             condition: {
               type: 'event',
               event_type: 'view',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 1,
               time_type: 'current_session',
               time_value: 0,
@@ -511,7 +512,7 @@ describe('BehavioralTargetingEvaluator', () => {
             condition: {
               type: 'event',
               event_type: 'click',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 1,
               time_type: 'current_session',
               time_value: 0,
@@ -521,7 +522,7 @@ describe('BehavioralTargetingEvaluator', () => {
             condition: {
               type: 'event',
               event_type: 'purchase',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 1,
               time_type: 'current_session',
               time_value: 0,
@@ -554,7 +555,7 @@ describe('BehavioralTargetingEvaluator', () => {
             condition: {
               type: 'event',
               event_type: 'click',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 1,
               time_type: 'current_session',
               time_value: 0,
@@ -595,7 +596,7 @@ describe('BehavioralTargetingEvaluator', () => {
             condition: {
               type: 'event',
               event_type: 'nonexistent',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 1,
               time_type: 'current_session',
               time_value: 0,

--- a/packages/experiment-tag/test/behavioral-targeting/integration.test.ts
+++ b/packages/experiment-tag/test/behavioral-targeting/integration.test.ts
@@ -1,3 +1,4 @@
+import { EvaluationOperator } from '@amplitude/experiment-core';
 import { BehavioralTargetingEvaluator } from 'src/behavioral-targeting/evaluator';
 import { EventStorageManager } from 'src/behavioral-targeting/event-storage';
 import { SessionManager } from 'src/behavioral-targeting/session-manager';
@@ -50,7 +51,7 @@ describe('Behavioral Targeting Integration', () => {
             condition: {
               type: 'event',
               event_type: 'add_to_cart',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 1,
               time_type: 'current_session',
               time_value: 0,
@@ -60,7 +61,7 @@ describe('Behavioral Targeting Integration', () => {
             condition: {
               type: 'event',
               event_type: 'purchase',
-              op: '=',
+              op: EvaluationOperator.IS,
               value: 0,
               time_type: 'current_session',
               time_value: 0,
@@ -103,7 +104,7 @@ describe('Behavioral Targeting Integration', () => {
             condition: {
               type: 'event',
               event_type: 'add_to_cart',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 1,
               time_type: 'current_session',
               time_value: 0,
@@ -122,7 +123,7 @@ describe('Behavioral Targeting Integration', () => {
             condition: {
               type: 'event',
               event_type: 'add_to_cart',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 1,
               time_type: 'rolling',
               time_value: 7,
@@ -169,7 +170,7 @@ describe('Behavioral Targeting Integration', () => {
             condition: {
               type: 'event',
               event_type: 'page_view',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 1,
               time_type: 'current_session',
               time_value: 0,
@@ -179,7 +180,7 @@ describe('Behavioral Targeting Integration', () => {
             condition: {
               type: 'event',
               event_type: 'add_to_cart',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 1,
               time_type: 'current_session',
               time_value: 0,
@@ -204,7 +205,7 @@ describe('Behavioral Targeting Integration', () => {
             condition: {
               type: 'event',
               event_type: 'add_to_cart',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 1,
               time_type: 'current_session',
               time_value: 0,
@@ -214,7 +215,7 @@ describe('Behavioral Targeting Integration', () => {
             condition: {
               type: 'event',
               event_type: 'purchase',
-              op: '=',
+              op: EvaluationOperator.IS,
               value: 0,
               time_type: 'current_session',
               time_value: 0,
@@ -247,7 +248,7 @@ describe('Behavioral Targeting Integration', () => {
             condition: {
               type: 'event',
               event_type: 'page_view',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 2,
               time_type: 'rolling',
               time_value: 30,
@@ -275,7 +276,7 @@ describe('Behavioral Targeting Integration', () => {
             condition: {
               type: 'event',
               event_type: 'purchase',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 2,
               time_type: 'current_session',
               time_value: 0,
@@ -307,7 +308,7 @@ describe('Behavioral Targeting Integration', () => {
             condition: {
               type: 'event',
               event_type: 'page_view',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 3,
               time_type: 'current_session',
               time_value: 0,
@@ -324,7 +325,7 @@ describe('Behavioral Targeting Integration', () => {
             condition: {
               type: 'event',
               event_type: 'search',
-              op: '=',
+              op: EvaluationOperator.IS,
               value: 0,
               time_type: 'current_session',
               time_value: 0,
@@ -358,7 +359,7 @@ describe('Behavioral Targeting Integration', () => {
             condition: {
               type: 'event',
               event_type: 'page_view',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 3,
               time_type: 'current_session',
               time_value: 0,
@@ -368,7 +369,7 @@ describe('Behavioral Targeting Integration', () => {
             condition: {
               type: 'event',
               event_type: 'click',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 2,
               time_type: 'current_session',
               time_value: 0,
@@ -381,7 +382,7 @@ describe('Behavioral Targeting Integration', () => {
             condition: {
               type: 'event',
               event_type: 'purchase',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 1,
               time_type: 'current_session',
               time_value: 0,
@@ -410,7 +411,7 @@ describe('Behavioral Targeting Integration', () => {
             condition: {
               type: 'event',
               event_type: 'page_view',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 2,
               time_type: 'current_session',
               time_value: 0,
@@ -427,7 +428,7 @@ describe('Behavioral Targeting Integration', () => {
             condition: {
               type: 'event',
               event_type: 'signup',
-              op: '=',
+              op: EvaluationOperator.IS,
               value: 0,
               time_type: 'current_session',
               time_value: 0,
@@ -440,7 +441,7 @@ describe('Behavioral Targeting Integration', () => {
             condition: {
               type: 'event',
               event_type: 'click',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 1,
               time_type: 'current_session',
               time_value: 0,
@@ -457,7 +458,7 @@ describe('Behavioral Targeting Integration', () => {
             condition: {
               type: 'event',
               event_type: 'signup',
-              op: '=',
+              op: EvaluationOperator.IS,
               value: 0,
               time_type: 'current_session',
               time_value: 0,
@@ -495,7 +496,7 @@ describe('Behavioral Targeting Integration', () => {
             condition: {
               type: 'event',
               event_type: 'purchase',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 1,
               time_type: 'rolling',
               time_value: 7,
@@ -506,7 +507,7 @@ describe('Behavioral Targeting Integration', () => {
             condition: {
               type: 'event',
               event_type: 'page_view',
-              op: '=',
+              op: EvaluationOperator.IS,
               value: 0,
               time_type: 'rolling',
               time_value: 24,
@@ -547,7 +548,7 @@ describe('Behavioral Targeting Integration', () => {
             condition: {
               type: 'event',
               event_type: 'click',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 500,
               time_type: 'current_session',
               time_value: 0,
@@ -585,7 +586,7 @@ describe('Behavioral Targeting Integration', () => {
             condition: {
               type: 'event',
               event_type: 'view',
-              op: '>=',
+              op: EvaluationOperator.GREATER_THAN_EQUALS,
               value: 1,
               time_type: 'current_session',
               time_value: 0,


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

Use `EvaluationOperator` for behavioral targeting evaluator. `EvaluationOperator` is already used for event property matching

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/amplitude/codesmith/experiment-js-client/pr/309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/amplitude/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because behavioral targeting rule payloads must now use `EvaluationOperator` string values instead of symbolic operators (e.g. `>=`), which could break evaluation if any callers still send the old format.
> 
> **Overview**
> Behavioral targeting count comparisons now use `EvaluationOperator` constants end-to-end, replacing symbolic operators like `>=`, `=`, and `!=` in both the evaluator switch logic and the `BehavioralCondition.op` type.
> 
> Tests and integration scenarios were updated accordingly, and `EvaluationOperator` is now exported as a `const` object in `experiment-core` for stronger typing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61b9c2e2428f173ad47e3e7c913dfdbff56ede5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->