### PR TITLE
fix: add pluginAddedToAnalytics prop

### DIFF
--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -118,6 +118,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
   private isRemoteBlocking = false;
   private customRedirectHandler: ((url: string) => void) | undefined;
   public isRunning = false;
+  public pluginAddedToAnalytics = false;
   private readonly messageBus: MessageBus;
   private pageObjects: PageObjects;
   private activePages: PageObjects = {};
@@ -792,7 +793,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       type: 'enrichment',
 
       setup: async (): Promise<void> => {
-        // No setup required
+        this.pluginAddedToAnalytics = true;
       },
 
       execute: async (context: Event): Promise<Event> => {

--- a/packages/experiment-tag/src/index.ts
+++ b/packages/experiment-tag/src/index.ts
@@ -94,7 +94,7 @@ export const createPlugin = (): Plugin => ({
   setup: async (): Promise<void> => {
     const globalScope = getGlobalScope();
     const client = globalScope?.webExperiment as DefaultWebExperimentClient;
-    if (client && !client.isStub) {
+    if (client && typeof client.pluginAddedToAnalytics === 'boolean') {
       client.pluginAddedToAnalytics = true;
     } else {
       // Client not yet initialized; apply the flag when flushEventBuffer runs.

--- a/packages/experiment-tag/src/index.ts
+++ b/packages/experiment-tag/src/index.ts
@@ -13,6 +13,8 @@ const eventBuffer: Array<{
   event_properties?: Record<string, unknown>;
 }> = [];
 
+let pendingPluginAddedToAnalytics = false;
+
 export const initialize = (
   apiKey: string,
   initConfigs: InitConfigs,
@@ -89,6 +91,16 @@ const fetchLatestConfigs = async (apiKey: string, serverZone?: string) => {
 export const createPlugin = (): Plugin => ({
   name: '@amplitude/experiment-tag',
   type: 'enrichment',
+  setup: async (): Promise<void> => {
+    const globalScope = getGlobalScope();
+    const client = globalScope?.webExperiment as DefaultWebExperimentClient;
+    if (client && !client.isStub) {
+      client.pluginAddedToAnalytics = true;
+    } else {
+      // Client not yet initialized; apply the flag when flushEventBuffer runs.
+      pendingPluginAddedToAnalytics = true;
+    }
+  },
   execute: async (context: Event): Promise<Event> => {
     const globalScope = getGlobalScope();
     const client = globalScope?.webExperiment as DefaultWebExperimentClient;
@@ -115,6 +127,10 @@ export const createPlugin = (): Plugin => ({
 
 // Internal function to flush buffered events
 export const flushEventBuffer = (client: DefaultWebExperimentClient): void => {
+  if (pendingPluginAddedToAnalytics) {
+    client.pluginAddedToAnalytics = true;
+    pendingPluginAddedToAnalytics = false;
+  }
   if (eventBuffer.length > 0) {
     eventBuffer.forEach(({ event_type, event_properties }) => {
       client.trackEvent(event_type, event_properties);


### PR DESCRIPTION
### Summary

Adds a `pluginAddedToAnalytics` boolean property to `DefaultWebExperimentClient` that is set to `true` when the Amplitude Analytics SDK calls `setup()` on the plugin returned by `webExperiment.plugin()`.

Previously there was no way to tell from the experiment-tag side whether `amplitude.add(webExperiment.plugin())` had completed. Callers can now check `window.webExperiment?.pluginAddedToAnalytics === true` to confirm the plugin has been successfully registered with the analytics SDK.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a boolean readiness flag and a small deferred-set mechanism without changing event forwarding behavior or data handling.
> 
> **Overview**
> Adds `pluginAddedToAnalytics` to `DefaultWebExperimentClient` and sets it to `true` when the Amplitude Analytics plugin `setup()` runs.
> 
> Updates the pre-init `createPlugin()` path to also set this flag (or defer it via a pending marker) and applies the deferred state during `flushEventBuffer()` so plugin registration can be detected even when the client isn’t initialized yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af2df394973ecbd06814c8754d0335d0128a6dfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->