### PR TITLE
fix(mutations): update dom-mutator version

### DIFF
--- a/packages/experiment-tag/package.json
+++ b/packages/experiment-tag/package.json
@@ -31,7 +31,7 @@
     "@amplitude/analytics-types": "^2.11.0",
     "@amplitude/experiment-core": "^0.13.1",
     "@amplitude/experiment-js-client": "^1.21.1",
-    "dom-mutator": "git+ssh://git@github.com/amplitude/dom-mutator#053784ca2ff34d127d779690e403340175b4692c",
+    "dom-mutator": "git+ssh://git@github.com/amplitude/dom-mutator#07a72dddbc2969ea826bdfe2b55d461d5d340992",
     "rollup-plugin-license": "^3.6.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3624,9 +3624,9 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-"dom-mutator@git+ssh://git@github.com/amplitude/dom-mutator#0294e723c6a8f85d448bdfa59999591f2ae9e476":
+"dom-mutator@git+ssh://git@github.com/amplitude/dom-mutator#07a72dddbc2969ea826bdfe2b55d461d5d340992":
   version "0.7.1"
-  resolved "git+ssh://git@github.com/amplitude/dom-mutator#0294e723c6a8f85d448bdfa59999591f2ae9e476"
+  resolved "git+ssh://git@github.com/amplitude/dom-mutator#07a72dddbc2969ea826bdfe2b55d461d5d340992"
 
 domexception@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

update dom-mutator version for fix
See https://github.com/amplitude/dom-mutator/pull/21

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump limited to `@amplitude/experiment-tag`; main risk is behavior changes inside `dom-mutator` affecting DOM mutation handling at runtime.
> 
> **Overview**
> Updates `@amplitude/experiment-tag` to use a newer git commit of `dom-mutator` and refreshes `yarn.lock` to match, pulling in the upstream fix referenced by the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ab617d87c0b35ffb0fd8b4d4d2e8a7e848ad786. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->