### PR TITLE
fix(experiment-tag): polish opener-severed modal copy and close affordance

### DIFF
--- a/packages/experiment-tag/src/util/opener-severed-banner.ts
+++ b/packages/experiment-tag/src/util/opener-severed-banner.ts
@@ -1,5 +1,4 @@
 const BANNER_ID = 'amp-exp-opener-severed';
-const AMPLITUDE_BRAND_COLOR = '#1e61f0';
 
 /**
  * Modal shown when `window.opener` is unreachable, so the visual editor
@@ -28,6 +27,20 @@ export const showOpenerSeveredBanner = () => {
         font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace !important;
       }
 
+      /* Defensive resets — host pages often style h2/h3/p with
+       * text-transform, letter-spacing, etc. that would otherwise leak in. */
+      #${BANNER_ID} h2,
+      #${BANNER_ID} h3,
+      #${BANNER_ID} p,
+      #${BANNER_ID} button,
+      #${BANNER_ID} code,
+      #${BANNER_ID} hr {
+        text-transform: none !important;
+        letter-spacing: normal !important;
+        text-decoration: none !important;
+        font-style: normal !important;
+      }
+
       #${BANNER_ID} {
         border: none;
         padding: 0;
@@ -43,13 +56,42 @@ export const showOpenerSeveredBanner = () => {
       }
 
       #${BANNER_ID} .modal {
+        position: relative;
         padding: 32px;
+      }
+
+      #${BANNER_ID} .close-icon {
+        position: absolute;
+        top: 16px;
+        right: 16px;
+        width: 28px;
+        height: 28px;
+        padding: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        background: transparent;
+        border: none;
+        border-radius: 6px;
+        color: #5a5e68;
+        cursor: pointer;
+      }
+
+      #${BANNER_ID} .close-icon:hover {
+        background: #f3f4f6;
+        color: #212124;
+      }
+
+      #${BANNER_ID} .close-icon svg {
+        width: 16px;
+        height: 16px;
       }
 
       #${BANNER_ID} .title {
         font-size: 18px;
         font-weight: 600;
         margin: 0 0 12px 0;
+        padding-right: 24px;
       }
 
       #${BANNER_ID} .body {
@@ -57,6 +99,19 @@ export const showOpenerSeveredBanner = () => {
         line-height: 1.5;
         margin: 0 0 12px 0;
         color: #5a5e68;
+      }
+
+      #${BANNER_ID} .divider {
+        border: none;
+        border-top: 1px solid #e5e7eb;
+        margin: 20px 0;
+      }
+
+      #${BANNER_ID} .subtitle {
+        font-size: 14px;
+        font-weight: 600;
+        margin: 0 0 8px 0;
+        color: #212124;
       }
 
       #${BANNER_ID} code {
@@ -70,30 +125,17 @@ export const showOpenerSeveredBanner = () => {
         display: flex;
         justify-content: flex-end;
         gap: 8px;
-        margin-top: 20px;
-      }
-
-      #${BANNER_ID} button {
-        font-size: 14px;
-        padding: 8px 16px;
-        border-radius: 6px;
-        border: 1px solid transparent;
-        cursor: pointer;
-      }
-
-      #${BANNER_ID} .primary {
-        background: ${AMPLITUDE_BRAND_COLOR};
-        color: white;
-      }
-
-      #${BANNER_ID} .primary:hover {
-        filter: brightness(0.95);
+        margin-top: 24px;
       }
 
       #${BANNER_ID} .secondary {
+        font-size: 14px;
+        padding: 8px 16px;
+        border-radius: 6px;
         background: white;
         color: #212124;
-        border-color: #d1d5db;
+        border: 1px solid #d1d5db;
+        cursor: pointer;
       }
 
       #${BANNER_ID} .secondary:hover {
@@ -102,17 +144,30 @@ export const showOpenerSeveredBanner = () => {
     </style>
 
     <div class="modal">
-      <h2 id="${BANNER_ID}-title" class="title">Visual Editor can't open on this page</h2>
+      <button
+        type="button"
+        class="close-icon"
+        data-action="close"
+        aria-label="Close"
+      >
+        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+          <path d="M3 3 L13 13 M13 3 L3 13" />
+        </svg>
+      </button>
+      <h2 id="${BANNER_ID}-title" class="title">Can't connect to this page</h2>
       <p class="body">
-        This page has been isolated from the window that opened it, so the
-        visual editor can't communicate with Amplitude here.
+        The Visual Editor lost its connection to this page and can't make
+        edits here. This is usually a configuration issue on the site.
+      </p>
+      <hr class="divider" />
+      <h3 class="subtitle">Technical Details</h3>
+      <p class="body">
+        This page sends a <code>Cross-Origin-Opener-Policy</code> header that
+        isolates it from the editor window. To resolve this:
       </p>
       <p class="body">
-        This is most often caused by a <code>Cross-Origin-Opener-Policy</code>
-        response header on this page. To use the visual editor, ask the site
-        owner to remove the header (or set it to <code>unsafe-none</code>) on
-        the pages you want to edit, or launch the editor on a staging build
-        that doesn't ship the header.
+        Remove the <code>Cross-Origin-Opener-Policy</code> header, or set its
+        value to <code>unsafe-none</code> on pages you want to edit.
       </p>
       <div class="actions">
         <button type="button" class="secondary" data-action="close">Close</button>
@@ -134,11 +189,13 @@ export const showOpenerSeveredBanner = () => {
 
     // TODO: switch to `command="close"` + `commandfor` once `last 5 firefox`
     // is entirely Firefox 144+ (when invoker commands shipped).
-    const closeButton = dialog.querySelector<HTMLButtonElement>(
+    const closeButtons = dialog.querySelectorAll<HTMLButtonElement>(
       'button[data-action="close"]',
     );
-    closeButton?.addEventListener('click', () => {
-      hideOpenerSeveredBanner();
+    closeButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        hideOpenerSeveredBanner();
+      });
     });
   };
 


### PR DESCRIPTION
### Summary

<img width="521" height="399" alt="Screenshot 2026-05-05 at 6 10 40 PM" src="https://github.com/user-attachments/assets/438a005c-470c-4c6b-b562-8ddf0a24ce91" /> 
Follow-up polish to the opener-severed dialog shipped in #310. The modal now reads more like a product surface and less like an engineering note, while the COOP-specific explanation is preserved for the technical reader.

- **Close affordance:** swap the blue primary CTA for a top-right icon close (X), keeping the bottom "Close" button as the explicit secondary action. Both affordances are wired up via `querySelectorAll` so either dismisses the modal.
- **Copy restructure:** title is now "Can't connect to this page" with a short, friendly summary. The `Cross-Origin-Opener-Policy` explanation moves below a divider under a "Technical Details" subheading so it's available without dominating the modal.
- **Defensive CSS resets:** add `text-transform`, `letter-spacing`, `text-decoration`, and `font-style` resets on `h2/h3/p/button/code/hr` inside `#amp-exp-opener-severed`. The modal renders directly in customer pages (no shadow DOM here, since the overlay can't load) and host pages frequently apply uppercase / wide tracking to headings; without these resets, the modal inherits them.

No behavioral changes: the modal is still triggered by the same `window.opener` severed check, still hidden by `hideOpenerSeveredBanner`, and the public API (`showOpenerSeveredBanner` / `hideOpenerSeveredBanner`) is unchanged.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/CSS and copy-only changes to the opener-severed dialog; behavior remains limited to showing/dismissing the modal when the opener channel is broken.
> 
> **Overview**
> Improves the `opener-severed` dialog shown when the Visual Editor can’t communicate via `window.opener`, updating the title/body copy and moving the COOP explanation under a **Technical Details** section with a divider.
> 
> Updates the dismissal UX by adding a top-right X close button and wiring *all* `data-action="close"` buttons via `querySelectorAll`, and hardens styling with defensive CSS resets to avoid host-page typography leaking into the modal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b6903c5bd8387daab8b26f813b1cd01cdafbf5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->