### PR TITLE
fix: include impression data in url as fallback for cross-subdomain redirect

### DIFF
--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -53,10 +53,7 @@ import { VISUAL_EDITOR_SESSION_KEY, WindowMessenger } from './util/messenger';
 import { patchRemoveChild } from './util/patch';
 import { DEVICE_IFRAME_ID, buildShell, isMobileModeActive } from './util/shell';
 import { installSpaLinkInterceptor } from './util/spa-link-interceptor';
-import {
-  getStorageItem,
-  setStorageItem,
-} from './util/storage';
+import { getStorageItem, setStorageItem } from './util/storage';
 import {
   getUrlParams,
   removeQueryParams,

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -903,7 +903,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       redirectUrl,
     );
 
-    if (this.config.encodeRedirectInUrl) {
+    if (this.config.redirectConfig?.encodeRedirectInUrl) {
       // Embed impression data in redirect URL for cross-domain and
       // cookie-blocked environments. Merge with any existing param in case
       // multiple redirect experiments fire in sequence.
@@ -1207,7 +1207,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
 
     // Read URL param impressions (highest priority)
     let urlImpressions: Record<string, StoredRedirectImpression> = {};
-    if (this.config.encodeRedirectInUrl) {
+    if (this.config.redirectConfig?.encodeRedirectInUrl) {
       const urlParams = getUrlParams();
       const encoded = urlParams[REDIRECT_IMPRESSION_PARAM];
       if (encoded) {

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -1182,7 +1182,9 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
         return;
       }
 
-      const storage = new CookieStorage<Record<string, StoredRedirectImpression>>({
+      const storage = new CookieStorage<
+        Record<string, StoredRedirectImpression>
+      >({
         domain: redirectDomain,
         sameSite: 'Lax',
         expirationDays: 1 / 1440, // 1 minute
@@ -1235,9 +1237,13 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
 
     // Read cookie impressions (lowest priority) when opted in
     let cookieImpressions: Record<string, StoredRedirectImpression> = {};
-    let cookieStorage: CookieStorage<Record<string, StoredRedirectImpression>> | undefined;
+    let cookieStorage:
+      | CookieStorage<Record<string, StoredRedirectImpression>>
+      | undefined;
     if (this.config.redirectConfig?.encodeRedirectInCookie) {
-      cookieStorage = new CookieStorage<Record<string, StoredRedirectImpression>>({
+      cookieStorage = new CookieStorage<
+        Record<string, StoredRedirectImpression>
+      >({
         domain: getCookieDomain(this.globalScope.location.href),
         sameSite: 'Lax',
       });
@@ -1262,12 +1268,18 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       return;
     }
 
-    const currentUrl = urlWithoutParamsAndAnchor(this.globalScope.location.href);
+    const currentUrl = urlWithoutParamsAndAnchor(
+      this.globalScope.location.href,
+    );
 
     for (const flagKey in merged) {
       const { redirectUrl, variantKey, expKey, metadata } = merged[flagKey];
       if (matchesUrl([currentUrl], urlWithoutParamsAndAnchor(redirectUrl))) {
-        this.exposureWithDedupe(flagKey, { key: variantKey, expKey, metadata }, true);
+        this.exposureWithDedupe(
+          flagKey,
+          { key: variantKey, expKey, metadata },
+          true,
+        );
         delete merged[flagKey];
       }
     }
@@ -1288,7 +1300,11 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       this.globalScope.setTimeout(async () => {
         for (const flagKey in merged) {
           const { variantKey, expKey, metadata } = merged[flagKey];
-          this.exposureWithDedupe(flagKey, { key: variantKey, expKey, metadata }, true);
+          this.exposureWithDedupe(
+            flagKey,
+            { key: variantKey, expKey, metadata },
+            true,
+          );
         }
         await cleanup();
       }, 500);

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -872,29 +872,34 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       redirectUrl,
     );
 
-    // Embed impression data in redirect URL for cross-domain and cookie-blocked environments.
-    // Merge with any existing param in case multiple redirect experiments fire in sequence.
-    const targetUrlObj = new URL(targetUrl);
-    let urlPayload: Record<string, StoredRedirectImpression> = {};
-    const existingEncoded = targetUrlObj.searchParams.get(
-      REDIRECT_IMPRESSION_PARAM,
-    );
-    if (existingEncoded) {
-      try {
-        urlPayload = JSON.parse(atob(existingEncoded));
-      } catch {} // eslint-disable-line no-empty
+    if (this.config.storeRedirectDataInUrlParam) {
+      // Embed impression data in redirect URL for cross-domain and
+      // cookie-blocked environments. Merge with any existing param in case
+      // multiple redirect experiments fire in sequence.
+      const targetUrlObj = new URL(targetUrl);
+      let urlPayload: Record<string, StoredRedirectImpression> = {};
+      const existingEncoded = targetUrlObj.searchParams.get(
+        REDIRECT_IMPRESSION_PARAM,
+      );
+      if (existingEncoded) {
+        try {
+          urlPayload = JSON.parse(atob(existingEncoded));
+        } catch {} // eslint-disable-line no-empty
+      }
+      urlPayload[flagKey] = {
+        redirectUrl,
+        variantKey: variant.key || '',
+        ...(variant.expKey !== undefined ? { expKey: variant.expKey } : {}),
+        ...(variant.metadata !== undefined
+          ? { metadata: variant.metadata }
+          : {}),
+      };
+      targetUrlObj.searchParams.set(
+        REDIRECT_IMPRESSION_PARAM,
+        btoa(JSON.stringify(urlPayload)),
+      );
+      targetUrl = targetUrlObj.toString();
     }
-    urlPayload[flagKey] = {
-      redirectUrl,
-      variantKey: variant.key || '',
-      ...(variant.expKey !== undefined ? { expKey: variant.expKey } : {}),
-      ...(variant.metadata !== undefined ? { metadata: variant.metadata } : {}),
-    };
-    targetUrlObj.searchParams.set(
-      REDIRECT_IMPRESSION_PARAM,
-      btoa(JSON.stringify(urlPayload)),
-    );
-    targetUrl = targetUrlObj.toString();
 
     // set previous url - relevant for SPA if redirect happens before push/replaceState is complete
     this.previousUrl = this.globalScope.location.href;
@@ -1161,21 +1166,22 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
   }
 
   private async fireStoredRedirectImpressions() {
-    // Read URL param and strip it from the URL immediately.
-    const urlParams = getUrlParams();
     let urlImpressions: Record<string, StoredRedirectImpression> = {};
-    const encoded = urlParams[REDIRECT_IMPRESSION_PARAM];
-    if (encoded) {
-      try {
-        urlImpressions = JSON.parse(atob(encoded));
-      } catch {} // eslint-disable-line no-empty
-      this.globalScope.history.replaceState(
-        {},
-        '',
-        removeQueryParams(this.globalScope.location.href, [
-          REDIRECT_IMPRESSION_PARAM,
-        ]),
-      );
+    if (this.config.storeRedirectDataInUrlParam) {
+      const urlParams = getUrlParams();
+      const encoded = urlParams[REDIRECT_IMPRESSION_PARAM];
+      if (encoded) {
+        try {
+          urlImpressions = JSON.parse(atob(encoded));
+        } catch {} // eslint-disable-line no-empty
+        this.globalScope.history.replaceState(
+          {},
+          '',
+          removeQueryParams(this.globalScope.location.href, [
+            REDIRECT_IMPRESSION_PARAM,
+          ]),
+        );
+      }
     }
 
     const storage = new CookieStorage<Record<string, StoredRedirectImpression>>(

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -915,7 +915,9 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       if (existingEncoded) {
         try {
           urlPayload = JSON.parse(atob(existingEncoded));
-        } catch {} // eslint-disable-line no-empty
+        } catch (error) {
+          console.error('Failed to decode existing AMP_REDIRECT param:', error);
+        }
       }
       urlPayload[flagKey] = {
         redirectUrl,

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -77,6 +77,14 @@ const REDIRECT_ACTION = 'redirect';
 export const PREVIEW_MODE_PARAM = 'PREVIEW';
 export const PREVIEW_MODE_SESSION_KEY = 'amp-preview-mode';
 const VISUAL_EDITOR_PARAM = 'VISUAL_EDITOR';
+const REDIRECT_IMPRESSION_PARAM = 'AMP_REDIRECT';
+
+type StoredRedirectImpression = {
+  redirectUrl: string;
+  variantKey: string;
+  expKey?: string;
+  metadata?: Record<string, unknown>;
+};
 
 safeGlobal.Experiment = FeatureExperiment;
 
@@ -847,7 +855,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       return;
     }
 
-    const targetUrl = concatenateQueryParamsOf(
+    let targetUrl = concatenateQueryParamsOf(
       this.globalScope.location.href,
       redirectUrl,
     );
@@ -863,6 +871,30 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       currentDomain,
       redirectUrl,
     );
+
+    // Embed impression data in redirect URL for cross-domain and cookie-blocked environments.
+    // Merge with any existing param in case multiple redirect experiments fire in sequence.
+    const targetUrlObj = new URL(targetUrl);
+    let urlPayload: Record<string, StoredRedirectImpression> = {};
+    const existingEncoded = targetUrlObj.searchParams.get(
+      REDIRECT_IMPRESSION_PARAM,
+    );
+    if (existingEncoded) {
+      try {
+        urlPayload = JSON.parse(atob(existingEncoded));
+      } catch {} // eslint-disable-line no-empty
+    }
+    urlPayload[flagKey] = {
+      redirectUrl,
+      variantKey: variant.key || '',
+      ...(variant.expKey !== undefined ? { expKey: variant.expKey } : {}),
+      ...(variant.metadata !== undefined ? { metadata: variant.metadata } : {}),
+    };
+    targetUrlObj.searchParams.set(
+      REDIRECT_IMPRESSION_PARAM,
+      btoa(JSON.stringify(urlPayload)),
+    );
+    targetUrl = targetUrlObj.toString();
 
     // set previous url - relevant for SPA if redirect happens before push/replaceState is complete
     this.previousUrl = this.globalScope.location.href;
@@ -1097,20 +1129,27 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       return;
     }
 
-    const storage = new CookieStorage<
-      Record<string, { redirectUrl: string; variant: Variant }>
-    >({
-      domain: redirectDomain,
-      sameSite: 'Lax',
-      expirationDays: 1 / 1440, // 1 minute
-    });
+    const storage = new CookieStorage<Record<string, StoredRedirectImpression>>(
+      {
+        domain: redirectDomain,
+        sameSite: 'Lax',
+        expirationDays: 1 / 1440, // 1 minute
+      },
+    );
 
     const storageKey = `EXP_${this.apiKey.slice(0, 10)}_REDIRECT`;
     return storage
       .get(storageKey)
       .then((storedRedirects) => {
         const redirects = storedRedirects || {};
-        redirects[flagKey] = { redirectUrl, variant };
+        redirects[flagKey] = {
+          redirectUrl,
+          variantKey: variant.key || '',
+          ...(variant.expKey !== undefined ? { expKey: variant.expKey } : {}),
+          ...(variant.metadata !== undefined
+            ? { metadata: variant.metadata }
+            : {}),
+        };
         storage.set(storageKey, redirects).catch();
       })
       .catch((error) => {
@@ -1122,18 +1161,43 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
   }
 
   private async fireStoredRedirectImpressions() {
-    const storage = new CookieStorage<
-      Record<string, { redirectUrl: string; variant: Variant }>
-    >({
-      domain: getCookieDomain(this.globalScope.location.href),
-      sameSite: 'Lax',
-    });
+    // Read URL param and strip it from the URL immediately.
+    const urlParams = getUrlParams();
+    let urlImpressions: Record<string, StoredRedirectImpression> = {};
+    const encoded = urlParams[REDIRECT_IMPRESSION_PARAM];
+    if (encoded) {
+      try {
+        urlImpressions = JSON.parse(atob(encoded));
+      } catch {} // eslint-disable-line no-empty
+      this.globalScope.history.replaceState(
+        {},
+        '',
+        removeQueryParams(this.globalScope.location.href, [
+          REDIRECT_IMPRESSION_PARAM,
+        ]),
+      );
+    }
+
+    const storage = new CookieStorage<Record<string, StoredRedirectImpression>>(
+      {
+        domain: getCookieDomain(this.globalScope.location.href),
+        sameSite: 'Lax',
+      },
+    );
 
     const storageKey = `EXP_${this.apiKey.slice(0, 10)}_REDIRECT`;
 
     try {
-      const storedRedirects = (await storage.get(storageKey)) || {};
-      if (Object.keys(storedRedirects).length === 0) {
+      const cookieImpressions = (await storage.get(storageKey)) || {};
+
+      // Union cookie and URL param; URL param wins on collision since it was
+      // embedded at redirect time and directly reflects the served variant.
+      const merged: Record<string, StoredRedirectImpression> = {
+        ...cookieImpressions,
+        ...urlImpressions,
+      };
+
+      if (Object.keys(merged).length === 0) {
         return;
       }
 
@@ -1141,28 +1205,26 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
         this.globalScope.location.href,
       );
 
-      // Track exposures for redirects that match current URL
-      for (const flagKey in storedRedirects) {
-        const { redirectUrl, variant } = storedRedirects[flagKey];
+      // Fire impressions for entries matching the current URL.
+      for (const flagKey in merged) {
+        const { redirectUrl, variantKey, expKey, metadata } = merged[flagKey];
         const strippedRedirectUrl = urlWithoutParamsAndAnchor(redirectUrl);
 
         if (matchesUrl([currentUrl], strippedRedirectUrl)) {
+          const variant: Variant = { key: variantKey, expKey, metadata };
           this.exposureWithDedupe(flagKey, variant, true);
-          delete storedRedirects[flagKey];
+          delete merged[flagKey];
         }
       }
 
-      // Track remaining redirects after timeout, then cleanup
-      if (Object.keys(storedRedirects).length > 0) {
+      // Fire remaining unmatched entries after timeout, then cleanup cookie.
+      if (Object.keys(merged).length > 0) {
         this.globalScope.setTimeout(async () => {
           try {
-            const redirects = (await storage.get(storageKey)) || {};
-            for (const flagKey in redirects) {
-              this.exposureWithDedupe(
-                flagKey,
-                redirects[flagKey].variant,
-                true,
-              );
+            for (const flagKey in merged) {
+              const { variantKey, expKey, metadata } = merged[flagKey];
+              const variant: Variant = { key: variantKey, expKey, metadata };
+              this.exposureWithDedupe(flagKey, variant, true);
             }
             await storage.remove(storageKey);
           } catch (error) {

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -56,7 +56,6 @@ import { installSpaLinkInterceptor } from './util/spa-link-interceptor';
 import {
   getStorageItem,
   setStorageItem,
-  removeStorageItem,
 } from './util/storage';
 import {
   getUrlParams,

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -868,7 +868,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       redirectUrl,
     );
 
-    if (this.config.storeRedirectDataInUrlParam) {
+    if (this.config.encodeRedirectInUrl) {
       // Embed impression data in redirect URL for cross-domain and
       // cookie-blocked environments. Merge with any existing param in case
       // multiple redirect experiments fire in sequence.
@@ -1163,7 +1163,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
 
   private async fireStoredRedirectImpressions() {
     let urlImpressions: Record<string, StoredRedirectImpression> = {};
-    if (this.config.storeRedirectDataInUrlParam) {
+    if (this.config.encodeRedirectInUrl) {
       const urlParams = getUrlParams();
       const encoded = urlParams[REDIRECT_IMPRESSION_PARAM];
       if (encoded) {

--- a/packages/experiment-tag/src/types.ts
+++ b/packages/experiment-tag/src/types.ts
@@ -117,7 +117,7 @@ export interface WebExperimentConfig extends ExperimentConfig {
   /**
    * When true, redirect experiment impression data is encoded as a query
    * parameter (AMP_REDIRECT) on the redirect destination URL. This enables impression tracking in cross-domain
-   redirect scenarios and in environments where cookies are blocked.
+   * redirect scenarios and in environments where cookies are blocked.
    */
   storeRedirectDataInUrlParam?: boolean;
 }

--- a/packages/experiment-tag/src/types.ts
+++ b/packages/experiment-tag/src/types.ts
@@ -114,6 +114,12 @@ export interface WebExperimentConfig extends ExperimentConfig {
    * 2. Custom handling of navigation {@link setRedirectHandler} should be implemented such that variant actions applied on the site reflect the latest context
    */
   useDefaultNavigationHandler?: boolean;
+  /**
+   * When true, redirect experiment impression data is encoded as a query
+   * parameter (AMP_REDIRECT) on the redirect destination URL. This enables impression tracking in cross-domain
+   redirect scenarios and in environments where cookies are blocked.
+   */
+  storeRedirectDataInUrlParam?: boolean;
 }
 
 export const Defaults: WebExperimentConfig = {

--- a/packages/experiment-tag/src/types.ts
+++ b/packages/experiment-tag/src/types.ts
@@ -109,10 +109,16 @@ export type BehavioralTargetingRules = {
 export interface RedirectConfig {
   /**
    * When true, redirect impression data is stored in a cookie scoped to the root domain
-   * instead of sessionStorage, enabling impression tracking across subdomains.
+   * in addition to sessionStorage, enabling impression tracking across subdomains.
    * Defaults to false.
    */
   encodeRedirectInCookie?: boolean;
+  /**
+   * When true, redirect impression data is base64-encoded as an AMP_REDIRECT query
+   * parameter on the destination URL, enabling tracking in cross-domain redirects
+   * and cookie-blocked environments. Defaults to false.
+   */
+  encodeRedirectInUrl?: boolean;
 }
 
 export interface WebExperimentConfig extends ExperimentConfig {
@@ -123,18 +129,11 @@ export interface WebExperimentConfig extends ExperimentConfig {
    * 2. Custom handling of navigation {@link setRedirectHandler} should be implemented such that variant actions applied on the site reflect the latest context
    */
   useDefaultNavigationHandler?: boolean;
-  /**
-   * When true, redirect experiment impression data is encoded as a query
-   * parameter (AMP_REDIRECT) on the redirect destination URL. This enables impression tracking in cross-domain
-   * redirect scenarios and in environments where cookies are blocked.
-   */
-  encodeRedirectInUrl?: boolean;
   redirectConfig?: RedirectConfig;
 }
 
 export const Defaults: WebExperimentConfig = {
   useDefaultNavigationHandler: true,
-  encodeRedirectInUrl: false,
 };
 
 /**

--- a/packages/experiment-tag/src/types.ts
+++ b/packages/experiment-tag/src/types.ts
@@ -119,11 +119,12 @@ export interface WebExperimentConfig extends ExperimentConfig {
    * parameter (AMP_REDIRECT) on the redirect destination URL. This enables impression tracking in cross-domain
    * redirect scenarios and in environments where cookies are blocked.
    */
-  storeRedirectDataInUrlParam?: boolean;
+  encodeRedirectInUrl?: boolean;
 }
 
 export const Defaults: WebExperimentConfig = {
   useDefaultNavigationHandler: true,
+  encodeRedirectInUrl: false,
 };
 
 /**

--- a/packages/experiment-tag/test/experiment.test.ts
+++ b/packages/experiment-tag/test/experiment.test.ts
@@ -1351,7 +1351,7 @@ describe('initializeExperiment', () => {
     // Set up stored redirect data in cookie store
     const storedRedirects = {
       'test-redirect': {
-        variant: { key: 'treatment' },
+        variantKey: 'treatment',
         redirectUrl: 'http://test.com/2',
       },
     };


### PR DESCRIPTION
### Summary

Adds an opt-in `encodeRedirectInUrl` flag that encodes redirect impression data as an `AMP_REDIRECT` query parameter on the destination URL, enabling impression tracking in environments where neither sessionStorage nor cookies are available (cross-domain redirects, cookie-blocked environments).

```js
window.experimentConfig = {
  redirectConfig: {
    encodeRedirectInUrl: true
  }
}
```

**Changes:**

- **`redirectConfig.encodeRedirectInUrl`** (`WebExperimentConfig.redirectConfig`): When `true`, impression data is base64-encoded and appended as `AMP_REDIRECT` on the redirect destination URL at redirect time. Defaults to `false`.
- **`handleRedirect`**: When `encodeRedirectInUrl` is enabled, builds an `AMP_REDIRECT` payload containing the lean impression shape (`redirectUrl`, `variantKey`, `expKey?`, `metadata?`) and sets it on the destination URL. Merges with any existing `AMP_REDIRECT` param to handle sequential redirect experiments.
- **`fireStoredRedirectImpressions`**: When `encodeRedirectInUrl` is enabled, reads and decodes `AMP_REDIRECT` from the current URL, then strips it via `history.replaceState`. Merges all three sources — cookie, sessionStorage, URL param — with priority **url > session > cookie**, so the URL param (most authoritative, embedded at redirect time) always wins on collision.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes redirect behavior and impression attribution by mutating destination URLs and parsing/removing a new query param, which could affect navigation or tracking if encoding/decoding fails or payloads get large. The feature is opt-in via `redirectConfig.encodeRedirectInUrl`, limiting blast radius.
> 
> **Overview**
> Adds an opt-in `redirectConfig.encodeRedirectInUrl` to persist redirect impression data via a base64-encoded `AMP_REDIRECT` query param on the destination URL, to support cross-domain and cookie-blocked environments.
> 
> Updates `handleRedirect` to merge any existing `AMP_REDIRECT` payload with the current redirect’s impression data before navigating, and updates `fireStoredRedirectImpressions` to read/decode and then strip `AMP_REDIRECT` from the current URL, merging impression sources with priority **url > sessionStorage > cookie**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d86b82dea3879e9406deae99caa6722e854205e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->