### PR TITLE
fix(experiment-tag): CSP-safe widget CSS injection [WEB-6]

### DIFF
--- a/packages/experiment-tag/jest.config.js
+++ b/packages/experiment-tag/jest.config.js
@@ -9,6 +9,7 @@ module.exports = {
   testEnvironment: 'jsdom',
   displayName: package.name,
   rootDir: '.',
+  setupFilesAfterEnv: ['<rootDir>/test/jest.setup.ts'],
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
     prefix: '<rootDir>/',
   }),

--- a/packages/experiment-tag/package.json
+++ b/packages/experiment-tag/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.4",
+    "construct-style-sheets-polyfill": "^3.1.0",
     "rollup-plugin-gzip": "^3.1.0",
     "rollup-plugin-license": "^3.6.0"
   },

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -43,6 +43,10 @@ import type { AudienceEvaluationDebugInfo, DebugState } from './types/debug';
 import { applyAntiFlickerCss } from './util/anti-flicker';
 import { enrichUserWithCampaignData } from './util/campaign';
 import { setMarketingCookie } from './util/cookie';
+import {
+  cspSafeStyleSheet,
+  type StyleSheetHandle,
+} from './util/csp-safe-stylesheet';
 import { DebugRecorder } from './util/debug-recorder';
 import { getInjectUtils } from './util/inject-utils';
 import { hideLoadingIndicator } from './util/loading-indicator';
@@ -891,16 +895,12 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
         this.globalScope.document.head.appendChild(script);
       }
     }
-    // Create CSS
+    // Adopt CSS as a constructable stylesheet (CSP-safe; works on strict
+    // style-src customer pages where <style> elements would be blocked)
     const rawCss = action.data.css;
-    let style: HTMLStyleElement | undefined;
+    let sheetHandle: StyleSheetHandle | undefined;
     if (rawCss) {
-      style = this.globalScope.document.createElement('style');
-      if (style) {
-        style.innerHTML = rawCss;
-        style.id = `css-${id}`;
-        this.globalScope.document.head.appendChild(style);
-      }
+      sheetHandle = cspSafeStyleSheet(this.globalScope.document, rawCss);
     }
     // Create HTML
     const rawHtml = action.data.html;
@@ -936,7 +936,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       revert: () => {
         state.cancelled = true;
         utils.remove?.();
-        style?.remove();
+        sheetHandle?.revert();
         script?.remove();
         this.appliedInjections.delete(id);
       },

--- a/packages/experiment-tag/src/util/csp-safe-stylesheet.ts
+++ b/packages/experiment-tag/src/util/csp-safe-stylesheet.ts
@@ -21,7 +21,7 @@ export type StyleSheetHandle = {
  * Document constructor.
  */
 function isDocument(node: Document | ShadowRoot): node is Document {
-  return node.nodeType === /* Node.DOCUMENT_NODE */ 9;
+  return node.nodeType === Node.DOCUMENT_NODE;
 }
 
 export function cspSafeStyleSheet(

--- a/packages/experiment-tag/src/util/csp-safe-stylesheet.ts
+++ b/packages/experiment-tag/src/util/csp-safe-stylesheet.ts
@@ -18,7 +18,13 @@ export function cspSafeStyleSheet(
   target: Document | ShadowRoot,
   css: string,
 ): StyleSheetHandle {
-  const sheet = new CSSStyleSheet();
+  // CSSStyleSheets are realm-bound — adopting one cross-realm throws
+  // NotAllowedError. Construct the sheet via the target's owning realm so it
+  // can be adopted into an iframe's contentDocument.
+  const ownerDoc: Document =
+    (target as Document).ownerDocument ?? (target as Document);
+  const SheetCtor = ownerDoc.defaultView?.CSSStyleSheet ?? CSSStyleSheet;
+  const sheet = new SheetCtor();
   sheet.replaceSync(css);
   let adopted = false;
 

--- a/packages/experiment-tag/src/util/csp-safe-stylesheet.ts
+++ b/packages/experiment-tag/src/util/csp-safe-stylesheet.ts
@@ -1,0 +1,48 @@
+/**
+ * Adopts a CSSStyleSheet onto a Document or ShadowRoot.
+ *
+ * Constructable stylesheets are not gated by CSP `style-src`, which means this
+ * works on customer pages with strict nonce/hash CSP policies (e.g. Fathom)
+ * where `<style>` element injection would be blocked.
+ *
+ * Returns idempotent revert/reapply handles for hide-and-restore use cases
+ * (e.g. AI stylizer page snapshots).
+ *
+ * NOTE: This file is duplicated in:
+ *   - apps/experiment-overlay/src/lib/csp-safe-stylesheet.ts (javascript repo)
+ *   - packages/experiment-tag/src/util/csp-safe-stylesheet.ts (experiment-js-client repo)
+ * If you change one, change the other.
+ */
+
+export type StyleSheetHandle = {
+  revert: () => void;
+  reapply: () => void;
+};
+
+export function cspSafeStyleSheet(
+  target: Document | ShadowRoot,
+  css: string,
+): StyleSheetHandle {
+  const sheet = new CSSStyleSheet();
+  sheet.replaceSync(css);
+  let adopted = false;
+
+  const adopt = () => {
+    if (adopted) return;
+    target.adoptedStyleSheets = [...target.adoptedStyleSheets, sheet];
+    adopted = true;
+  };
+
+  adopt();
+
+  return {
+    revert: () => {
+      if (!adopted) return;
+      target.adoptedStyleSheets = target.adoptedStyleSheets.filter(
+        (s) => s !== sheet,
+      );
+      adopted = false;
+    },
+    reapply: adopt,
+  };
+}

--- a/packages/experiment-tag/src/util/csp-safe-stylesheet.ts
+++ b/packages/experiment-tag/src/util/csp-safe-stylesheet.ts
@@ -14,6 +14,16 @@ export type StyleSheetHandle = {
   reapply: () => void;
 };
 
+/**
+ * Discriminates Document from ShadowRoot via nodeType. We avoid
+ * `instanceof Document` because `instanceof` lies across realms — an iframe's
+ * contentDocument IS a Document but isn't an instance of THIS realm's
+ * Document constructor.
+ */
+function isDocument(node: Document | ShadowRoot): node is Document {
+  return node.nodeType === /* Node.DOCUMENT_NODE */ 9;
+}
+
 export function cspSafeStyleSheet(
   target: Document | ShadowRoot,
   css: string,
@@ -21,8 +31,11 @@ export function cspSafeStyleSheet(
   // CSSStyleSheets are realm-bound — adopting one cross-realm throws
   // NotAllowedError. Construct the sheet via the target's owning realm so it
   // can be adopted into an iframe's contentDocument.
-  const ownerDoc: Document =
-    (target as Document).ownerDocument ?? (target as Document);
+  // ShadowRoot.ownerDocument is always a Document per spec; the `?? document`
+  // is purely a TS-narrowing concession (the lib.dom type is nullable).
+  const ownerDoc: Document = isDocument(target)
+    ? target
+    : target.ownerDocument ?? document;
   const SheetCtor = ownerDoc.defaultView?.CSSStyleSheet ?? CSSStyleSheet;
   const sheet = new SheetCtor();
   sheet.replaceSync(css);

--- a/packages/experiment-tag/src/util/csp-safe-stylesheet.ts
+++ b/packages/experiment-tag/src/util/csp-safe-stylesheet.ts
@@ -2,16 +2,11 @@
  * Adopts a CSSStyleSheet onto a Document or ShadowRoot.
  *
  * Constructable stylesheets are not gated by CSP `style-src`, which means this
- * works on customer pages with strict nonce/hash CSP policies (e.g. Fathom)
- * where `<style>` element injection would be blocked.
+ * works on customer pages with strict nonce/hash CSP policies where `<style>`
+ * element injection would be blocked.
  *
  * Returns idempotent revert/reapply handles for hide-and-restore use cases
- * (e.g. AI stylizer page snapshots).
- *
- * NOTE: This file is duplicated in:
- *   - apps/experiment-overlay/src/lib/csp-safe-stylesheet.ts (javascript repo)
- *   - packages/experiment-tag/src/util/csp-safe-stylesheet.ts (experiment-js-client repo)
- * If you change one, change the other.
+ * (e.g. temporarily hiding then restoring a page's styles).
  */
 
 export type StyleSheetHandle = {

--- a/packages/experiment-tag/test/jest.setup.ts
+++ b/packages/experiment-tag/test/jest.setup.ts
@@ -1,0 +1,1 @@
+import 'construct-style-sheets-polyfill';

--- a/packages/experiment-tag/test/util/csp-safe-stylesheet.test.ts
+++ b/packages/experiment-tag/test/util/csp-safe-stylesheet.test.ts
@@ -1,0 +1,77 @@
+import { cspSafeStyleSheet } from '../../src/util/csp-safe-stylesheet';
+
+describe('cspSafeStyleSheet', () => {
+  beforeEach(() => {
+    document.adoptedStyleSheets = [];
+  });
+
+  it('adopts a CSSStyleSheet onto the target', () => {
+    const handle = cspSafeStyleSheet(document, '.foo { color: red; }');
+
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+    expect(document.adoptedStyleSheets[0]).toBeInstanceOf(CSSStyleSheet);
+
+    handle.revert();
+  });
+
+  it('revert removes the sheet from adoptedStyleSheets', () => {
+    const handle = cspSafeStyleSheet(document, '.foo {}');
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+
+    handle.revert();
+    expect(document.adoptedStyleSheets).toHaveLength(0);
+  });
+
+  it('revert is idempotent', () => {
+    const handle = cspSafeStyleSheet(document, '.foo {}');
+    handle.revert();
+    handle.revert();
+    expect(document.adoptedStyleSheets).toHaveLength(0);
+  });
+
+  it('reapply re-adopts the same sheet after revert', () => {
+    const handle = cspSafeStyleSheet(document, '.foo {}');
+    const originalSheet = document.adoptedStyleSheets[0];
+
+    handle.revert();
+    handle.reapply();
+
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+    expect(document.adoptedStyleSheets[0]).toBe(originalSheet);
+  });
+
+  it('reapply is idempotent (no-op when already adopted)', () => {
+    const handle = cspSafeStyleSheet(document, '.foo {}');
+    handle.reapply();
+    handle.reapply();
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+
+    handle.revert();
+  });
+
+  it('preserves other adopted sheets when reverting (filters by identity)', () => {
+    const otherSheet = new CSSStyleSheet();
+    otherSheet.replaceSync('.other {}');
+    document.adoptedStyleSheets = [otherSheet];
+
+    const handle = cspSafeStyleSheet(document, '.foo {}');
+    expect(document.adoptedStyleSheets).toHaveLength(2);
+
+    handle.revert();
+    expect(document.adoptedStyleSheets).toEqual([otherSheet]);
+  });
+
+  it('works on a ShadowRoot target', () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const shadow = host.attachShadow({ mode: 'open' });
+
+    const handle = cspSafeStyleSheet(shadow, '.foo {}');
+    expect(shadow.adoptedStyleSheets).toHaveLength(1);
+    expect(shadow.adoptedStyleSheets[0]).toBeInstanceOf(CSSStyleSheet);
+
+    handle.revert();
+    expect(shadow.adoptedStyleSheets).toHaveLength(0);
+    document.body.removeChild(host);
+  });
+});

--- a/packages/experiment-tag/test/util/csp-safe-stylesheet.test.ts
+++ b/packages/experiment-tag/test/util/csp-safe-stylesheet.test.ts
@@ -1,5 +1,18 @@
 import { cspSafeStyleSheet } from '../../src/util/csp-safe-stylesheet';
 
+/**
+ * Cross-realm coverage gap: these tests do NOT exercise the cross-realm
+ * CSSStyleSheet adoption scenario. In real browsers, a sheet constructed in
+ * one realm cannot be adopted into a Document/ShadowRoot from a different
+ * realm — the browser throws NotAllowedError. construct-style-sheets-polyfill
+ * (used here under jsdom) doesn't enforce that invariant, so these tests
+ * would pass even if the helper regressed to constructing sheets in the
+ * wrong realm.
+ *
+ * The helper's realm-derivation logic
+ * (`target.ownerDocument.defaultView?.CSSStyleSheet`) is exercised manually
+ * via the visual editor's mobile-mode device-iframe scenario.
+ */
 describe('cspSafeStyleSheet', () => {
   beforeEach(() => {
     document.adoptedStyleSheets = [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,7 +43,7 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.28.6", "@babel/code-frame@^7.29.0":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.28.6", "@babel/code-frame@^7.29.0":
   version "7.29.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.0.tgz#7cd7a59f15b3cc0dcd803038f7792712a7d0b15c"
   integrity sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==
@@ -939,14 +939,7 @@
     "@babel/plugin-transform-modules-commonjs" "^7.27.1"
     "@babel/plugin-transform-typescript" "^7.28.5"
 
-"@babel/runtime-corejs3@^7.10.2":
-  version "7.29.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.29.2.tgz#cb86ad06e7a1d39224afb12a874301085e071846"
-  integrity sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==
-  dependencies:
-    core-js-pure "^3.48.0"
-
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2", "@babel/runtime@^7.28.6":
+"@babel/runtime@^7.11.2", "@babel/runtime@^7.28.6":
   version "7.29.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
   integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
@@ -1444,17 +1437,6 @@
     pirates "^4.0.4"
     slash "^3.0.0"
     write-file-atomic "^4.0.2"
-
-"@jest/types@^26.6.2":
-  version "26.6.2"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
-  integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^3.0.0"
-    "@types/node" "*"
-    "@types/yargs" "^15.0.0"
-    chalk "^4.0.0"
 
 "@jest/types@^29.6.3":
   version "29.6.3"
@@ -2212,20 +2194,6 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@testing-library/dom@7.26.0":
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.26.0.tgz#da4d052dc426a4ccc916303369c6e7552126f680"
-  integrity sha512-fyKFrBbS1IigaE3FV21LyeC7kSGF84lqTlSYdKmGaHuK2eYQ/bXVPM5vAa2wx/AU1iPD6oQHsxy2QQ17q9AMCg==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/runtime" "^7.10.3"
-    "@types/aria-query" "^4.2.0"
-    aria-query "^4.2.2"
-    chalk "^4.1.0"
-    dom-accessibility-api "^0.5.1"
-    lz-string "^1.4.4"
-    pretty-format "^26.4.2"
-
 "@tootallnate/once@2":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
@@ -2255,11 +2223,6 @@
   version "8.16.5"
   resolved "https://registry.yarnpkg.com/@types/amplitude-js/-/amplitude-js-8.16.5.tgz#ad8c2c0f2f8b436f014f8b72ddb5535dd00368e6"
   integrity sha512-W73JfDpwDH4VijOGo+nVuQOqUCiqyEGGVdajU4ziWTLn27cn+QtFuFuBdlhCraIIrO52fDRO4NSOGkawtn77Jw==
-
-"@types/aria-query@^4.2.0":
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
-  integrity sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==
 
 "@types/babel__core@^7.1.14":
   version "7.20.5"
@@ -2419,13 +2382,6 @@
   version "21.0.3"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.3.tgz#815e30b786d2e8f0dcd85fd5bcf5e1a04d008f15"
   integrity sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==
-
-"@types/yargs@^15.0.0":
-  version "15.0.20"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.20.tgz#6d00a124c9f757427d4ca3cbc87daea778053c68"
-  integrity sha512-KIkX+/GgfFitlASYCGoSF+T4XRXhOubJLhkLVtSfsRTe9jWMmuM2g28zQ41BtPTG7TRBb2xHW+LCNVE9QR/vsg==
-  dependencies:
-    "@types/yargs-parser" "*"
 
 "@types/yargs@^17.0.8":
   version "17.0.35"
@@ -2665,7 +2621,7 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-regex@^5.0.0, ansi-regex@^5.0.1:
+ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
@@ -2713,14 +2669,6 @@ argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
-
-aria-query@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
-  integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
-  dependencies:
-    "@babel/runtime" "^7.10.2"
-    "@babel/runtime-corejs3" "^7.10.2"
 
 array-buffer-byte-length@^1.0.1, array-buffer-byte-length@^1.0.2:
   version "1.0.2"
@@ -3353,6 +3301,11 @@ console-control-strings@^1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==
 
+construct-style-sheets-polyfill@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/construct-style-sheets-polyfill/-/construct-style-sheets-polyfill-3.1.0.tgz#c490abd79efdb359fafa62ec14ea55232be0eecf"
+  integrity sha512-HBLKP0chz8BAY6rBdzda11c3wAZeCZ+kIG4weVC2NM3AXzxx09nhe8t0SQNdloAvg5GLuHwq/0SPOOSPvtCcKw==
+
 conventional-changelog-angular@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz#5eec8edbff15aa9b1680a8dcfbd53e2d7eb2ba7a"
@@ -3437,11 +3390,6 @@ core-js-compat@^3.48.0:
   integrity sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==
   dependencies:
     browserslist "^4.28.1"
-
-core-js-pure@^3.48.0:
-  version "3.49.0"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.49.0.tgz#ff8436b7251a3832f5fdbbe3e10f7f2e58e51fb1"
-  integrity sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==
 
 core-util-is@~1.0.0:
   version "1.0.3"
@@ -3675,11 +3623,6 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
-
-dom-accessibility-api@^0.5.1:
-  version "0.5.16"
-  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
-  integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
 
 "dom-mutator@git+ssh://git@github.com/amplitude/dom-mutator#0294e723c6a8f85d448bdfa59999591f2ae9e476":
   version "0.7.1"
@@ -6070,11 +6013,6 @@ lunr@^2.3.9:
   resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.9.tgz#18b123142832337dd6e964df1a5a7707b25d35e1"
   integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
 
-lz-string@^1.4.4:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
-  integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
-
 magic-string@^0.25.7:
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.9.tgz#de7f9faf91ef8a1c91d02c2e5314c8277dbcdd1c"
@@ -7124,16 +7062,6 @@ pretty-format@30.3.0:
     ansi-styles "^5.2.0"
     react-is "^18.3.1"
 
-pretty-format@^26.4.2:
-  version "26.6.2"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
-  integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
-  dependencies:
-    "@jest/types" "^26.6.2"
-    ansi-regex "^5.0.0"
-    ansi-styles "^4.0.0"
-    react-is "^17.0.1"
-
 pretty-format@^29.0.0, pretty-format@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
@@ -7263,11 +7191,6 @@ randombytes@^2.1.0:
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
   dependencies:
     safe-buffer "^5.1.0"
-
-react-is@^17.0.1:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
-  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-is@^18.0.0, react-is@^18.3.1:
   version "18.3.1"


### PR DESCRIPTION
## Summary

- Replaces production widget CSS injection in `experiment.ts` from `<style>` element creation to constructable stylesheets adopted onto the customer document via `Document.adoptedStyleSheets`.
- Constructable stylesheets aren't gated by CSP `style-src`, so this fixes production widget rendering on customer pages with strict nonce/hash CSPs.
- Adds a duplicate of the `cspSafeStyleSheet` helper from the visual editor side (cross-reference comment in source ties the two copies together).
- Adds `construct-style-sheets-polyfill` as a devDependency for jest's jsdom 20 environment (jsdom 20 doesn't natively support constructable stylesheets).

## Companion changes

The visual editor side of this fix lives in an internal Amplitude repo. The same constructable-stylesheet swap is applied there to the editor's widget rendering paths. The two PRs together address the bug end-to-end: the internal one fixes the editor experience, this one fixes production widget rendering on the same customer pages.

## Tickets

- Internal tracking: WEB-6 (production SDK side, this PR).

## Backwards compatibility

- **Variant payload format unchanged.** Both old and new SDK read the same `action.data.css` string from the variant payload. No schema or format change.
- **Old widgets, new SDK:** the CSS string format is identical to what the old SDK consumed; constructable stylesheet adoption applies it to the same selector matches as the old `<style>`-element approach.
- **Edge case (rare):** constructable stylesheets reject `@import` rules per the CSSOM spec; the polyfill silently strips them. Customer widget CSS that uses `@import url('...')` would lose those imports. Real browsers behave the same way. Affected widgets would need to either inline the imported styles or use `<link rel=\"stylesheet\">` separately.
- **Edge case (very rare):** the previous code set `style.id = \"css-\${id}\"`. After this change, no `<style>` element exists in the customer DOM with that id. If any customer custom-JS in their inject action depended on `document.querySelector('#css-\${id}')` to read or mutate the widget's CSS (atypical pattern), that lookup will return null. Out-of-the-box widget templates don't do this.

## Test plan

- [x] Unit tests for `cspSafeStyleSheet` helper (7 new tests, all pass).
- [x] All existing experiment-tag tests pass (148/148).
- [x] Typecheck clean.
- [x] Lint clean (60 pre-existing warnings, 0 new).
- [x] SDK build succeeds.
- [ ] Post-merge: smoke-test a customer page with strict CSP and a published widget, confirm it renders styled (requires the new SDK release to ship and the customer's page to load it via dynamic script).

## Out of scope (intentionally)

- The 3 other `<style>` injection sites in this SDK (`anti-flicker.ts`, `preview/preview.ts`, `util/shell.ts`) — same issue, mechanical follow-up tracked internally as WEB-7.
- Older-browser fallback for browsers lacking `Document.adoptedStyleSheets`. Native support: Chrome 99+, Firefox 101+, Safari 16.4+ — three years of support across all modern browsers; SDK targets es2015 syntactically but customers running 4+ year old browsers are vanishingly rare.
- Squelching pre-existing `construct-style-sheets-polyfill` MutationObserver stderr noise during jsdom test teardown (cosmetic; doesn't fail tests).

## Release coordination

This change requires a new minor version of `@amplitude/experiment-tag` to ship to customer pages. The SDK is delivered via dynamic script with no customer pinning, so the fix propagates to customers on their next page load after the new version is published and CDN propagates (typically minutes).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production widget CSS injection from `<style>` tags to `adoptedStyleSheets`, which can affect how styles are applied/removed on customer pages (and depends on constructable stylesheet support). Scope is limited to inject-action CSS handling and is covered by new unit tests.
> 
> **Overview**
> Fixes widget rendering on strict CSP pages by switching inject-action CSS application from creating a `<style>` element to adopting a constructable stylesheet via `Document/ShadowRoot.adoptedStyleSheets`.
> 
> Adds a new `cspSafeStyleSheet` helper (with revert/reapply handles and iframe-realm-safe construction), wires it into `handleInject` cleanup, and updates Jest to load `construct-style-sheets-polyfill` with new unit tests for the helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e70fa58a3aaa48205ee81547a3e9070cd1c886e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->