### PR TITLE
fix: specify DEVICE_IFRAME_ID for iframe check

### DIFF
--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -50,7 +50,7 @@ import { getInjectUtils } from './util/inject-utils';
 import { hideLoadingIndicator } from './util/loading-indicator';
 import { VISUAL_EDITOR_SESSION_KEY, WindowMessenger } from './util/messenger';
 import { patchRemoveChild } from './util/patch';
-import { buildShell, isMobileModeActive } from './util/shell';
+import { DEVICE_IFRAME_ID, buildShell, isMobileModeActive } from './util/shell';
 import { installSpaLinkInterceptor } from './util/spa-link-interceptor';
 import {
   getStorageItem,
@@ -210,13 +210,18 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     installSpaLinkInterceptor();
     const urlParams = getUrlParams();
 
-    // When running inside an iframe (mobile shell), skip overlay loading and
-    // expose dom-mutator on the window so the overlay in the parent frame can
-    // apply and control mutations against this document.
-    if (
-      this.globalScope.self !== this.globalScope.top &&
-      isMobileModeActive()
-    ) {
+    // When running inside the mobile-shell iframe (i.e. the iframe that
+    // buildShell created on the parent page), skip overlay loading and expose
+    // dom-mutator on the window so the overlay in the parent frame can apply
+    // and control mutations against this document.
+    let isInsideDeviceIframe = false;
+    try {
+      isInsideDeviceIframe =
+        this.globalScope.frameElement?.id === DEVICE_IFRAME_ID;
+    } catch {
+      isInsideDeviceIframe = false;
+    }
+    if (isInsideDeviceIframe && isMobileModeActive()) {
       (this.globalScope as any).ampDomMutator = domMutatorExports;
       this.isRunning = true;
       return;

--- a/packages/experiment-tag/src/util/shell.ts
+++ b/packages/experiment-tag/src/util/shell.ts
@@ -1,5 +1,5 @@
 const MOBILE_MODE_SESSION_KEY = 'amp-visual-editor-mobile-mode';
-const DEVICE_IFRAME_ID = 'amp-device-iframe';
+export const DEVICE_IFRAME_ID = 'amp-device-iframe';
 const DEVICE_CONTAINER_ID = 'amp-overlay-device-iframe-container';
 const OVERLAY_HOST_ID = 'overlay-shadow-host';
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

Specifically check for `DEVICE_IFRAME_ID` instead of any generic iframe.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, small behavioral change limited to visual editor mobile-shell iframe detection; main risk is edge cases where `frameElement` access fails or iframe IDs differ, potentially affecting overlay initialization.
> 
> **Overview**
> Tightens the “running inside mobile shell iframe” detection in `DefaultWebExperimentClient.start()` to only trigger when the current frame’s `frameElement.id` matches `DEVICE_IFRAME_ID`, rather than any iframe.
> 
> Exports `DEVICE_IFRAME_ID` from `util/shell.ts` and uses it in the iframe check (with a `try/catch` guard), reducing accidental skip of overlay loading in unrelated iframe embeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a9c79e008d0ca9cbf4ed215257b39fbc98fb97f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->