### PR TITLE
fix(experiment-tag): show modal when window.opener is severed in visual editor

### DIFF
--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -47,6 +47,8 @@ import { DebugRecorder } from './util/debug-recorder';
 import { getInjectUtils } from './util/inject-utils';
 import { hideLoadingIndicator } from './util/loading-indicator';
 import { VISUAL_EDITOR_SESSION_KEY, WindowMessenger } from './util/messenger';
+import { isOpenerChannelBroken } from './util/opener-channel';
+import { showOpenerSeveredBanner } from './util/opener-severed-banner';
 import { patchRemoveChild } from './util/patch';
 import { buildShell, isMobileModeActive } from './util/shell';
 import {
@@ -238,6 +240,35 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
 
     // if in visual edit mode, remove the query param
     if (this.isVisualEditorMode) {
+      const veSource =
+        urlParams[VISUAL_EDITOR_PARAM] === 'true'
+          ? 'url_param'
+          : 'session_storage';
+      DebugRecorder.push('ve_mode_detected', `source=${veSource}`);
+
+      // The overlay is loaded by skylab postMessaging OpenOverlay through the
+      // window.opener channel. If it's broken (COOP, or explicit
+      // window.opener = null), that message never arrives and the editor
+      // never loads — show a banner instead.
+      if (isOpenerChannelBroken()) {
+        DebugRecorder.push(
+          'opener_check',
+          'FAIL: window.opener is null, closed, or inaccessible',
+        );
+        DebugRecorder.setMessengerState('error');
+        showOpenerSeveredBanner();
+        this.globalScope.history.replaceState(
+          {},
+          '',
+          removeQueryParams(this.globalScope.location.href, [
+            VISUAL_EDITOR_PARAM,
+          ]),
+        );
+        this.isRunning = true;
+        return;
+      }
+      DebugRecorder.push('opener_check', 'PASS');
+
       if (isMobileModeActive()) {
         // In mobile mode, build the shell first and load the overlay after.
         // The overlay must render into the already-built shell to avoid a
@@ -246,12 +277,6 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
         await buildShell(this.globalScope);
       }
       WindowMessenger.setup();
-
-      const veSource =
-        urlParams[VISUAL_EDITOR_PARAM] === 'true'
-          ? 'url_param'
-          : 'session_storage';
-      DebugRecorder.push('ve_mode_detected', `source=${veSource}`);
       this.globalScope.history.replaceState(
         {},
         '',

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -264,6 +264,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
             VISUAL_EDITOR_PARAM,
           ]),
         );
+        // Prevent re-initialization; the SDK won't load in this session.
         this.isRunning = true;
         return;
       }

--- a/packages/experiment-tag/src/util/messenger.ts
+++ b/packages/experiment-tag/src/util/messenger.ts
@@ -5,6 +5,7 @@ import {
   showLoadingIndicator,
   hideLoadingIndicator,
 } from './loading-indicator';
+import { isOpenerChannelBroken } from './opener-channel';
 import { getStorageItem } from './storage';
 
 interface VisualEditorSession {
@@ -17,6 +18,15 @@ export const VISUAL_EDITOR_SESSION_KEY = 'visual-editor-state';
 export class WindowMessenger {
   static setup() {
     let state: 'closed' | 'opening' | 'open' = 'closed';
+
+    // Surface a diagnostic so `getDebugState().events` exposes the opener
+    // state regardless of how setup() was reached (VE mode, preview mode).
+    DebugRecorder.push(
+      'opener_check',
+      isOpenerChannelBroken()
+        ? 'FAIL: window.opener is null, closed, or inaccessible'
+        : 'PASS',
+    );
 
     // Check for existing session on setup
     const existingSession = WindowMessenger.getStoredSession();

--- a/packages/experiment-tag/src/util/opener-channel.ts
+++ b/packages/experiment-tag/src/util/opener-channel.ts
@@ -1,0 +1,24 @@
+import { getGlobalScope } from '@amplitude/experiment-core';
+
+/**
+ * True when `window.opener` is missing or inaccessible, i.e. the visual
+ * editor has no channel to reach skylab. Commonly caused by the customer
+ * page's `Cross-Origin-Opener-Policy` header isolating the popup from
+ * its opener. Accessing `opener.closed` can throw on an opaque
+ * WindowProxy, so we defensively catch.
+ */
+export const isOpenerChannelBroken = (): boolean => {
+  try {
+    const scope = getGlobalScope();
+    if (!scope) {
+      return true;
+    }
+    const opener = scope.opener as Window | null | undefined;
+    if (!opener) {
+      return true;
+    }
+    return opener.closed;
+  } catch {
+    return true;
+  }
+};

--- a/packages/experiment-tag/src/util/opener-severed-banner.ts
+++ b/packages/experiment-tag/src/util/opener-severed-banner.ts
@@ -1,0 +1,161 @@
+const BANNER_ID = 'amp-exp-opener-severed';
+const AMPLITUDE_BRAND_COLOR = '#1e61f0';
+
+/**
+ * Modal shown when `window.opener` is unreachable, so the visual editor
+ * can't postMessage saves back to skylab. Vanilla DOM + inline CSS so this
+ * module has no dependency on the overlay bundle (which can't load here).
+ */
+export const showOpenerSeveredBanner = () => {
+  if (document.getElementById(BANNER_ID)) {
+    return;
+  }
+
+  const dialog = document.createElement('dialog');
+  dialog.id = BANNER_ID;
+  dialog.setAttribute('role', 'alertdialog');
+  dialog.setAttribute('aria-labelledby', `${BANNER_ID}-title`);
+
+  dialog.innerHTML = `
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600&display=swap');
+
+      #${BANNER_ID},
+      #${BANNER_ID} * {
+        font-family: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif !important;
+      }
+      #${BANNER_ID} code {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace !important;
+      }
+
+      #${BANNER_ID} {
+        border: none;
+        padding: 0;
+        background: white;
+        border-radius: 8px;
+        max-width: 480px;
+        box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
+        color: #212124;
+      }
+
+      #${BANNER_ID}::backdrop {
+        background: rgba(33, 33, 36, 0.4);
+      }
+
+      #${BANNER_ID} .modal {
+        padding: 32px;
+      }
+
+      #${BANNER_ID} .title {
+        font-size: 18px;
+        font-weight: 600;
+        margin: 0 0 12px 0;
+      }
+
+      #${BANNER_ID} .body {
+        font-size: 14px;
+        line-height: 1.5;
+        margin: 0 0 12px 0;
+        color: #5a5e68;
+      }
+
+      #${BANNER_ID} code {
+        background: #f3f4f6;
+        padding: 1px 6px;
+        border-radius: 4px;
+        font-size: 13px;
+      }
+
+      #${BANNER_ID} .actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 8px;
+        margin-top: 20px;
+      }
+
+      #${BANNER_ID} button {
+        font-size: 14px;
+        padding: 8px 16px;
+        border-radius: 6px;
+        border: 1px solid transparent;
+        cursor: pointer;
+      }
+
+      #${BANNER_ID} .primary {
+        background: ${AMPLITUDE_BRAND_COLOR};
+        color: white;
+      }
+
+      #${BANNER_ID} .primary:hover {
+        filter: brightness(0.95);
+      }
+
+      #${BANNER_ID} .secondary {
+        background: white;
+        color: #212124;
+        border-color: #d1d5db;
+      }
+
+      #${BANNER_ID} .secondary:hover {
+        background: #f9fafb;
+      }
+    </style>
+
+    <div class="modal">
+      <h2 id="${BANNER_ID}-title" class="title">Visual Editor can't open on this page</h2>
+      <p class="body">
+        This page has been isolated from the window that opened it, so the
+        visual editor can't communicate with Amplitude here.
+      </p>
+      <p class="body">
+        This is most often caused by a <code>Cross-Origin-Opener-Policy</code>
+        response header on this page. To use the visual editor, ask the site
+        owner to remove the header (or set it to <code>unsafe-none</code>) on
+        the pages you want to edit, or launch the editor on a staging build
+        that doesn't ship the header.
+      </p>
+      <div class="actions">
+        <button type="button" class="secondary" data-action="close">Close</button>
+      </div>
+    </div>
+  `;
+
+  const mount = () => {
+    if (document.getElementById(BANNER_ID)) {
+      return;
+    }
+    document.body.appendChild(dialog);
+
+    if (typeof dialog.showModal === 'function') {
+      dialog.showModal();
+    } else {
+      dialog.setAttribute('open', '');
+    }
+
+    // TODO: switch to `command="close"` + `commandfor` once `last 5 firefox`
+    // is entirely Firefox 144+ (when invoker commands shipped).
+    const closeButton = dialog.querySelector<HTMLButtonElement>(
+      'button[data-action="close"]',
+    );
+    closeButton?.addEventListener('click', () => {
+      hideOpenerSeveredBanner();
+    });
+  };
+
+  if (document.body) {
+    mount();
+  } else {
+    document.addEventListener('DOMContentLoaded', mount, { once: true });
+  }
+};
+
+export const hideOpenerSeveredBanner = () => {
+  const dialog = document.getElementById(BANNER_ID) as HTMLDialogElement | null;
+  if (!dialog) {
+    return;
+  }
+  if (typeof dialog.close === 'function' && dialog.open) {
+    dialog.close();
+  }
+  dialog.remove();
+};

--- a/packages/experiment-tag/test/util/mocks.ts
+++ b/packages/experiment-tag/test/util/mocks.ts
@@ -81,6 +81,7 @@ export const createMockGlobal = (overrides?: Record<string, unknown>) => {
     location: createLocationMock(),
     innerHeight: 768,
     innerWidth: 1024,
+    opener: { closed: false },
   };
 
   // Apply overrides with smart merging for nested objects


### PR DESCRIPTION
### Summary



When a customer page severs `window.opener` (typically via `Cross-Origin-Opener-Policy`, or explicit `window.opener = null`), skylab can't `postMessage` `OpenOverlay` to the popup, so the visual editor never loads and the user sees no feedback at all — just a regular customer page where they expected the editor.

This change detects the broken opener channel before `WindowMessenger.setup()` runs in visual-editor mode, renders an explanatory native `<dialog>` modal, and skips overlay loading entirely. The modal uses vanilla DOM + inline CSS (no overlay-bundle dep — the overlay can't load in this scenario), names COOP as the typical cause, and offers two actionable paths: ask the site owner to remove/relax the header, or use a staging build that doesn't ship it.

Telemetry: `DebugRecorder` now records the `opener_check` result on every `WindowMessenger.setup()` entry so support sessions include opener state regardless of which path (VE mode, preview mode) reached `setup()`.

Tracked in [SKY-10343](https://amplitude.atlassian.net/browse/SKY-10343).

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No — adds new user-facing behavior on a previously silent failure mode; no existing API or behavior change.

<details>
<summary>AI Prompt</summary>

Refine the visual editor's opener-severed modal: investigate when `window.opener` can be null beyond COOP, soften the banner copy to be honest about what users can actually do, switch the implementation to a native `<dialog>` for modal semantics, fix the close button so it actually dismisses the modal, and tighten comments throughout.

</details>

Made with [Cursor](https://cursor.com)

[SKY-10343]: https://amplitude.atlassian.net/browse/SKY-10343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior only changes in visual editor sessions when `window.opener` is missing/inaccessible, adding a user-facing fallback and extra debug telemetry without affecting normal experiment evaluation.
> 
> **Overview**
> Adds early detection for a severed `window.opener` channel in visual editor mode; when detected, the SDK now logs an `opener_check`, marks messenger state as error, removes the `VISUAL_EDITOR` URL param, and shows an explanatory native `dialog` modal instead of waiting for an overlay that will never load.
> 
> Introduces `isOpenerChannelBroken()` and a standalone `showOpenerSeveredBanner()`/`hideOpenerSeveredBanner()` implementation (vanilla DOM + inline CSS), and records `opener_check` diagnostics on every `WindowMessenger.setup()` entry (including preview mode). Tests’ global mock now includes an `opener` stub.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58590b2ee22b8911370a13f745afa53cf0ecb4b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->