### PR TITLE
fix: track preview variant impressions only if page object matches

### DIFF
--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -592,7 +592,9 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
         return;
       }
       if (this.isPreviewMode) {
-        this.exposureWithDedupe(key, variantObject, true);
+        if (this.isActionActiveOnPage(key, undefined)) {
+          this.exposureWithDedupe(key, variantObject, true);
+        }
         showPreviewModeModal({
           flags: this.previewFlags,
         });

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -598,7 +598,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       }
       const payload = variantObject.payload;
       if (!payload || !Array.isArray(payload)) {
-        if (this.isPreviewMode && this.isActionActiveOnPage(key, undefined)) {
+        if (this.isActionActiveOnPage(key, undefined)) {
           this.exposureWithDedupe(key, variantObject);
         }
         return;

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -592,15 +592,15 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
         return;
       }
       if (this.isPreviewMode) {
-        if (this.isActionActiveOnPage(key, undefined)) {
-          this.exposureWithDedupe(key, variantObject, true);
-        }
         showPreviewModeModal({
           flags: this.previewFlags,
         });
       }
       const payload = variantObject.payload;
       if (!payload || !Array.isArray(payload)) {
+        if (this.isPreviewMode && this.isActionActiveOnPage(key, undefined)) {
+          this.exposureWithDedupe(key, variantObject);
+        }
         return;
       }
       this.handleVariantAction(key, variantObject);
@@ -1047,7 +1047,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       this.urlExposureCache?.[currentUrl]?.[key] === variant.key;
 
     if (!hasTrackedVariant) {
-      if (forceVariant) {
+      if (forceVariant || !!this.previewFlags[key]) {
         const variantAndSource = {
           variant: variant,
           source: 'local-evaluation',


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

Preview variant exposures were previously fired unconditionally in `previewVariants`, regardless of whether a page object was active for the flag.

**Fix:** `exposureWithDedupe` now auto-detects preview flags (via `previewFlags[key]`) and routes them through `exposureInternal` with `source: 'local-evaluation'`. This removes the need for an explicit forced exposure in `previewVariants` — `handleMutate`/`handleInject` fire exposure naturally with their existing scope checks. For no-payload variants (`control`/`off`), exposure is fired at the payload guard gated on `isActionActiveOnPage`.

The preview mode modal continues to show unconditionally.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Affects experiment exposure/impression tracking paths, which can change analytics counts and attribution in preview mode. Scope is limited to `previewVariants` and `exposureWithDedupe` logic with straightforward conditions.
> 
> **Overview**
> Preview-mode variant exposures are no longer fired unconditionally in `previewVariants`; for variants without an action payload (e.g. `control`/`off`), exposure is now tracked only when `isActionActiveOnPage` indicates the experiment is active on the current page.
> 
> `exposureWithDedupe` now automatically routes previewed flags (keys present in `previewFlags`) through `exposureInternal` with `source: 'local-evaluation'`, matching the prior forced-variant behavior without requiring callers to pass `forceVariant`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 616d9293183ddff39586311a011cf84e17f80b30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->