### PR TITLE
feat(spa-router): intercept clicks on SPA routed links

### DIFF
--- a/packages/experiment-tag/package.json
+++ b/packages/experiment-tag/package.json
@@ -31,7 +31,7 @@
     "@amplitude/analytics-types": "^2.11.0",
     "@amplitude/experiment-core": "^0.13.1",
     "@amplitude/experiment-js-client": "^1.21.1",
-    "dom-mutator": "git+ssh://git@github.com/amplitude/dom-mutator#0294e723c6a8f85d448bdfa59999591f2ae9e476",
+    "dom-mutator": "git+ssh://git@github.com/amplitude/dom-mutator#053784ca2ff34d127d779690e403340175b4692c",
     "rollup-plugin-license": "^3.6.0"
   },
   "devDependencies": {

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -189,6 +189,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       return;
     }
     patchRemoveChild();
+    installSpaLinkInterceptor();
     const urlParams = getUrlParams();
 
     // When running inside an iframe (mobile shell), skip overlay loading and

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -49,6 +49,7 @@ import { hideLoadingIndicator } from './util/loading-indicator';
 import { VISUAL_EDITOR_SESSION_KEY, WindowMessenger } from './util/messenger';
 import { patchRemoveChild } from './util/patch';
 import { buildShell, isMobileModeActive } from './util/shell';
+import { installSpaLinkInterceptor } from './util/spa-link-interceptor';
 import {
   getStorageItem,
   setStorageItem,

--- a/packages/experiment-tag/src/util/spa-link-interceptor.ts
+++ b/packages/experiment-tag/src/util/spa-link-interceptor.ts
@@ -13,6 +13,7 @@ declare global {
   }
 }
 
+// determine if click navigates to a different in-app page
 function isLocalNavigation(
   event: MouseEvent,
   href: string,
@@ -67,7 +68,7 @@ export function installSpaLinkInterceptor() {
       return;
     }
 
-    // checK for typical SPA page navigation
+    // check for typical SPA page navigation
     const href = anchor.getAttribute('href');
     const target = anchor.getAttribute('target');
     if (!href || !isLocalNavigation(e, href, target)) {

--- a/packages/experiment-tag/src/util/spa-link-interceptor.ts
+++ b/packages/experiment-tag/src/util/spa-link-interceptor.ts
@@ -98,6 +98,6 @@ function navigateSpa(href: string): void {
   }
 
   // other routers use pushState
-  history.pushState(null, '', href);
+  history.pushState(history.state, '', href);
   window.dispatchEvent(new PopStateEvent('popstate', { state: history.state }));
 }

--- a/packages/experiment-tag/src/util/spa-link-interceptor.ts
+++ b/packages/experiment-tag/src/util/spa-link-interceptor.ts
@@ -51,7 +51,15 @@ function detectSpaRouting(anchor: HTMLAnchorElement) {
   );
 }
 
+// guard against double scripts
+const initFlag = Symbol.for('@amplitude/spa-link-interceptor-initiated');
+
 export function installSpaLinkInterceptor() {
+  if (window[initFlag]) {
+    return;
+  }
+  window[initFlag] = true;
+
   const handler = (e: MouseEvent) => {
     const anchor = (e.target as Element).closest(
       'a',

--- a/packages/experiment-tag/src/util/spa-link-interceptor.ts
+++ b/packages/experiment-tag/src/util/spa-link-interceptor.ts
@@ -71,11 +71,11 @@ export function installSpaLinkInterceptor() {
     // check for typical SPA page navigation
     const href = anchor.getAttribute('href');
     const target = anchor.getAttribute('target');
-    if (!href || !isLocalNavigation(e, href, target)) {
-      return;
-    }
-
-    if (!detectSpaRouter(anchor)) {
+    if (
+      !href ||
+      !isLocalNavigation(e, href, target) ||
+      !detectSpaRouter(anchor)
+    ) {
       return;
     }
 

--- a/packages/experiment-tag/src/util/spa-link-interceptor.ts
+++ b/packages/experiment-tag/src/util/spa-link-interceptor.ts
@@ -98,6 +98,6 @@ function navigateSpa(href: string): void {
   }
 
   // other routers use pushState
-  history.pushState(history.state, '', href);
+  history.pushState(null, '', href);
   window.dispatchEvent(new PopStateEvent('popstate', { state: history.state }));
 }

--- a/packages/experiment-tag/src/util/spa-link-interceptor.ts
+++ b/packages/experiment-tag/src/util/spa-link-interceptor.ts
@@ -1,0 +1,99 @@
+import type { ElementRecord } from 'dom-mutator/dist/types';
+
+declare global {
+  interface Element {
+    __mutationRecord__?: ElementRecord;
+  }
+  interface Window {
+    next?: {
+      router?: {
+        push: (href: string) => void;
+      };
+    };
+  }
+}
+
+function isLocalNavigation(
+  event: MouseEvent,
+  href: string,
+  target: string | null,
+): boolean {
+  const isModified =
+    (target && target !== '_self') ||
+    event.metaKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    event.altKey ||
+    event.button > 0;
+
+  const url = new URL(href, window.location.origin);
+
+  // ignore if link is just changing the hash
+  const samePage =
+    url.href.split('#')[0] === window.location.href.split('#')[0];
+  const sameOrigin = url.origin === window.location.origin;
+
+  return !isModified && sameOrigin && !samePage;
+}
+
+function detectSpaRouter(anchor: HTMLAnchorElement) {
+  // detect NextJS router
+  if (window.next?.router?.push) {
+    return true;
+  }
+
+  // detect React app, caveats:
+  // not guaranteed for react-router to be used
+  // not guaranteed to be a <Link> component that utilizes the router
+  const fiberKey = Object.keys(anchor).find((k) =>
+    k.startsWith('__reactFiber'),
+  );
+  if (!fiberKey) return false;
+
+  // SPA link components should have an onClick handler
+  return Boolean(anchor[fiberKey]?.memoizedProps?.onClick);
+}
+
+export function installSpaLinkInterceptor() {
+  const handler = (e: MouseEvent) => {
+    const anchor = (e.target as Element).closest(
+      'a',
+    ) as HTMLAnchorElement | null;
+    if (!anchor) return;
+
+    // only intercept if the href has been mutated
+    const mutationRecord = anchor.__mutationRecord__;
+    if (!mutationRecord?.attributes?.href?.mutations.length) {
+      return;
+    }
+
+    // checK for typical SPA page navigation
+    const href = anchor.getAttribute('href');
+    const target = anchor.getAttribute('target');
+    if (!href || !isLocalNavigation(e, href, target)) {
+      return;
+    }
+
+    if (!detectSpaRouter(anchor)) {
+      return;
+    }
+
+    e.preventDefault();
+    e.stopPropagation();
+    navigateSpa(href);
+  };
+
+  document.addEventListener('click', handler, true);
+}
+
+function navigateSpa(href: string): void {
+  // special case for NextJS router
+  if (window.next?.router?.push) {
+    window.next.router.push(href);
+    return;
+  }
+
+  // other routers use pushState
+  history.pushState(null, '', href);
+  window.dispatchEvent(new PopStateEvent('popstate', { state: history.state }));
+}

--- a/packages/experiment-tag/src/util/spa-link-interceptor.ts
+++ b/packages/experiment-tag/src/util/spa-link-interceptor.ts
@@ -37,22 +37,16 @@ function isLocalNavigation(
   return !isModified && sameOrigin && !samePage;
 }
 
-function detectSpaRouter(anchor: HTMLAnchorElement) {
-  // detect NextJS router
-  if (window.next?.router?.push) {
-    return true;
-  }
-
-  // detect React app, caveats:
-  // not guaranteed for react-router to be used
-  // not guaranteed to be a <Link> component that utilizes the router
+function detectSpaRouting(anchor: HTMLAnchorElement) {
+  // detect React and NextJS router links
+  // caveat: not 100% guaranteed to be a <Link> component that utilizes the router
   const fiberKey = Object.keys(anchor).find((k) =>
     k.startsWith('__reactFiber'),
   );
   if (!fiberKey) return false;
 
-  // SPA link components should have an onClick handler
-  return Boolean(anchor[fiberKey]?.memoizedProps?.onClick);
+  // <Link> components should have an onClick handler
+  return String(anchor[fiberKey]?.memoizedProps?.onClick).includes('defaultPrevented');
 }
 
 export function installSpaLinkInterceptor() {
@@ -74,7 +68,7 @@ export function installSpaLinkInterceptor() {
     if (
       !href ||
       !isLocalNavigation(e, href, target) ||
-      !detectSpaRouter(anchor)
+      !detectSpaRouting(anchor)
     ) {
       return;
     }

--- a/packages/experiment-tag/src/util/spa-link-interceptor.ts
+++ b/packages/experiment-tag/src/util/spa-link-interceptor.ts
@@ -47,7 +47,7 @@ function detectSpaRouting(anchor: HTMLAnchorElement) {
 
   // <Link> components should have an onClick handler that checks for event.defaultPrevented
   return String(anchor[fiberKey]?.memoizedProps?.onClick).includes(
-    '.defaultPrevented'
+    '.defaultPrevented',
   );
 }
 

--- a/packages/experiment-tag/src/util/spa-link-interceptor.ts
+++ b/packages/experiment-tag/src/util/spa-link-interceptor.ts
@@ -26,7 +26,7 @@ function isLocalNavigation(
     event.altKey ||
     event.button > 0;
 
-  const url = new URL(href, window.location.origin);
+  const url = new URL(href, window.location.href);
 
   // ignore if link is just changing the hash
   const samePage =
@@ -79,7 +79,6 @@ export function installSpaLinkInterceptor() {
     }
 
     e.preventDefault();
-    e.stopPropagation();
     navigateSpa(href);
   };
 

--- a/packages/experiment-tag/src/util/spa-link-interceptor.ts
+++ b/packages/experiment-tag/src/util/spa-link-interceptor.ts
@@ -45,8 +45,10 @@ function detectSpaRouting(anchor: HTMLAnchorElement) {
   );
   if (!fiberKey) return false;
 
-  // <Link> components should have an onClick handler
-  return String(anchor[fiberKey]?.memoizedProps?.onClick).includes('defaultPrevented');
+  // <Link> components should have an onClick handler that checks for event.defaultPrevented
+  return String(anchor[fiberKey]?.memoizedProps?.onClick).includes(
+    '.defaultPrevented'
+  );
 }
 
 export function installSpaLinkInterceptor() {


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->
routers like in Next or React use their internal state to navigate within the app instead of the actual href attribute
This intercepts clicks on any SPA routed links to go to the href we mutated if it is same domain.

depends on https://github.com/amplitude/dom-mutator/pull/20

Caveat: The detection is not 100% foolproof.

  * I check for `defaultPrevented` since for example amplitude.com uses NextJS but their links are just normal links with a custom onClick which does not contain `defaultPrevented`. 
  * Other params like `<Link reloadDocument replace>` (React-router) or `<Link replace>` (Nextjs) would not be respected but the navigation would still work


Tested on NextJS app router, NextJS pages router, react-router

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds global click interception and programmatic navigation for certain mutated SPA links, which can affect in-app routing behavior and potentially interfere with site click handling if detection/guards misfire.
> 
> **Overview**
> Adds a new `spa-link-interceptor` that globally captures `click` events and, **only for mutated `<a href>` values that look like SPA router links**, prevents default navigation and triggers client-side routing via `window.next.router.push` or `history.pushState` + `popstate`.
> 
> Hooks this interceptor into `DefaultWebExperimentClient.start()` so it installs automatically, and bumps the `dom-mutator` dependency commit to pick up the mutation-record support used for detecting mutated `href`s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00997e13d6d1f23aa1450ad0c627aae4f5132899. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->