### PR TITLE
fix(experiment-tag): extend CSP-safe style injection to non-widget paths [WEB-7]

### DIFF
--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -42,7 +42,7 @@ import {
   BehavioralTargetingRules,
 } from './types';
 import type { AudienceEvaluationDebugInfo, DebugState } from './types/debug';
-import { applyAntiFlickerCss } from './util/anti-flicker';
+import { applyAntiFlickerCss, removeAntiFlickerCss } from './util/anti-flicker';
 import { enrichUserWithCampaignData } from './util/campaign';
 import { setMarketingCookie } from './util/cookie';
 import {
@@ -388,8 +388,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     this.updateUserWithBehaviors();
 
     if (!this.isRemoteBlocking) {
-      // Remove anti-flicker css if remote flags are not blocking
-      this.globalScope.document.getElementById?.('amp-exp-css')?.remove();
+      removeAntiFlickerCss();
     }
 
     // apply local variants

--- a/packages/experiment-tag/src/index.ts
+++ b/packages/experiment-tag/src/index.ts
@@ -5,7 +5,7 @@ import { DefaultWebExperimentClient } from './experiment';
 import { HttpClient } from './preview/http';
 import { SdkPreviewApi } from './preview/preview-api';
 import { InitConfigs, WebExperimentConfig } from './types';
-import { applyAntiFlickerCss } from './util/anti-flicker';
+import { applyAntiFlickerCss, removeAntiFlickerCss } from './util/anti-flicker';
 import { isPreviewMode } from './util/url';
 
 const eventBuffer: Array<{
@@ -57,8 +57,7 @@ export const initialize = (
         startClient(apiKey, initConfigs, config);
       })
       .finally(() => {
-        // Remove anti-flicker css if it exists
-        document.getElementById('amp-exp-css')?.remove();
+        removeAntiFlickerCss();
       });
   } else {
     startClient(apiKey, initConfigs, config);
@@ -73,8 +72,7 @@ const startClient = (
   DefaultWebExperimentClient.getInstance(apiKey, initConfigs, config)
     .start()
     .finally(() => {
-      // Remove anti-flicker css if it exists
-      document.getElementById('amp-exp-css')?.remove();
+      removeAntiFlickerCss();
     });
 };
 

--- a/packages/experiment-tag/src/preview/preview.ts
+++ b/packages/experiment-tag/src/preview/preview.ts
@@ -2,6 +2,13 @@
  * Lightweight floating dismissable modal for experiment preview mode
  */
 
+import {
+  cspSafeStyleSheet,
+  type StyleSheetHandle,
+} from '../util/csp-safe-stylesheet';
+
+let modalStylesHandle: StyleSheetHandle | undefined;
+
 interface PreviewModeModalOptions {
   flags: Record<string, string>;
   onDismiss?: () => void;
@@ -113,13 +120,11 @@ export class PreviewModeModal {
   }
 
   private injectStyles(): void {
-    if (document.getElementById('amp-preview-modal-styles')) {
+    if (modalStylesHandle) {
       return;
     }
 
-    const style = document.createElement('style');
-    style.id = 'amp-preview-modal-styles';
-    style.textContent = `
+    const css = `
       .amp-preview-modal {
         position: fixed;
         top: 20px;
@@ -311,7 +316,7 @@ export class PreviewModeModal {
       }
     `;
 
-    document.head.appendChild(style);
+    modalStylesHandle = cspSafeStyleSheet(document, css);
   }
 }
 

--- a/packages/experiment-tag/src/util/anti-flicker.ts
+++ b/packages/experiment-tag/src/util/anti-flicker.ts
@@ -1,16 +1,39 @@
 import { getGlobalScope } from '@amplitude/experiment-core';
 
+import {
+  cspSafeStyleSheet,
+  type StyleSheetHandle,
+} from './csp-safe-stylesheet';
+
+const ANTI_FLICKER_CSS =
+  '* { visibility: hidden !important; background-image: none !important; }';
+const TIMEOUT_MS = 1000;
+
+let activeHandle: StyleSheetHandle | undefined;
+
+/**
+ * Adopt the anti-flicker stylesheet onto the document via a constructable
+ * stylesheet (CSP-safe; works on strict style-src customer pages). Idempotent —
+ * a second call before removal / timeout is a no-op. Auto-reverts after 1s as
+ * a safety net in case the consumer never calls removeAntiFlickerCss.
+ */
 export const applyAntiFlickerCss = () => {
+  if (activeHandle) return;
   const globalScope = getGlobalScope();
-  if (!globalScope?.document.getElementById('amp-exp-css')) {
-    const id = 'amp-exp-css';
-    const s = document.createElement('style');
-    s.id = id;
-    s.innerText =
-      '* { visibility: hidden !important; background-image: none !important; }';
-    document.head.appendChild(s);
-    globalScope?.window.setTimeout(function () {
-      s.remove();
-    }, 1000);
-  }
+  const targetDoc = globalScope?.document ?? document;
+
+  activeHandle = cspSafeStyleSheet(targetDoc, ANTI_FLICKER_CSS);
+
+  globalScope?.window.setTimeout(() => {
+    removeAntiFlickerCss();
+  }, TIMEOUT_MS);
+};
+
+/**
+ * Revert the anti-flicker stylesheet immediately. Idempotent — safe to call
+ * even when no sheet is active.
+ */
+export const removeAntiFlickerCss = (): void => {
+  activeHandle?.revert();
+  activeHandle = undefined;
 };

--- a/packages/experiment-tag/src/util/anti-flicker.ts
+++ b/packages/experiment-tag/src/util/anti-flicker.ts
@@ -22,10 +22,16 @@ export const applyAntiFlickerCss = () => {
   const globalScope = getGlobalScope();
   const targetDoc = globalScope?.document ?? document;
 
-  activeHandle = cspSafeStyleSheet(targetDoc, ANTI_FLICKER_CSS);
+  const handle = cspSafeStyleSheet(targetDoc, ANTI_FLICKER_CSS);
+  activeHandle = handle;
 
   globalScope?.window.setTimeout(() => {
-    removeAntiFlickerCss();
+    // Capture-by-identity: only revert if the handle we scheduled for is still
+    // active. Without this guard, an apply→remove→apply within TIMEOUT_MS
+    // would let the first timeout prematurely revert the second apply.
+    if (activeHandle === handle) {
+      removeAntiFlickerCss();
+    }
   }, TIMEOUT_MS);
 };
 

--- a/packages/experiment-tag/src/util/shell.ts
+++ b/packages/experiment-tag/src/util/shell.ts
@@ -1,3 +1,5 @@
+import { cspSafeStyleSheet } from './csp-safe-stylesheet';
+
 const MOBILE_MODE_SESSION_KEY = 'amp-visual-editor-mobile-mode';
 export const DEVICE_IFRAME_ID = 'amp-device-iframe';
 const DEVICE_CONTAINER_ID = 'amp-overlay-device-iframe-container';
@@ -112,15 +114,14 @@ export function buildShell(globalScope: typeof globalThis): Promise<void> {
   const doc = globalScope.document;
 
   const run = () => {
-    // Inject a CSS rule that hides any direct children of <body> except the
-    // device-iframe container and the overlay host. This prevents third-party
-    // scripts from rendering visible elements in the shell.
-    const shellGuard = doc.createElement('style');
-    shellGuard.setAttribute('data-amp-shell-guard', '');
-    shellGuard.textContent =
-      `body > *:not(#${DEVICE_CONTAINER_ID}):not(#${OVERLAY_HOST_ID}) ` +
-      `{ display: none !important; }`;
-    doc.head.appendChild(shellGuard);
+    // Adopt a CSS rule that hides any direct children of <body> except the
+    // device-iframe container and the overlay host. CSP-safe via constructable
+    // stylesheet — the inline <style> form would be blocked on customer pages
+    // with strict style-src CSPs.
+    cspSafeStyleSheet(
+      doc,
+      `body > *:not(#${DEVICE_CONTAINER_ID}):not(#${OVERLAY_HOST_ID}) { display: none !important; }`,
+    );
 
     while (doc.body.firstChild) {
       doc.body.removeChild(doc.body.firstChild);

--- a/packages/experiment-tag/test/preview/preview.test.ts
+++ b/packages/experiment-tag/test/preview/preview.test.ts
@@ -1,0 +1,57 @@
+describe('PreviewModeModal style injection', () => {
+  beforeEach(() => {
+    // Clear adoptedStyleSheets BEFORE wiping head.innerHTML — the
+    // construct-style-sheets-polyfill tracks the <style> nodes it injected
+    // into <head> and throws if we remove them out from under it before
+    // resetting the adopted list.
+    document.adoptedStyleSheets = [];
+    document.body.innerHTML = '';
+    document.head.innerHTML = '';
+    jest.resetModules();
+  });
+
+  /**
+   * The module-level `modalStylesHandle` in preview.ts persists across tests
+   * in this file. Use jest.isolateModulesAsync to give each test a fresh
+   * module instance so cross-test pollution doesn't make idempotency look
+   * broken (or pass spuriously).
+   */
+  const loadFreshPreview = async () => {
+    let mod: typeof import('../../src/preview/preview');
+    await jest.isolateModulesAsync(async () => {
+      mod = await import('../../src/preview/preview');
+    });
+    return mod!;
+  };
+
+  it('show() adopts a constructable stylesheet onto the document', async () => {
+    const { PreviewModeModal } = await loadFreshPreview();
+    new PreviewModeModal({ flags: { 'flag-1': 'A' } }).show();
+
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+    expect(document.adoptedStyleSheets[0]).toBeInstanceOf(CSSStyleSheet);
+  });
+
+  it('a second instance does not double-adopt the stylesheet', async () => {
+    const { PreviewModeModal } = await loadFreshPreview();
+    new PreviewModeModal({ flags: { 'flag-1': 'A' } }).show();
+    new PreviewModeModal({ flags: { 'flag-2': 'B' } }).show();
+
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+  });
+
+  it('hide() does not revert the stylesheet (matches pre-refactor behavior)', async () => {
+    // injectStyles() runs synchronously inside createModal(), so the sheet is
+    // adopted before requestAnimationFrame appends the modal to the body.
+    // We assert against adopted sheets only — not against the modal element —
+    // so we don't have to flush the rAF in jsdom.
+    const { PreviewModeModal } = await loadFreshPreview();
+    const modal = new PreviewModeModal({ flags: { 'flag-1': 'A' } });
+    modal.show();
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+
+    modal.hide();
+
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+  });
+});

--- a/packages/experiment-tag/test/util/anti-flicker.test.ts
+++ b/packages/experiment-tag/test/util/anti-flicker.test.ts
@@ -1,0 +1,70 @@
+import { getGlobalScope } from '@amplitude/experiment-core';
+
+import {
+  applyAntiFlickerCss,
+  removeAntiFlickerCss,
+} from '../../src/util/anti-flicker';
+
+jest.mock('@amplitude/experiment-core', () => ({
+  ...jest.requireActual('@amplitude/experiment-core'),
+  getGlobalScope: jest.fn(),
+}));
+
+describe('applyAntiFlickerCss / removeAntiFlickerCss', () => {
+  beforeEach(() => {
+    document.adoptedStyleSheets = [];
+    removeAntiFlickerCss();
+    (getGlobalScope as jest.Mock).mockReturnValue(window);
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    removeAntiFlickerCss();
+  });
+
+  it('adopts a constructable stylesheet on the document', () => {
+    applyAntiFlickerCss();
+
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+    expect(document.adoptedStyleSheets[0]).toBeInstanceOf(CSSStyleSheet);
+  });
+
+  it('is idempotent — second apply within the timeout window does not double-adopt', () => {
+    applyAntiFlickerCss();
+    applyAntiFlickerCss();
+
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+  });
+
+  it('reverts the sheet automatically after 1000ms', () => {
+    applyAntiFlickerCss();
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+
+    jest.advanceTimersByTime(1000);
+
+    expect(document.adoptedStyleSheets).toHaveLength(0);
+  });
+
+  it('removeAntiFlickerCss reverts the sheet immediately', () => {
+    applyAntiFlickerCss();
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+
+    removeAntiFlickerCss();
+
+    expect(document.adoptedStyleSheets).toHaveLength(0);
+  });
+
+  it('removeAntiFlickerCss is a no-op when nothing was applied', () => {
+    expect(() => removeAntiFlickerCss()).not.toThrow();
+    expect(document.adoptedStyleSheets).toHaveLength(0);
+  });
+
+  it('apply after remove re-adopts (next-init scenario)', () => {
+    applyAntiFlickerCss();
+    removeAntiFlickerCss();
+    applyAntiFlickerCss();
+
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+  });
+});

--- a/packages/experiment-tag/test/util/anti-flicker.test.ts
+++ b/packages/experiment-tag/test/util/anti-flicker.test.ts
@@ -67,4 +67,28 @@ describe('applyAntiFlickerCss / removeAntiFlickerCss', () => {
 
     expect(document.adoptedStyleSheets).toHaveLength(1);
   });
+
+  it('safety-net timeout from a previous apply does not revert a later apply', () => {
+    // T=0: first apply, schedules timeout for T=1000
+    applyAntiFlickerCss();
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+
+    // T=200: cleanup arrives early
+    jest.advanceTimersByTime(200);
+    removeAntiFlickerCss();
+    expect(document.adoptedStyleSheets).toHaveLength(0);
+
+    // T=300: second apply, schedules its own timeout for T=1300
+    jest.advanceTimersByTime(100);
+    applyAntiFlickerCss();
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+
+    // T=1000: first timeout fires. It must NOT revert the second apply.
+    jest.advanceTimersByTime(700);
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+
+    // T=1300: second timeout fires. Now the second apply gets cleaned up.
+    jest.advanceTimersByTime(300);
+    expect(document.adoptedStyleSheets).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary
- Extends WEB-6's `cspSafeStyleSheet` helper to the 3 remaining non-widget `<style>`-element injection sites in `experiment-tag` (anti-flicker, preview-mode modal, visual-editor mobile-mode shell guard).
- All sites now adopt their CSS via `Document.adoptedStyleSheets` instead of creating `<style>` elements, so they pass strict-CSP `style-src` directives (e.g. Fathom Video).
- Anti-flicker introduces a paired `removeAntiFlickerCss()` API. The previous external callers (in `index.ts` and `experiment.ts`) used `getElementById('amp-exp-css')?.remove()` to clean up — that pattern can't query a constructable sheet, so they now call `removeAntiFlickerCss()` instead.
- Preview-modal swaps the DOM-based idempotency check (`getElementById('amp-preview-modal-styles')`) for a module-level handle. Semantically identical: only the first instance ever adopts; subsequent instances no-op.
- Shell guard drops the `data-amp-shell-guard` attribute marker (it was unused outside its own assignment).

## Out of scope
- Overlay-side non-widget injection sites (highlight styles, color picker, toast, shrinkwrap) ship in a separate PR against the `amplitude/javascript` repo — same WEB-7 ticket, different repo.

## Tickets
- WEB-7

## Test plan
- [x] Unit tests for `applyAntiFlickerCss` / `removeAntiFlickerCss` (adopt + revert lifecycle, idempotency, setTimeout safety net, external remove, re-adopt after remove)
- [x] Unit tests for `PreviewModeModal.injectStyles` (adopt-once-globally, second-instance no-op, hide() doesn't revert)
- [x] All existing experiment-tag tests pass (157/157, including the `applyAntiFlickerCss` spy in `experiment.test.ts`)
- [x] Manual smoke: constructable-sheet adoption verified to actually paint the page invisible (via local test page)
- [ ] After merge + release: smoke a Fathom-class CSP customer page with the new SDK in preview mode + mobile-mode visual editor — anti-flicker should briefly hide the page without a \`Refused to apply inline style…\` warning; shell guard and preview modal should render without CSP errors.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how critical page-hiding and editor/preview UI CSS is injected and removed; mistakes could leave pages hidden or preview/editor UI unstyled under certain timing/CSP conditions.
> 
> **Overview**
> Switches the remaining non-widget CSS injection points to `cspSafeStyleSheet` (constructable `adoptedStyleSheets`) so they work under strict `style-src` CSP.
> 
> `anti-flicker` is refactored to be idempotent, CSP-safe, and to expose `removeAntiFlickerCss()`; call sites in `index.ts` and `experiment.ts` now use this API instead of removing `#amp-exp-css`.
> 
> The preview-mode modal now tracks a module-level stylesheet handle for “inject once” behavior, and the visual-editor mobile shell guard CSS is injected via `cspSafeStyleSheet` instead of an inline `<style>` element. Adds unit tests covering constructable stylesheet adoption/removal and idempotency for both anti-flicker and the preview modal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3005e0f9c77a8ddcf5fc9b14c1fe047bfad6ca2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->