### PR TITLE
fix(experiment-tag): defer history API url change handler to avoid mid-navigation DOM mutations

### DIFF
--- a/packages/experiment-tag/src/subscriptions/subscriptions.ts
+++ b/packages/experiment-tag/src/subscriptions/subscriptions.ts
@@ -855,8 +855,13 @@ export class SubscriptionManager {
       history.pushState = function (...args) {
         // Call the original pushState
         const result = originalPushState.apply(this, args);
-        // Revert mutations and apply variants
-        handleUrlChange();
+        // Defer experiment re-evaluation so the calling navigation framework
+        // (e.g. Angular, Vue, MFE routers) can finish its own synchronous
+        // navigation cycle before we apply DOM mutations. Running synchronously
+        // inside pushState interleaves with framework rendering and can corrupt
+        // component bindings (e.g. Angular async pipe receiving non-Observable
+        // values).
+        setTimeout(handleUrlChange, 0);
         return result;
       };
 
@@ -864,8 +869,7 @@ export class SubscriptionManager {
       history.replaceState = function (...args) {
         // Call the original replaceState
         const result = originalReplaceState.apply(this, args);
-        // Revert mutations and apply variants
-        handleUrlChange();
+        setTimeout(handleUrlChange, 0);
         return result;
       };
     };


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

The SDK wraps `history.pushState` and `history.replaceState` to detect SPA navigations and re-evaluate experiments. Previously the `handleUrlChange()` callback — which runs `applyVariants()` and applies DOM mutations via `dom-mutator` — was called **synchronously** inside those wrappers.

This meant DOM mutations fired mid-navigation, before the calling framework (e.g. Angular, Vue, or any microfrontend router) had finished its own navigation cycle. In Angular specifically, this interleaved with component initialization: mutations ran while bindings were still being set up, causing the `async` pipe to receive a non-Observable value and throw:

> `You provided an invalid object where a stream was expected.`

**Fix:** replace the synchronous call with `setTimeout(handleUrlChange, 0)`, deferring experiment re-evaluation to the next event loop task. By that point the framework's navigation cycle — guards, resolvers, component creation — has fully completed and DOM bindings are stable.

**Tradeoff:** experiment mutations on SPA navigations apply ~1 event loop tick later than before. Anti-flicker on initial page load is unaffected (handled separately).

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core SPA navigation instrumentation for all customers using the default handler; timing shift is small but could affect race-sensitive UIs, while fixing real framework breakage.
> 
> **Overview**
> **Defers SPA experiment re-application** when navigation uses `history.pushState` or `history.replaceState`: `handleUrlChange()` (which publishes `url_change` and drives variant re-apply / DOM mutations) now runs via `setTimeout(..., 0)` instead of synchronously inside the history wrappers.
> 
> That lets the host router/framework finish its navigation/render pass before the SDK mutates the DOM, avoiding interleaved updates that broke Angular bindings (e.g. `async` pipe errors). **`popstate` handling is unchanged** (still immediate). Experiment updates on programmatic navigations may land **one macrotask later**; initial-load anti-flicker paths are outside this hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af1a0935a9ff949a2d9c8db6098bd079d5c9d9d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->