### PR TITLE
fix(experiment-tag): strip <style> from html mutations and widget injects for CSP-safety [WEB-8]

### DIFF
--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -1012,12 +1012,17 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     if (rawCss) {
       sheetHandle = cspSafeStyleSheet(this.globalScope.document, rawCss);
     }
-    // Create HTML
+    // Create HTML — strip any embedded <style> elements (legacy widget data
+    // shape from inside-widget AI stylize) and adopt their CSS as a separate
+    // sheet so strict-CSP customer pages don't block style application.
     const rawHtml = action.data.html;
     let html: Element | undefined;
+    let htmlSheetHandle: StyleSheetHandle | null = null;
     if (rawHtml) {
+      const result = extractAndAdoptStyles(rawHtml, this.globalScope.document);
+      htmlSheetHandle = result.handle;
       html =
-        new DOMParser().parseFromString(rawHtml, 'text/html').body
+        new DOMParser().parseFromString(result.html, 'text/html').body
           .firstElementChild ?? undefined;
     }
     // Inject
@@ -1047,6 +1052,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
         state.cancelled = true;
         utils.remove?.();
         sheetHandle?.revert();
+        htmlSheetHandle?.revert();
         script?.remove();
         this.appliedInjections.delete(id);
       },

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -50,6 +50,7 @@ import {
   type StyleSheetHandle,
 } from './util/csp-safe-stylesheet';
 import { DebugRecorder } from './util/debug-recorder';
+import { extractAndAdoptStyles } from './util/extract-and-adopt-styles';
 import { getInjectUtils } from './util/inject-utils';
 import { hideLoadingIndicator } from './util/loading-indicator';
 import { VISUAL_EDITOR_SESSION_KEY, WindowMessenger } from './util/messenger';
@@ -891,6 +892,26 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     this.globalScope.location.replace(targetUrl);
   }
 
+  private applyDeclarativeMutation(m: any): MutationController {
+    const isHtmlMutation =
+      m.attribute === 'html' && (m.action === 'set' || m.action === 'append');
+    if (!isHtmlMutation) return mutate.declarative(m);
+
+    const { html, handle } = extractAndAdoptStyles(
+      m.value ?? '',
+      this.globalScope.document,
+    );
+    const downstream = mutate.declarative({ ...m, value: html });
+    if (!handle) return downstream;
+    return {
+      ...downstream,
+      revert: () => {
+        downstream.revert();
+        handle.revert();
+      },
+    };
+  }
+
   private handleMutate(action, flagKey: string, variant: Variant) {
     const mutations = action.data?.mutations || [];
     const variantKey = variant.key || '';
@@ -925,7 +946,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
           ]
         ) {
           // Apply mutation
-          mutationControllers[index] = mutate.declarative(m);
+          mutationControllers[index] = this.applyDeclarativeMutation(m);
         }
       }
     });

--- a/packages/experiment-tag/src/util/extract-and-adopt-styles.ts
+++ b/packages/experiment-tag/src/util/extract-and-adopt-styles.ts
@@ -10,10 +10,6 @@
  * Returns the cleaned HTML and a handle whose lifecycle the caller MUST tie
  * to the surrounding mutation/inject controller's revert. Returns
  * `handle: null` when the input has no <style> tags.
- *
- * NOTE: A copy of this file ships in the visual editor at
- *   apps/experiment-overlay/src/lib/extract-and-adopt-styles.ts
- * If you change one, change the other.
  */
 
 import {

--- a/packages/experiment-tag/src/util/extract-and-adopt-styles.ts
+++ b/packages/experiment-tag/src/util/extract-and-adopt-styles.ts
@@ -1,0 +1,37 @@
+/**
+ * Removes <style> elements from `html` and adopts their combined CSS onto
+ * `target` as a constructable stylesheet (CSP-safe).
+ *
+ * Used at every site that inserts author-controlled HTML into a customer
+ * document — declarativeMutate (html mutations) and widget injection — to
+ * neutralize embedded <style> elements that would be blocked by strict
+ * style-src CSPs.
+ *
+ * Returns the cleaned HTML and a handle whose lifecycle the caller MUST tie
+ * to the surrounding mutation/inject controller's revert. Returns
+ * `handle: null` when the input has no <style> tags.
+ *
+ * NOTE: A copy of this file ships in the visual editor at
+ *   apps/experiment-overlay/src/lib/extract-and-adopt-styles.ts
+ * If you change one, change the other.
+ */
+
+import {
+  cspSafeStyleSheet,
+  type StyleSheetHandle,
+} from './csp-safe-stylesheet';
+import { extractStylesFromHtml } from './extract-styles-from-html';
+
+export type ExtractAndAdoptResult = {
+  html: string;
+  handle: StyleSheetHandle | null;
+};
+
+export function extractAndAdoptStyles(
+  html: string,
+  target: Document | ShadowRoot,
+): ExtractAndAdoptResult {
+  const { html: cleanedHtml, css } = extractStylesFromHtml(html);
+  if (css === '') return { html, handle: null };
+  return { html: cleanedHtml, handle: cspSafeStyleSheet(target, css) };
+}

--- a/packages/experiment-tag/src/util/extract-styles-from-html.ts
+++ b/packages/experiment-tag/src/util/extract-styles-from-html.ts
@@ -1,0 +1,44 @@
+/**
+ * Removes <style> elements from `html` and returns their combined textContent
+ * as a `css` string. Pure string transformation — no DOM side effects, no
+ * adoption.
+ *
+ * Returns `{ html: input, css: '' }` unchanged if there are no <style> tags
+ * (fast path via `String.includes`).
+ *
+ * Used by:
+ *   - extractAndAdoptStyles (composes adoption on top)
+ *   - the visual editor's WidgetRenderer normalization, which migrates the
+ *     css into widget.content.css instead of adopting at this point
+ *
+ * Implementation note: <style> elements are removed wholesale; any attributes
+ * on them (nonce, media, scoped, etc.) are dropped along with the element.
+ * CSS source contents are preserved verbatim, so in-source @media queries
+ * continue to work.
+ *
+ * NOTE: A copy of this file ships in the visual editor at
+ *   apps/experiment-overlay/src/lib/extract-styles-from-html.ts
+ *   (https://github.com/amplitude/javascript)
+ * If you change one, change the other. Keep the public copy free of internal
+ * product names and references to that repo.
+ */
+
+export type ExtractedStyles = {
+  html: string;
+  css: string;
+};
+
+export function extractStylesFromHtml(html: string): ExtractedStyles {
+  if (!html.includes('<style')) return { html, css: '' };
+
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const styleElements = doc.querySelectorAll('style');
+  if (styleElements.length === 0) return { html, css: '' };
+
+  const css = Array.from(styleElements)
+    .map((el) => el.textContent ?? '')
+    .join('\n');
+  styleElements.forEach((el) => el.remove());
+
+  return { html: doc.body.innerHTML, css };
+}

--- a/packages/experiment-tag/src/util/extract-styles-from-html.ts
+++ b/packages/experiment-tag/src/util/extract-styles-from-html.ts
@@ -11,10 +11,17 @@
  *   - callers that want to migrate the extracted CSS into a separate
  *     persistent storage layer instead of adopting it as a stylesheet
  *
- * Implementation note: <style> elements are removed wholesale; any attributes
- * on them (nonce, media, scoped, etc.) are dropped along with the element.
- * CSS source contents are preserved verbatim, so in-source @media queries
- * continue to work.
+ * Implementation notes:
+ *   - <style> elements are removed wholesale; any attributes on them (nonce,
+ *     media, scoped, etc.) are dropped along with the element. CSS source
+ *     contents are preserved verbatim, so in-source @media queries continue
+ *     to work.
+ *   - We deliberately use a regex (not DOMParser) because DOMParser
+ *     materializes <style> elements as it parses, which constructs their
+ *     CSSStyleSheet and triggers CSP `style-src` enforcement on strict
+ *     customer pages — even when the elements live in a detached document
+ *     and are never inserted into the live DOM. The whole point of this
+ *     helper is to avoid that very violation.
  */
 
 export type ExtractedStyles = {
@@ -22,17 +29,17 @@ export type ExtractedStyles = {
   css: string;
 };
 
+const STYLE_TAG_RE = /<style\b[^>]*>([\s\S]*?)<\/style\s*>/gi;
+
 export function extractStylesFromHtml(html: string): ExtractedStyles {
   if (!html.includes('<style')) return { html, css: '' };
 
-  const doc = new DOMParser().parseFromString(html, 'text/html');
-  const styleElements = doc.querySelectorAll('style');
-  if (styleElements.length === 0) return { html, css: '' };
+  const cssChunks: string[] = [];
+  const cleanedHtml = html.replace(STYLE_TAG_RE, (_match, content: string) => {
+    cssChunks.push(content);
+    return '';
+  });
 
-  const css = Array.from(styleElements)
-    .map((el) => el.textContent ?? '')
-    .join('\n');
-  styleElements.forEach((el) => el.remove());
-
-  return { html: doc.body.innerHTML, css };
+  if (cssChunks.length === 0) return { html, css: '' };
+  return { html: cleanedHtml, css: cssChunks.join('\n') };
 }

--- a/packages/experiment-tag/src/util/extract-styles-from-html.ts
+++ b/packages/experiment-tag/src/util/extract-styles-from-html.ts
@@ -8,19 +8,13 @@
  *
  * Used by:
  *   - extractAndAdoptStyles (composes adoption on top)
- *   - the visual editor's WidgetRenderer normalization, which migrates the
- *     css into widget.content.css instead of adopting at this point
+ *   - callers that want to migrate the extracted CSS into a separate
+ *     persistent storage layer instead of adopting it as a stylesheet
  *
  * Implementation note: <style> elements are removed wholesale; any attributes
  * on them (nonce, media, scoped, etc.) are dropped along with the element.
  * CSS source contents are preserved verbatim, so in-source @media queries
  * continue to work.
- *
- * NOTE: A copy of this file ships in the visual editor at
- *   apps/experiment-overlay/src/lib/extract-styles-from-html.ts
- *   (https://github.com/amplitude/javascript)
- * If you change one, change the other. Keep the public copy free of internal
- * product names and references to that repo.
  */
 
 export type ExtractedStyles = {

--- a/packages/experiment-tag/test/experiment.test.ts
+++ b/packages/experiment-tag/test/experiment.test.ts
@@ -1435,3 +1435,110 @@ describe('helper methods', () => {
     expect(variants['flag-2'].key).toEqual('control');
   });
 });
+
+describe('applyDeclarativeMutation (Site 2 — html-mutation strip-and-adopt)', () => {
+  const mockGetGlobalScope = jest.spyOn(experimentCore, 'getGlobalScope');
+  let client: any;
+  let mockGlobal: any;
+
+  beforeEach(() => {
+    apiKey++;
+    jest.clearAllMocks();
+    jest.spyOn(experimentCore, 'isLocalStorageAvailable').mockReturnValue(true);
+    document.adoptedStyleSheets = [];
+    document.body.innerHTML = '<div id="t">original</div>';
+    mockGlobal = newMockGlobal();
+    mockGetGlobalScope.mockReturnValue(mockGlobal);
+
+    client = DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+      initialFlags: JSON.stringify([]),
+      pageObjects: JSON.stringify({}),
+    });
+    // applyDeclarativeMutation reads `this.globalScope.document` for the
+    // adoption target; override to use the live jsdom document so
+    // dom-mutator and adoptedStyleSheets target the same Document.
+    (client as any).globalScope = { document, location: window.location };
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    document.adoptedStyleSheets = [];
+  });
+
+  it('passes through non-html mutations unchanged', () => {
+    const ctrl = (client as any).applyDeclarativeMutation({
+      action: 'append',
+      attribute: 'style',
+      selector: '#t',
+      value: 'color: red;',
+    });
+
+    const target = document.querySelector<HTMLElement>('#t');
+    expect(target?.style.color).toBe('red');
+    expect(document.adoptedStyleSheets).toHaveLength(0);
+    ctrl.revert();
+  });
+
+  it('passes through html mutations without <style> unchanged', () => {
+    const ctrl = (client as any).applyDeclarativeMutation({
+      action: 'set',
+      attribute: 'html',
+      selector: '#t',
+      value: '<span>plain</span>',
+    });
+
+    const target = document.querySelector<HTMLElement>('#t');
+    expect(target?.innerHTML).toBe('<span>plain</span>');
+    expect(document.adoptedStyleSheets).toHaveLength(0);
+    ctrl.revert();
+  });
+
+  it('strips <style> from html mutations and adopts as a sheet', () => {
+    const ctrl = (client as any).applyDeclarativeMutation({
+      action: 'set',
+      attribute: 'html',
+      selector: '#t',
+      value: '<span class="ai">new</span><style>.ai { color: red; }</style>',
+    });
+
+    const target = document.querySelector<HTMLElement>('#t');
+    expect(target?.innerHTML).toBe('<span class="ai">new</span>');
+    expect(target?.querySelector('style')).toBeNull();
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+    expect(document.adoptedStyleSheets[0]).toBeInstanceOf(CSSStyleSheet);
+
+    ctrl.revert();
+  });
+
+  it('reverting reverts both the html change and the adopted sheet', () => {
+    const ctrl = (client as any).applyDeclarativeMutation({
+      action: 'set',
+      attribute: 'html',
+      selector: '#t',
+      value: '<span class="ai">new</span><style>.ai { color: red; }</style>',
+    });
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+
+    ctrl.revert();
+
+    const target = document.querySelector<HTMLElement>('#t');
+    expect(target?.innerHTML).toBe('original');
+    expect(document.adoptedStyleSheets).toHaveLength(0);
+  });
+
+  it('also handles html mutations with action="append"', () => {
+    const ctrl = (client as any).applyDeclarativeMutation({
+      action: 'append',
+      attribute: 'html',
+      selector: '#t',
+      value: '<span class="b">b</span><style>.b { color: blue; }</style>',
+    });
+
+    const target = document.querySelector<HTMLElement>('#t');
+    expect(target?.innerHTML).toContain('<span class="b">b</span>');
+    expect(target?.querySelector('style')).toBeNull();
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+
+    ctrl.revert();
+  });
+});

--- a/packages/experiment-tag/test/experiment.test.ts
+++ b/packages/experiment-tag/test/experiment.test.ts
@@ -1542,3 +1542,119 @@ describe('applyDeclarativeMutation (Site 2 — html-mutation strip-and-adopt)', 
     ctrl.revert();
   });
 });
+
+describe('handleInject — embedded <style> in rawHtml (Site 4, legacy widget data)', () => {
+  const mockGetGlobalScope = jest.spyOn(experimentCore, 'getGlobalScope');
+  let client: any;
+  let mockGlobal: any;
+  const INJECT_ID = 'widget1abc';
+  const FLAG_KEY = 'inject-test';
+
+  beforeEach(() => {
+    apiKey++;
+    jest.clearAllMocks();
+    jest.spyOn(experimentCore, 'isLocalStorageAvailable').mockReturnValue(true);
+    document.adoptedStyleSheets = [];
+    document.body.innerHTML = '<div id="root"></div>';
+
+    mockGlobal = newMockGlobal();
+    mockGetGlobalScope.mockReturnValue(mockGlobal);
+
+    client = DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+      initialFlags: JSON.stringify([]),
+      pageObjects: JSON.stringify({}),
+    });
+    // Override globalScope so handleInject's document.head.appendChild and
+    // adoptedStyleSheets reads target the live test document. The inject
+    // code reads `globalScope[id]` to find the inject function — provide a
+    // stub that appends the html into #root.
+    (client as any).globalScope = {
+      document,
+      location: window.location,
+      [INJECT_ID]: (html: Element | undefined) => {
+        if (html) document.querySelector('#root')?.appendChild(html);
+      },
+    };
+    (client as any).appliedInjections = new Set();
+    (client as any).appliedMutations = {};
+
+    (client as any).isActionActiveOnPage = jest.fn().mockReturnValue(true);
+    (client as any).exposureWithDedupe = jest.fn();
+  });
+
+  afterEach(() => {
+    // Clear adopted sheets BEFORE clearing body. The construct-style-sheets
+    // polyfill stores adopter <style> nodes inside document.body; clearing
+    // body first orphans them and the polyfill's removeChild call throws.
+    document.adoptedStyleSheets = [];
+    document.body.innerHTML = '';
+  });
+
+  function buildAction(html: string, css = '') {
+    return {
+      data: { id: INJECT_ID, html, css, js: '', scope: ['*'] },
+    };
+  }
+
+  function variant() {
+    return { key: 'treatment' };
+  }
+
+  test('rawHtml without <style> adopts only content.css (one sheet)', () => {
+    (client as any).handleInject(
+      buildAction('<div class="w">x</div>', '.outer { color: blue; }'),
+      FLAG_KEY,
+      variant(),
+    );
+
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+    expect(document.querySelector('.w')).not.toBeNull();
+    expect(document.querySelector('.w style')).toBeNull();
+  });
+
+  test('rawHtml with embedded <style> adopts both content.css and extracted CSS (two sheets)', () => {
+    (client as any).handleInject(
+      buildAction(
+        '<div class="w">x<style>.w { color: red; }</style></div>',
+        '.outer { color: blue; }',
+      ),
+      FLAG_KEY,
+      variant(),
+    );
+
+    expect(document.adoptedStyleSheets).toHaveLength(2);
+    expect(document.adoptedStyleSheets[0]).toBeInstanceOf(CSSStyleSheet);
+    expect(document.adoptedStyleSheets[1]).toBeInstanceOf(CSSStyleSheet);
+
+    // The injected DOM does NOT contain the <style> element anymore.
+    const widget = document.querySelector('.w');
+    expect(widget).not.toBeNull();
+    expect(widget?.querySelector('style')).toBeNull();
+  });
+
+  test('rawHtml with embedded <style> but no content.css adopts one sheet (the extracted CSS)', () => {
+    (client as any).handleInject(
+      buildAction('<div class="w">x<style>.w {}</style></div>', ''),
+      FLAG_KEY,
+      variant(),
+    );
+
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+    expect(document.querySelector('.w style')).toBeNull();
+  });
+
+  test('reverting the inject reverts both sheet handles', () => {
+    (client as any).handleInject(
+      buildAction('<div class="w">x<style>.w {}</style></div>', '.outer {}'),
+      FLAG_KEY,
+      variant(),
+    );
+    expect(document.adoptedStyleSheets).toHaveLength(2);
+
+    (client as any).appliedMutations[FLAG_KEY]?.[variant().key]?.['inject']?.[
+      INJECT_ID
+    ]?.revert();
+
+    expect(document.adoptedStyleSheets).toHaveLength(0);
+  });
+});

--- a/packages/experiment-tag/test/util/extract-and-adopt-styles.test.ts
+++ b/packages/experiment-tag/test/util/extract-and-adopt-styles.test.ts
@@ -1,0 +1,67 @@
+import { extractAndAdoptStyles } from '../../src/util/extract-and-adopt-styles';
+
+describe('extractAndAdoptStyles', () => {
+  beforeEach(() => {
+    document.adoptedStyleSheets = [];
+  });
+
+  it('returns input html and null handle when no <style> present', () => {
+    const html = '<div>hi</div>';
+    const result = extractAndAdoptStyles(html, document);
+
+    expect(result.html).toBe(html);
+    expect(result.handle).toBeNull();
+    expect(document.adoptedStyleSheets).toHaveLength(0);
+  });
+
+  it('extracts <style>, returns cleaned html and a handle, adopts the sheet on the target', () => {
+    const html = '<div>hi</div><style>.a { color: red; }</style>';
+    const result = extractAndAdoptStyles(html, document);
+
+    expect(result.html).toBe('<div>hi</div>');
+    expect(result.handle).not.toBeNull();
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+    expect(document.adoptedStyleSheets[0]).toBeInstanceOf(CSSStyleSheet);
+  });
+
+  it('handle.revert removes the sheet', () => {
+    const result = extractAndAdoptStyles(
+      '<div></div><style>.a {}</style>',
+      document,
+    );
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+
+    result.handle?.revert();
+    expect(document.adoptedStyleSheets).toHaveLength(0);
+  });
+
+  it('handle.reapply re-adopts after revert', () => {
+    const result = extractAndAdoptStyles(
+      '<div></div><style>.a {}</style>',
+      document,
+    );
+    const sheet = document.adoptedStyleSheets[0];
+    result.handle?.revert();
+    result.handle?.reapply();
+
+    expect(document.adoptedStyleSheets).toHaveLength(1);
+    expect(document.adoptedStyleSheets[0]).toBe(sheet);
+  });
+
+  it('works with a ShadowRoot target', () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const shadow = host.attachShadow({ mode: 'open' });
+
+    const result = extractAndAdoptStyles(
+      '<p>hi</p><style>p { color: red; }</style>',
+      shadow,
+    );
+
+    expect(result.html).toBe('<p>hi</p>');
+    expect(shadow.adoptedStyleSheets).toHaveLength(1);
+
+    result.handle?.revert();
+    document.body.removeChild(host);
+  });
+});

--- a/packages/experiment-tag/test/util/extract-styles-from-html.test.ts
+++ b/packages/experiment-tag/test/util/extract-styles-from-html.test.ts
@@ -38,6 +38,14 @@ describe('extractStylesFromHtml', () => {
     expect(() => extractStylesFromHtml('<div><style>.a{}')).not.toThrow();
   });
 
+  it('strips <style> elements with attributes (nonce, media, etc.)', () => {
+    const html =
+      '<div>x</div><style media="print" nonce="abc">.a{}</style><style>.b{}</style>';
+    const result = extractStylesFromHtml(html);
+    expect(result.html).toBe('<div>x</div>');
+    expect(result.css).toBe('.a{}\n.b{}');
+  });
+
   it('preserves CSS source verbatim including @media queries and pseudo-classes', () => {
     const css =
       '.btn:hover { color: red; }\n@media (max-width: 600px) { .btn { font-size: 12px; } }';

--- a/packages/experiment-tag/test/util/extract-styles-from-html.test.ts
+++ b/packages/experiment-tag/test/util/extract-styles-from-html.test.ts
@@ -1,0 +1,48 @@
+import { extractStylesFromHtml } from '../../src/util/extract-styles-from-html';
+
+describe('extractStylesFromHtml', () => {
+  it('returns input unchanged when there are no <style> tags (fast path)', () => {
+    const html = '<div class="foo">hello</div>';
+    const result = extractStylesFromHtml(html);
+    expect(result).toEqual({ html, css: '' });
+  });
+
+  it('returns input unchanged when input is empty', () => {
+    expect(extractStylesFromHtml('')).toEqual({ html: '', css: '' });
+  });
+
+  it('extracts a single <style> block, removes it from html, returns its content as css', () => {
+    const html = '<div>hi</div><style>.foo { color: red; }</style>';
+    const result = extractStylesFromHtml(html);
+    expect(result.html).toBe('<div>hi</div>');
+    expect(result.css).toBe('.foo { color: red; }');
+  });
+
+  it('concatenates multiple <style> blocks in source order', () => {
+    const html =
+      '<style>.a { color: red; }</style><div>x</div><style>.b { color: blue; }</style>';
+    const result = extractStylesFromHtml(html);
+    expect(result.html).toBe('<div>x</div>');
+    expect(result.css).toBe('.a { color: red; }\n.b { color: blue; }');
+  });
+
+  it('extracts <style> nested inside other elements; preserves surrounding html', () => {
+    const html =
+      '<div class="outer"><span>inner</span><style>.x{}</style></div>';
+    const result = extractStylesFromHtml(html);
+    expect(result.html).toBe('<div class="outer"><span>inner</span></div>');
+    expect(result.css).toBe('.x{}');
+  });
+
+  it('does not throw on malformed input', () => {
+    expect(() => extractStylesFromHtml('<div><style>.a{}')).not.toThrow();
+  });
+
+  it('preserves CSS source verbatim including @media queries and pseudo-classes', () => {
+    const css =
+      '.btn:hover { color: red; }\n@media (max-width: 600px) { .btn { font-size: 12px; } }';
+    const html = `<button class="btn">x</button><style>${css}</style>`;
+    const result = extractStylesFromHtml(html);
+    expect(result.css).toBe(css);
+  });
+});


### PR DESCRIPTION
## Summary

Three new files + two integration sites in `experiment.ts` make the production SDK CSP-safe for AI stylizer mutations:

- **New** `extractStylesFromHtml` — pure utility: strips `<style>` elements from an HTML string and returns their combined CSS.
- **New** `extractAndAdoptStyles` — composes the above with the existing WEB-6 `cspSafeStyleSheet`. Returns cleaned HTML + a sheet handle (or `handle: null` when there's nothing to extract).
- **`handleMutate`** (Site 2): a new private `applyDeclarativeMutation` method wraps `mutate.declarative` for html mutations only. Strips embedded `<style>`, adopts as a constructable stylesheet, and composes the sheet's revert into the `MutationController.revert`. Non-html mutations pass through unchanged.
- **`handleInject`** (Site 4): widget `content.html` runs through `extractAndAdoptStyles` before `DOMParser.parseFromString`, threading a second sheet handle (`htmlSheetHandle`) into the existing inject revert closure alongside the existing `sheetHandle` (from `content.css`).

Together these neutralize:
- The AI stylizer's persisted text mutations whose value embeds `<style>` (legacy data + going-forward).
- Widget content.html with embedded `<style>` from prior inside-widget AI stylize edits.

Both shapes were CSP-blocked on strict customer pages (e.g. Fathom Video) before this PR, even after WEB-6's `content.css` adoption.

## Spec

[`amplitude/javascript:docs/superpowers/specs/2026-05-12-csp-safe-style-injection-ai-stylizer-design.md`](https://github.com/amplitude/javascript/blob/master/docs/superpowers/specs/2026-05-12-csp-safe-style-injection-ai-stylizer-design.md) (private — internal-only Superpowers spec)

## Tickets

- [WEB-8](https://linear.app/amplitude/issue/WEB-8) (this PR — production SDK side)
- Companion overlay PR forthcoming in [`amplitude/javascript`](https://github.com/amplitude/javascript)
- Cleanup follow-up tracked as [WEB-29](https://linear.app/amplitude/issue/WEB-29) (introduces a clean ` MutationType.adoptedSheet` for the authoring side; legacy data continues to rely on this PR's strip helper)

## Test plan

- [x] Unit tests for `extractStylesFromHtml` (7 cases) and `extractAndAdoptStyles` (5 cases)
- [x] Integration tests through `applyDeclarativeMutation` (5 cases via `(client as any).applyDeclarativeMutation(...)`)
- [x] Integration tests through `handleInject` (4 cases via `(client as any).handleInject(...)`)
- [x] Full `experiment-tag` test suite passes (179/179)
- [x] tsc, eslint, prettier all clean
- [ ] After merge + minor SDK release: smoke-test on a Fathom-like CSP-strict customer page that an experiment with AI-stylized non-widget elements applies styling without `Refused to apply inline style…` console errors. Also verify a widget with embedded `<style>` in content.html (legacy AI stylize data) renders styled.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `mutate` and `inject` actions apply and revert DOM/CSS by extracting embedded `<style>` blocks into adopted constructable stylesheets; bugs here could leave experiments partially applied or styles not reverted on customer pages.
> 
> **Overview**
> Makes **html mutations and widget injections CSP-safe** by removing embedded `<style>` tags from author-controlled HTML and adopting their CSS via `cspSafeStyleSheet` instead.
> 
> Adds `extractStylesFromHtml` (regex-based extraction to avoid DOMParser CSP violations) and `extractAndAdoptStyles` (adoption + lifecycle handle). Updates `handleMutate` to route `html` `set`/`append` mutations through a new `applyDeclarativeMutation` wrapper that composes stylesheet revert with the underlying `MutationController`. Updates `handleInject` to run `content.html` through the same extraction/adoption path and ensure both the existing `content.css` sheet and extracted-HTML sheet are reverted.
> 
> Adds unit tests for both utilities plus integration tests covering mutation/inject behavior and revert semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0b5f9f4d937a1b9d3e0754bb0fab0feecf0f62d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[WEB-8]: https://amplitude.atlassian.net/browse/WEB-8?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ