### PR TITLE
fix: harden safeGlobal consumers and SSR location access

### DIFF
--- a/packages/experiment-browser/src/factory.ts
+++ b/packages/experiment-browser/src/factory.ts
@@ -1,5 +1,5 @@
 import { AnalyticsConnector } from '@amplitude/analytics-connector';
-import { safeGlobal } from '@amplitude/experiment-core';
+import { getGlobalScope } from '@amplitude/experiment-core';
 
 import { Defaults, ExperimentConfig } from './config';
 import { ExperimentClient } from './experimentClient';
@@ -7,9 +7,14 @@ import { AmplitudeIntegrationPlugin } from './integration/amplitude';
 import { DefaultUserProvider } from './providers/default';
 import { ExperimentPlugin } from './types/plugin';
 
-// Global instances for debugging.
-safeGlobal.experimentInstances = {};
-const instances = safeGlobal.experimentInstances;
+// Global instances for debugging. Falls back to a module-local map when no
+// global scope is available (e.g. SSR or iOS Safari globalThis === null).
+const globalScope = getGlobalScope();
+if (globalScope) {
+  globalScope.experimentInstances = {};
+}
+const instances: Record<string, ExperimentClient> =
+  globalScope?.experimentInstances ?? {};
 
 /**
  * Initializes a singleton {@link ExperimentClient} identified by the configured

--- a/packages/experiment-browser/src/integration/amplitude.ts
+++ b/packages/experiment-browser/src/integration/amplitude.ts
@@ -4,7 +4,7 @@ import {
   EventBridge,
   IdentityStore,
 } from '@amplitude/analytics-connector';
-import { safeGlobal } from '@amplitude/experiment-core';
+import { getSetTimeout } from '@amplitude/experiment-core';
 
 import { ExperimentConfig } from '../config';
 import { Client } from '../types/client';
@@ -149,7 +149,12 @@ export class AmplitudeIntegrationPlugin implements IntegrationPlugin {
           this.identityStore.addIdentityListener(listener);
         }),
         new Promise<void>((_, reject) => {
-          safeGlobal.setTimeout(
+          const setTimeoutFn = getSetTimeout();
+          if (!setTimeoutFn) {
+            reject('Timed out waiting for Amplitude Analytics SDK to initialize.');
+            return;
+          }
+          setTimeoutFn(
             reject,
             ms,
             'Timed out waiting for Amplitude Analytics SDK to initialize.',

--- a/packages/experiment-browser/src/integration/amplitude.ts
+++ b/packages/experiment-browser/src/integration/amplitude.ts
@@ -151,7 +151,9 @@ export class AmplitudeIntegrationPlugin implements IntegrationPlugin {
         new Promise<void>((_, reject) => {
           const setTimeoutFn = getSetTimeout();
           if (!setTimeoutFn) {
-            reject('Timed out waiting for Amplitude Analytics SDK to initialize.');
+            reject(
+              'Timed out waiting for Amplitude Analytics SDK to initialize.',
+            );
             return;
           }
           setTimeoutFn(

--- a/packages/experiment-browser/src/integration/manager.ts
+++ b/packages/experiment-browser/src/integration/manager.ts
@@ -1,7 +1,10 @@
 import {
+  getClearInterval,
   getGlobalScope,
+  getLocalStorage,
+  getSessionStorage,
+  getSetInterval,
   isLocalStorageAvailable,
-  safeGlobal,
 } from '@amplitude/experiment-core';
 
 import { Defaults, ExperimentConfig } from '../config';
@@ -137,9 +140,10 @@ export class SessionDedupeCache {
   constructor(instanceName: string) {
     this.storageKey = `EXP_sent_v3_${instanceName}`;
     // Remove previous versions of storage if they exist.
-    if (this.isSessionStorageAvailable) {
-      safeGlobal.sessionStorage.removeItem(`EXP_sent_${instanceName}`);
-      safeGlobal.sessionStorage.removeItem(`EXP_sent_v2_${instanceName}`);
+    const sessionStorage = getSessionStorage();
+    if (this.isSessionStorageAvailable && sessionStorage) {
+      sessionStorage.removeItem(`EXP_sent_${instanceName}`);
+      sessionStorage.removeItem(`EXP_sent_v2_${instanceName}`);
     }
   }
 
@@ -177,8 +181,9 @@ export class SessionDedupeCache {
 
   private clearCache(): void {
     this.inMemoryCache = {};
-    if (this.isSessionStorageAvailable) {
-      safeGlobal.sessionStorage.removeItem(this.storageKey);
+    const sessionStorage = getSessionStorage();
+    if (this.isSessionStorageAvailable && sessionStorage) {
+      sessionStorage.removeItem(this.storageKey);
     }
   }
 
@@ -193,16 +198,18 @@ export class SessionDedupeCache {
   }
 
   private loadCache(): void {
-    if (this.isSessionStorageAvailable) {
-      const storedCache = safeGlobal.sessionStorage.getItem(this.storageKey);
+    const sessionStorage = getSessionStorage();
+    if (this.isSessionStorageAvailable && sessionStorage) {
+      const storedCache = sessionStorage.getItem(this.storageKey);
       this.inMemoryCache = storedCache ? JSON.parse(storedCache) : {};
     }
   }
 
   private storeCache(): void {
-    if (this.isSessionStorageAvailable) {
+    const sessionStorage = getSessionStorage();
+    if (this.isSessionStorageAvailable && sessionStorage) {
       try {
-        safeGlobal.sessionStorage.setItem(
+        sessionStorage.setItem(
           this.storageKey,
           JSON.stringify(this.inMemoryCache),
         );
@@ -236,9 +243,12 @@ export class PersistentTrackingQueue {
 
   setTracker(tracker: (event: ExperimentEvent) => boolean): void {
     this.tracker = tracker;
-    this.poller = safeGlobal.setInterval(() => {
-      this.loadFlushStore();
-    }, 1000);
+    const setInterval = getSetInterval();
+    if (setInterval) {
+      this.poller = setInterval(() => {
+        this.loadFlushStore();
+      }, 1000);
+    }
     this.loadFlushStore();
   }
 
@@ -257,27 +267,32 @@ export class PersistentTrackingQueue {
     }
     this.inMemoryQueue = this.inMemoryQueue.slice(i);
     if (this.inMemoryQueue.length === 0 && this.poller) {
-      safeGlobal.clearInterval(this.poller);
+      const clearInterval = getClearInterval();
+      if (clearInterval) {
+        clearInterval(this.poller);
+      }
       this.poller = undefined;
     }
   }
 
   private loadQueue(): void {
-    if (this.isLocalStorageAvailable) {
-      const storedQueue = safeGlobal.localStorage.getItem(this.storageKey);
+    const localStorage = getLocalStorage();
+    if (this.isLocalStorageAvailable && localStorage) {
+      const storedQueue = localStorage.getItem(this.storageKey);
       this.inMemoryQueue = storedQueue ? JSON.parse(storedQueue) : [];
     }
   }
 
   private storeQueue(): void {
-    if (this.isLocalStorageAvailable) {
+    const localStorage = getLocalStorage();
+    if (this.isLocalStorageAvailable && localStorage) {
       // Trim the queue if it is too large.
       if (this.inMemoryQueue.length > this.maxQueueSize) {
         this.inMemoryQueue = this.inMemoryQueue.slice(
           this.inMemoryQueue.length - this.maxQueueSize,
         );
       }
-      safeGlobal.localStorage.setItem(
+      localStorage.setItem(
         this.storageKey,
         JSON.stringify(this.inMemoryQueue),
       );

--- a/packages/experiment-browser/src/integration/manager.ts
+++ b/packages/experiment-browser/src/integration/manager.ts
@@ -292,10 +292,7 @@ export class PersistentTrackingQueue {
           this.inMemoryQueue.length - this.maxQueueSize,
         );
       }
-      localStorage.setItem(
-        this.storageKey,
-        JSON.stringify(this.inMemoryQueue),
-      );
+      localStorage.setItem(this.storageKey, JSON.stringify(this.inMemoryQueue));
     }
   }
 

--- a/packages/experiment-browser/src/transport/http.ts
+++ b/packages/experiment-browser/src/transport/http.ts
@@ -3,7 +3,11 @@
  * @internal
  */
 
-import { safeGlobal, TimeoutError } from '@amplitude/experiment-core';
+import {
+  getFetch,
+  getSetTimeout,
+  TimeoutError,
+} from '@amplitude/experiment-core';
 import {
   HttpClient as CoreHttpClient,
   HttpRequest,
@@ -13,7 +17,7 @@ import unfetch from 'unfetch';
 
 import { HttpClient, SimpleResponse } from '../types/transport';
 
-const fetch = safeGlobal.fetch || unfetch;
+const fetch = getFetch() || unfetch;
 
 /*
  * Copied from:
@@ -28,13 +32,16 @@ const timeout = (
     return promise;
   }
   return new Promise(function (resolve, reject) {
-    safeGlobal.setTimeout(function () {
-      reject(
-        new TimeoutError(
-          'Request timeout after ' + timeoutMillis + ' milliseconds',
-        ),
-      );
-    }, timeoutMillis);
+    const setTimeoutFn = getSetTimeout();
+    if (setTimeoutFn) {
+      setTimeoutFn(function () {
+        reject(
+          new TimeoutError(
+            'Request timeout after ' + timeoutMillis + ' milliseconds',
+          ),
+        );
+      }, timeoutMillis);
+    }
     promise.then(resolve, reject);
   });
 };

--- a/packages/experiment-browser/src/util/backoff.ts
+++ b/packages/experiment-browser/src/util/backoff.ts
@@ -1,4 +1,4 @@
-import { safeGlobal } from '@amplitude/experiment-core';
+import { getSetTimeout } from '@amplitude/experiment-core';
 
 export class Backoff {
   private readonly attempts: number;
@@ -45,7 +45,11 @@ export class Backoff {
     if (this.done) {
       return;
     }
-    this.timeoutHandle = safeGlobal.setTimeout(async () => {
+    const setTimeoutFn = getSetTimeout();
+    if (!setTimeoutFn) {
+      return;
+    }
+    this.timeoutHandle = setTimeoutFn(async () => {
       try {
         await fn();
       } catch (e) {

--- a/packages/experiment-browser/src/util/backoff.ts
+++ b/packages/experiment-browser/src/util/backoff.ts
@@ -1,4 +1,4 @@
-import { getSetTimeout } from '@amplitude/experiment-core';
+import { getClearTimeout, getSetTimeout } from '@amplitude/experiment-core';
 
 export class Backoff {
   private readonly attempts: number;
@@ -34,7 +34,10 @@ export class Backoff {
 
   public cancel(): void {
     this.done = true;
-    clearTimeout(this.timeoutHandle);
+    const clearTimeoutFn = getClearTimeout();
+    if (clearTimeoutFn) {
+      clearTimeoutFn(this.timeoutHandle);
+    }
   }
 
   private async backoff(

--- a/packages/experiment-browser/src/util/convert.ts
+++ b/packages/experiment-browser/src/util/convert.ts
@@ -10,9 +10,9 @@ export const convertUserToContext = (
     return {};
   }
   const context: Record<string, unknown> = { user: user };
-  // add page context
+  // add page context (skip if location is unavailable, e.g. Node SSR)
   const globalScope = getGlobalScope();
-  if (globalScope) {
+  if (globalScope?.location) {
     context.page = {
       url: globalScope.location.href,
     };

--- a/packages/experiment-browser/src/util/state.ts
+++ b/packages/experiment-browser/src/util/state.ts
@@ -1,4 +1,8 @@
-import { safeGlobal } from '@amplitude/experiment-core';
+import {
+  getDocument,
+  getLocalStorage,
+  getSessionStorage,
+} from '@amplitude/experiment-core';
 
 export type AmplitudeState = {
   deviceId?: string;
@@ -12,7 +16,11 @@ export const parseAmplitudeCookie = (
   // Get the cookie value
   const key = generateKey(apiKey, newFormat);
   let value: string | undefined = undefined;
-  const cookies = safeGlobal.document.cookie.split('; ');
+  const document = getDocument();
+  if (!document) {
+    return;
+  }
+  const cookies = document.cookie.split('; ');
   for (const cookie of cookies) {
     const [cookieKey, cookieValue] = cookie.split('=', 2);
     if (cookieKey === key) {
@@ -49,7 +57,9 @@ export const parseAmplitudeLocalStorage = (
 ): AmplitudeState | undefined => {
   const key = generateKey(apiKey, true);
   try {
-    const value = safeGlobal.localStorage.getItem(key);
+    const localStorage = getLocalStorage();
+    if (!localStorage) return;
+    const value = localStorage.getItem(key);
     if (!value) return;
     const state = JSON.parse(value);
     if (typeof state !== 'object') return;
@@ -64,7 +74,9 @@ export const parseAmplitudeSessionStorage = (
 ): AmplitudeState | undefined => {
   const key = generateKey(apiKey, true);
   try {
-    const value = safeGlobal.sessionStorage.getItem(key);
+    const sessionStorage = getSessionStorage();
+    if (!sessionStorage) return;
+    const value = sessionStorage.getItem(key);
     if (!value) return;
     const state = JSON.parse(value);
     if (typeof state !== 'object') return;

--- a/packages/experiment-browser/test/convert.test.ts
+++ b/packages/experiment-browser/test/convert.test.ts
@@ -109,4 +109,31 @@ describe('convertUserToContext', () => {
       });
     });
   });
+
+  describe('Node SSR regression', () => {
+    test('does not throw and omits page when global has no .location (Node SSR)', () => {
+      const fakeNodeGlobal = {} as typeof globalThis;
+      jest.spyOn(util, 'getGlobalScope').mockReturnValue(fakeNodeGlobal);
+      const user: ExperimentUser = { user_id: 'user_id' };
+      let context: Record<string, unknown> = {};
+      expect(() => {
+        context = convertUserToContext(user);
+      }).not.toThrow();
+      expect(context).toEqual({ user: { user_id: 'user_id' } });
+      expect(context).not.toHaveProperty('page');
+    });
+
+    test('includes page when location is present', () => {
+      const fakeBrowserGlobal = {
+        location: { href: 'https://example.com/path' },
+      } as unknown as typeof globalThis;
+      jest.spyOn(util, 'getGlobalScope').mockReturnValue(fakeBrowserGlobal);
+      const user: ExperimentUser = { user_id: 'user_id' };
+      const context = convertUserToContext(user);
+      expect(context).toEqual({
+        user: { user_id: 'user_id' },
+        page: { url: 'https://example.com/path' },
+      });
+    });
+  });
 });

--- a/packages/experiment-browser/test/integration/manager.test.ts
+++ b/packages/experiment-browser/test/integration/manager.test.ts
@@ -1,3 +1,4 @@
+import * as core from '@amplitude/experiment-core';
 import { safeGlobal } from '@amplitude/experiment-core';
 import { ExperimentConfig } from 'src/config';
 import { ExperimentClient } from 'src/experimentClient';
@@ -738,5 +739,36 @@ describe('PersistentTrackingQueue', () => {
     queue.push({ eventType: 'test2' });
     expect(queue['inMemoryQueue'].length).toEqual(0);
     expect(success).toEqual(3);
+  });
+});
+
+describe('iOS Safari null-globalThis regression', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('PersistentTrackingQueue.setTracker does not throw when global scope is unavailable', () => {
+    jest.spyOn(core, 'getGlobalScope').mockReturnValue(undefined);
+    const queue = new PersistentTrackingQueue('null-global-test');
+    expect(() => {
+      queue.setTracker(() => true);
+    }).not.toThrow();
+    queue['poller'] = undefined;
+  });
+
+  test('PersistentTrackingQueue.push does not throw when localStorage helper returns undefined', () => {
+    jest.spyOn(core, 'getLocalStorage').mockReturnValue(undefined);
+    const queue = new PersistentTrackingQueue('null-localstorage-test');
+    expect(() => {
+      queue.push({ eventType: 'test' });
+    }).not.toThrow();
+  });
+
+  test('SessionDedupeCache constructor does not throw when sessionStorage helper returns undefined', () => {
+    jest.spyOn(core, 'getSessionStorage').mockReturnValue(undefined);
+    expect(() => {
+      const cache = new SessionDedupeCache('null-session-test');
+      cache.shouldTrack({ flag_key: 'k', variant: 'v' });
+    }).not.toThrow();
   });
 });

--- a/packages/experiment-core/src/index.ts
+++ b/packages/experiment-core/src/index.ts
@@ -25,5 +25,13 @@ export {
   safeGlobal,
   getGlobalScope,
   isLocalStorageAvailable,
+  getLocalStorage,
+  getSessionStorage,
+  getDocument,
+  getFetch,
+  getSetTimeout,
+  getClearTimeout,
+  getSetInterval,
+  getClearInterval,
 } from './util/global';
 export { FetchError, TimeoutError } from './evaluation/error';

--- a/packages/experiment-core/src/util/global.ts
+++ b/packages/experiment-core/src/util/global.ts
@@ -1,21 +1,20 @@
-export const safeGlobal =
-  typeof globalThis !== 'undefined' ? globalThis : global || self;
-
 export const getGlobalScope = (): typeof globalThis | undefined => {
-  if (typeof globalThis !== 'undefined') {
+  if (typeof globalThis !== 'undefined' && globalThis !== null) {
     return globalThis;
   }
-  if (typeof window !== 'undefined') {
+  if (typeof window !== 'undefined' && window !== null) {
     return window;
   }
-  if (typeof self !== 'undefined') {
+  if (typeof self !== 'undefined' && self !== null) {
     return self;
   }
-  if (typeof global !== 'undefined') {
+  if (typeof global !== 'undefined' && global !== null) {
     return global;
   }
   return undefined;
 };
+
+export const safeGlobal: typeof globalThis | undefined = getGlobalScope();
 
 export const isLocalStorageAvailable = (): boolean => {
   const globalScope = getGlobalScope();
@@ -30,4 +29,41 @@ export const isLocalStorageAvailable = (): boolean => {
     }
   }
   return false;
+};
+
+export const getLocalStorage = (): Storage | undefined => {
+  return getGlobalScope()?.localStorage;
+};
+
+export const getSessionStorage = (): Storage | undefined => {
+  return getGlobalScope()?.sessionStorage;
+};
+
+export const getDocument = (): Document | undefined => {
+  return getGlobalScope()?.document;
+};
+
+export const getFetch = (): typeof fetch | undefined => {
+  const scope = getGlobalScope();
+  return scope?.fetch ? scope.fetch.bind(scope) : undefined;
+};
+
+export const getSetTimeout = (): typeof setTimeout | undefined => {
+  const scope = getGlobalScope();
+  return scope?.setTimeout ? scope.setTimeout.bind(scope) : undefined;
+};
+
+export const getClearTimeout = (): typeof clearTimeout | undefined => {
+  const scope = getGlobalScope();
+  return scope?.clearTimeout ? scope.clearTimeout.bind(scope) : undefined;
+};
+
+export const getSetInterval = (): typeof setInterval | undefined => {
+  const scope = getGlobalScope();
+  return scope?.setInterval ? scope.setInterval.bind(scope) : undefined;
+};
+
+export const getClearInterval = (): typeof clearInterval | undefined => {
+  const scope = getGlobalScope();
+  return scope?.clearInterval ? scope.clearInterval.bind(scope) : undefined;
 };

--- a/packages/experiment-core/src/util/poller.ts
+++ b/packages/experiment-core/src/util/poller.ts
@@ -1,4 +1,4 @@
-import { safeGlobal } from './global';
+import { getClearInterval, getSetInterval } from './global';
 
 export class Poller {
   public readonly action: () => Promise<void>;
@@ -12,7 +12,11 @@ export class Poller {
     if (this.poller) {
       return;
     }
-    this.poller = safeGlobal.setInterval(this.action, this.ms);
+    const setInterval = getSetInterval();
+    if (!setInterval) {
+      return;
+    }
+    this.poller = setInterval(this.action, this.ms);
     void this.action();
   }
 
@@ -20,9 +24,13 @@ export class Poller {
     if (!this.poller) {
       return;
     }
+    const clearInterval = getClearInterval();
+    if (!clearInterval) {
+      return;
+    }
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    safeGlobal.clearInterval(this.poller);
+    clearInterval(this.poller);
     this.poller = undefined;
   }
 }

--- a/packages/experiment-core/src/util/poller.ts
+++ b/packages/experiment-core/src/util/poller.ts
@@ -25,12 +25,11 @@ export class Poller {
       return;
     }
     const clearInterval = getClearInterval();
-    if (!clearInterval) {
-      return;
+    if (clearInterval) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      clearInterval(this.poller);
     }
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    clearInterval(this.poller);
     this.poller = undefined;
   }
 }

--- a/packages/experiment-core/test/util/global.test.ts
+++ b/packages/experiment-core/test/util/global.test.ts
@@ -96,19 +96,21 @@ describe('getSetTimeout / getClearTimeout', () => {
   it('returned setTimeout schedules the callback and clearTimeout cancels it', (done) => {
     const setTimeoutFn = getSetTimeout();
     const clearTimeoutFn = getClearTimeout();
-    expect(setTimeoutFn).toBeDefined();
-    expect(clearTimeoutFn).toBeDefined();
+    if (!setTimeoutFn || !clearTimeoutFn) {
+      done.fail('expected setTimeout/clearTimeout to be defined');
+      return;
+    }
 
     let cancelled = false;
-    const handle = setTimeoutFn!(() => {
+    const handle = setTimeoutFn(() => {
       if (cancelled) {
         done.fail('cancelled timeout fired');
       }
     }, 50);
-    clearTimeoutFn!(handle);
+    clearTimeoutFn(handle);
     cancelled = true;
 
-    setTimeoutFn!(() => done(), 100);
+    setTimeoutFn(() => done(), 100);
   });
 });
 
@@ -116,16 +118,18 @@ describe('getSetInterval / getClearInterval', () => {
   it('returned setInterval schedules and clearInterval cancels', (done) => {
     const setIntervalFn = getSetInterval();
     const clearIntervalFn = getClearInterval();
-    expect(setIntervalFn).toBeDefined();
-    expect(clearIntervalFn).toBeDefined();
+    if (!setIntervalFn || !clearIntervalFn) {
+      done.fail('expected setInterval/clearInterval to be defined');
+      return;
+    }
 
     let calls = 0;
-    const handle = setIntervalFn!(() => {
+    const handle = setIntervalFn(() => {
       calls += 1;
     }, 25);
 
     setTimeout(() => {
-      clearIntervalFn!(handle);
+      clearIntervalFn(handle);
       const callsAtCancel = calls;
       setTimeout(() => {
         expect(calls).toBe(callsAtCancel);

--- a/packages/experiment-core/test/util/global.test.ts
+++ b/packages/experiment-core/test/util/global.test.ts
@@ -1,0 +1,136 @@
+import {
+  getClearInterval,
+  getClearTimeout,
+  getDocument,
+  getFetch,
+  getGlobalScope,
+  getLocalStorage,
+  getSessionStorage,
+  getSetInterval,
+  getSetTimeout,
+} from '../../src/util/global';
+
+type Helper<T> = () => T | undefined;
+
+const withDeletedProperty = <T>(
+  prop: keyof typeof globalThis,
+  fn: () => T,
+): T => {
+  const scope = globalThis as Record<string, unknown>;
+  const original = scope[prop as string];
+  delete scope[prop as string];
+  try {
+    return fn();
+  } finally {
+    scope[prop as string] = original;
+  }
+};
+
+describe('getGlobalScope', () => {
+  it('returns globalThis in a normal environment', () => {
+    expect(getGlobalScope()).toBe(globalThis);
+  });
+});
+
+describe.each<[string, Helper<unknown>, keyof typeof globalThis]>([
+  ['getLocalStorage', getLocalStorage, 'localStorage'],
+  ['getSessionStorage', getSessionStorage, 'sessionStorage'],
+  ['getDocument', getDocument, 'document'],
+])('%s', (_name, helper, prop) => {
+  it('returns the value when present on the global', () => {
+    expect(helper()).toBe(globalThis[prop]);
+  });
+
+  it('returns undefined when the property is missing', () => {
+    withDeletedProperty(prop, () => {
+      expect(helper()).toBeUndefined();
+    });
+  });
+});
+
+describe.each<[string, Helper<unknown>, keyof typeof globalThis]>([
+  ['getSetTimeout', getSetTimeout, 'setTimeout'],
+  ['getClearTimeout', getClearTimeout, 'clearTimeout'],
+  ['getSetInterval', getSetInterval, 'setInterval'],
+  ['getClearInterval', getClearInterval, 'clearInterval'],
+])('%s', (_name, helper, prop) => {
+  it('returns a callable when present on the global', () => {
+    expect(typeof helper()).toBe('function');
+  });
+
+  it('returns undefined when the property is missing', () => {
+    withDeletedProperty(prop, () => {
+      expect(helper()).toBeUndefined();
+    });
+  });
+});
+
+describe('getFetch', () => {
+  it('returns the fetch function when present on the global', () => {
+    const scope = globalThis as Record<string, unknown>;
+    const original = scope.fetch;
+    const stub = jest.fn();
+    scope.fetch = stub;
+    try {
+      const fetchFn = getFetch();
+      expect(typeof fetchFn).toBe('function');
+      fetchFn?.('http://example.com');
+      expect(stub).toHaveBeenCalledWith('http://example.com');
+    } finally {
+      if (original === undefined) {
+        delete scope.fetch;
+      } else {
+        scope.fetch = original;
+      }
+    }
+  });
+
+  it('returns undefined when fetch is missing from the global', () => {
+    withDeletedProperty('fetch', () => {
+      expect(getFetch()).toBeUndefined();
+    });
+  });
+});
+
+describe('getSetTimeout / getClearTimeout', () => {
+  it('returned setTimeout schedules the callback and clearTimeout cancels it', (done) => {
+    const setTimeoutFn = getSetTimeout();
+    const clearTimeoutFn = getClearTimeout();
+    expect(setTimeoutFn).toBeDefined();
+    expect(clearTimeoutFn).toBeDefined();
+
+    let cancelled = false;
+    const handle = setTimeoutFn!(() => {
+      if (cancelled) {
+        done.fail('cancelled timeout fired');
+      }
+    }, 50);
+    clearTimeoutFn!(handle);
+    cancelled = true;
+
+    setTimeoutFn!(() => done(), 100);
+  });
+});
+
+describe('getSetInterval / getClearInterval', () => {
+  it('returned setInterval schedules and clearInterval cancels', (done) => {
+    const setIntervalFn = getSetInterval();
+    const clearIntervalFn = getClearInterval();
+    expect(setIntervalFn).toBeDefined();
+    expect(clearIntervalFn).toBeDefined();
+
+    let calls = 0;
+    const handle = setIntervalFn!(() => {
+      calls += 1;
+    }, 25);
+
+    setTimeout(() => {
+      clearIntervalFn!(handle);
+      const callsAtCancel = calls;
+      setTimeout(() => {
+        expect(calls).toBe(callsAtCancel);
+        done();
+      }, 75);
+    }, 80);
+  });
+});

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -5,7 +5,6 @@ import {
   FlagEvaluationTrace,
   getGlobalScope,
   isLocalStorageAvailable,
-  safeGlobal,
 } from '@amplitude/experiment-core';
 import {
   Experiment,
@@ -73,7 +72,10 @@ export const PREVIEW_MODE_PARAM = 'PREVIEW';
 export const PREVIEW_MODE_SESSION_KEY = 'amp-preview-mode';
 const VISUAL_EDITOR_PARAM = 'VISUAL_EDITOR';
 
-safeGlobal.Experiment = FeatureExperiment;
+const moduleScope = getGlobalScope();
+if (moduleScope) {
+  moduleScope.Experiment = FeatureExperiment;
+}
 
 export class DefaultWebExperimentClient implements WebExperimentClient {
   private readonly apiKey: string;

--- a/packages/experiment-tag/src/preview/http.ts
+++ b/packages/experiment-tag/src/preview/http.ts
@@ -1,4 +1,4 @@
-import { safeGlobal, TimeoutError } from '@amplitude/experiment-core';
+import { getFetch, TimeoutError } from '@amplitude/experiment-core';
 import unfetch from 'unfetch';
 
 export interface SimpleResponse {
@@ -16,7 +16,7 @@ export interface HttpClient {
   ): Promise<SimpleResponse>;
 }
 
-const fetch = safeGlobal.fetch || unfetch;
+const fetch = getFetch() || unfetch;
 
 const withTimeout = (
   promise: Promise<SimpleResponse>,

--- a/packages/experiment-tag/test/experiment.test.ts
+++ b/packages/experiment-tag/test/experiment.test.ts
@@ -1,5 +1,8 @@
 import * as experimentCore from '@amplitude/experiment-core';
-import { safeGlobal } from '@amplitude/experiment-core';
+import { safeGlobal as maybeSafeGlobal } from '@amplitude/experiment-core';
+
+// Tests run in jsdom so safeGlobal is always defined.
+const safeGlobal = maybeSafeGlobal as typeof globalThis;
 import { ExperimentClient } from '@amplitude/experiment-js-client';
 import { Base64 } from 'js-base64';
 import { DefaultWebExperimentClient } from 'src/experiment';

--- a/packages/experiment-tag/test/experiment.test.ts
+++ b/packages/experiment-tag/test/experiment.test.ts
@@ -1,8 +1,5 @@
 import * as experimentCore from '@amplitude/experiment-core';
 import { safeGlobal as maybeSafeGlobal } from '@amplitude/experiment-core';
-
-// Tests run in jsdom so safeGlobal is always defined.
-const safeGlobal = maybeSafeGlobal as typeof globalThis;
 import { ExperimentClient } from '@amplitude/experiment-js-client';
 import { Base64 } from 'js-base64';
 import { DefaultWebExperimentClient } from 'src/experiment';
@@ -14,6 +11,9 @@ import { createMutateFlag, createRedirectFlag } from './util/create-flag';
 import { createPageObject } from './util/create-page-object';
 import { MockHttpClient } from './util/mock-http-client';
 import { createMockGlobal, setupGlobalObservers } from './util/mocks';
+
+// Tests run in jsdom so safeGlobal is always defined.
+const safeGlobal = maybeSafeGlobal as typeof globalThis;
 
 let apiKey = 0;
 const DEFAULT_PAGE_OBJECTS = {

--- a/packages/plugin-segment/package.json
+++ b/packages/plugin-segment/package.json
@@ -27,6 +27,7 @@
     "url": "https://github.com/amplitude/experiment-js-client/issues"
   },
   "dependencies": {
+    "@amplitude/experiment-core": "^0.13.1",
     "@amplitude/experiment-js-client": "^1.21.1",
     "@segment/analytics-next": "^1.73.0"
   },

--- a/packages/plugin-segment/src/global.ts
+++ b/packages/plugin-segment/src/global.ts
@@ -1,6 +1,3 @@
-export const safeGlobal =
-  typeof globalThis !== 'undefined'
-    ? globalThis
-    : typeof global !== 'undefined'
-    ? global
-    : self;
+import { getGlobalScope } from '@amplitude/experiment-core';
+
+export const safeGlobal = getGlobalScope() ?? ({} as typeof globalThis);

--- a/packages/plugin-segment/src/plugin.ts
+++ b/packages/plugin-segment/src/plugin.ts
@@ -1,10 +1,15 @@
+import {
+  getClearInterval,
+  getGlobalScope,
+  getLocalStorage,
+  getSetInterval,
+} from '@amplitude/experiment-core';
 import type {
   ExperimentEvent,
   ExperimentUser,
   IntegrationPlugin,
 } from '@amplitude/experiment-js-client';
 
-import { safeGlobal } from './global';
 import { snippetInstance } from './snippet';
 import { Options, SegmentIntegrationPlugin } from './types/plugin';
 
@@ -29,11 +34,16 @@ export const segmentIntegrationPlugin: SegmentIntegrationPlugin = (
         // If the segment SDK is installed via the @segment/analytics-next npm
         // package then function calls to the snippet are not respected.
         if (!options.instance) {
-          const interval = safeGlobal.setInterval(() => {
+          const setInterval = getSetInterval();
+          if (!setInterval) return;
+          const interval = setInterval(() => {
             const instance = getInstance();
             if (instance.initialized) {
               ready = true;
-              safeGlobal.clearInterval(interval);
+              const clearInterval = getClearInterval();
+              if (clearInterval) {
+                clearInterval(interval);
+              }
               resolve();
             }
           }, 50);
@@ -50,7 +60,9 @@ export const segmentIntegrationPlugin: SegmentIntegrationPlugin = (
         };
       }
       const get = (key: string) => {
-        return JSON.parse(safeGlobal.localStorage.getItem(key)) || undefined;
+        const localStorage = getLocalStorage();
+        if (!localStorage) return undefined;
+        return JSON.parse(localStorage.getItem(key)) || undefined;
       };
       return {
         user_id: get('ajs_user_id'),
@@ -72,4 +84,7 @@ export const segmentIntegrationPlugin: SegmentIntegrationPlugin = (
   return plugin;
 };
 
-safeGlobal.experimentIntegration = segmentIntegrationPlugin();
+const globalScope = getGlobalScope();
+if (globalScope) {
+  globalScope.experimentIntegration = segmentIntegrationPlugin();
+}


### PR DESCRIPTION
## Summary
- Adds internal helpers in `@amplitude/experiment-core` (`getLocalStorage`, `getSessionStorage`, `getDocument`, `getFetch`, `getSetTimeout`/`getClearTimeout`, `getSetInterval`/`getClearInterval`) that gate browser-API access through `getGlobalScope()` plus an explicit property check, returning `undefined` when the global or property is missing.
- Migrates every unguarded `safeGlobal.X` deref in `experiment-browser` and `plugin-segment` to the helpers; module-load global writes (`factory.ts`, `plugin-segment/plugin.ts`, `experiment-tag/experiment.ts`) no-op when no global is present.
- Fixes #253 (iOS Safari `globalThis === null` crash in `PersistentTrackingQueue`) and the Node SSR crash on `globalScope.location.href` in `convertUserToContext`. Supersedes #256, which was a partial fix; this folds in #256's `safeGlobal`/`getGlobalScope` null-handling and extends it to every unguarded site. `safeGlobal` is now typed `typeof globalThis | undefined`.

## Test plan
- [x] 19 unit tests for the new helpers (global undefined / property missing / property present, plus end-to-end timer schedule + cancel)
- [x] Regression test for iOS Safari class — `PersistentTrackingQueue.setTracker`/`.push` and `SessionDedupeCache` constructor + `shouldTrack` no-throw when the global-scope helpers return `undefined`
- [x] Regression test for Node SSR class — `convertUserToContext` does not throw and omits `context.page` when the global has no `.location`; positive case with `.location` still includes `page.url`
- [x] All existing tests pass across `experiment-core`, `experiment-js-client`, `experiment-tag`, `experiment-plugin-segment`, `analytics-connector` (494 total)
- [x] Node smoke test against built `experiment-browser` UMD bundle: `Experiment.initialize` → `setUser` → `addPlugin` → `variant()` does not throw without browser globals

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core initialization, exposure dedupe/queue persistence, HTTP timeouts, and SSR evaluation context across multiple packages; behavior changes when globals or APIs are missing, though intended paths are guarded and well-tested.
> 
> **Overview**
> Replaces direct **`safeGlobal`** property access with **`@amplitude/experiment-core`** helpers that resolve the global scope (including **`null`** **`globalThis`**, e.g. iOS Safari) and return **`undefined`** when a browser API is missing.
> 
> **`getGlobalScope`** now treats **`globalThis` / `window` / `self` / `global`** as absent when they are **`null`**; **`safeGlobal`** is **`getGlobalScope()`** and may be **`undefined`**. New exports gate **`localStorage`**, **`sessionStorage`**, **`document`**, **`fetch`**, and timer APIs. **`experiment-browser`**, **`experiment-tag`**, and **`plugin-segment`** use these helpers for HTTP, backoff, integration queues/dedupe, Amplitude identity reads, and pollers; module-load assignments to the global (debug instances, Segment integration, **`Experiment`** on **`window`**) run only when a scope exists, with a module-local fallback for experiment client singletons when it does not.
> 
> **`convertUserToContext`** adds **`page`** only when **`globalScope.location`** exists, avoiding Node SSR throws. Regression tests cover null-global / missing storage and SSR page omission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1d5eda7452f87838192b3a9a68a942ca4baab7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->