### PR TITLE
feat: support Mutex and Holdout groups for web experiment

### DIFF
--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -413,6 +413,12 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     this.experimentClient.setUser(enrichedUser);
     this.updateUserWithBehaviors();
 
+    // Wait for the integration's setup() to complete before evaluating local
+    // flags — otherwise bucketing runs against incomplete user identity.
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    await this.experimentClient.integrationManager.ready();
+
     if (!this.isRemoteBlocking) {
       removeAntiFlickerCss();
     }

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -182,6 +182,22 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       }
     });
 
+    // Flags that depend on at least one remote flag are also considered remote.
+    // Iterate to fixed point to handle transitive dependencies.
+    let changed = true;
+    while (changed) {
+      changed = false;
+      this.initialFlags.forEach((flag: EvaluationFlag) => {
+        if (
+          !this.remoteFlagKeys.includes(flag.key) &&
+          flag.dependencies?.some((dep) => this.remoteFlagKeys.includes(dep))
+        ) {
+          this.remoteFlagKeys.push(flag.key);
+          changed = true;
+        }
+      });
+    }
+
     const initialFlagsString = JSON.stringify(this.initialFlags);
 
     // initialize the experiment

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -417,11 +417,17 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     this.experimentClient.setUser(enrichedUser);
     this.updateUserWithBehaviors();
 
-    // Wait for the integration's setup() to complete before evaluating local
-    // flags — otherwise bucketing runs against incomplete user identity.
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    await this.experimentClient.integrationManager.ready();
+    // Holdout/mutex bucketing requires user identity (user_id,
+    // device_id) — wait for the integration's setup() only when present.
+    const hasHoldoutOrMutex = this.initialFlags.some(
+      (flag) =>
+        flag.key.startsWith('holdout-') || flag.key.startsWith('mutex-'),
+    );
+    if (hasHoldoutOrMutex) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      await this.experimentClient.integrationManager.ready();
+    }
 
     if (!this.isRemoteBlocking) {
       removeAntiFlickerCss();

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -420,7 +420,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     // Holdout/mutex bucketing requires user identity (user_id,
     // device_id) — wait for the integration's setup() only when present.
     const hasHoldoutOrMutex = this.initialFlags.some(
-      (flag) =>
+      (flag: EvaluationFlag) =>
         flag.key.startsWith('holdout-') || flag.key.startsWith('mutex-'),
     );
     if (hasHoldoutOrMutex) {

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -184,6 +184,10 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
 
     // Flags that depend on at least one remote flag are also considered remote.
     // Iterate to fixed point to handle transitive dependencies.
+    // Track which keys were promoted so we can exclude only those from
+    // localFlagKeys — flags that are directly 'remote' but cached in session
+    // storage as 'local' should still be applied locally (fast-path rendering).
+    const transitivelyPromotedKeys = new Set<string>();
     let changed = true;
     while (changed) {
       changed = false;
@@ -193,6 +197,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
           flag.dependencies?.some((dep) => this.remoteFlagKeys.includes(dep))
         ) {
           this.remoteFlagKeys.push(flag.key);
+          transitivelyPromotedKeys.add(flag.key);
           changed = true;
         }
       });
@@ -214,9 +219,14 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       ...this.config,
     });
     // Get all the locally available flag keys from the SDK.
+    // Exclude flags promoted to remoteFlagKeys via the dependency loop above —
+    // their remote dependencies must be fetched first or mutex/holdout bucketing
+    // will run against stale parent-flag state and assign the wrong variant.
     const variants = this.experimentClient.all();
     this.localFlagKeys = Object.keys(variants).filter(
-      (key) => variants[key]?.metadata?.evaluationMode === 'local',
+      (key) =>
+        variants[key]?.metadata?.evaluationMode === 'local' &&
+        !transitivelyPromotedKeys.has(key),
     );
     this.messageBus = new MessageBus();
   }

--- a/packages/experiment-tag/test/experiment.test.ts
+++ b/packages/experiment-tag/test/experiment.test.ts
@@ -609,6 +609,64 @@ describe('initializeExperiment', () => {
     expect(mockExposure).toHaveBeenCalledWith('test-2');
   });
 
+  test('remote evaluation - local flag with remote dependency not applied before remote fetch', async () => {
+    // local-dep depends on remote-parent, so it must be treated as remote
+    // and must NOT appear in localFlagKeys (which would cause premature applyVariants)
+    const remoteParentFlag = {
+      ...createMutateFlag('remote-parent', 'treatment', [], [], 'remote'),
+    };
+    const localDepFlag = {
+      ...createMutateFlag('local-dep', 'treatment', [DEFAULT_MUTATE_SCOPE]),
+      dependencies: ['remote-parent'],
+    };
+    const initialFlags = [remoteParentFlag, localDepFlag];
+    const remoteFlags = [
+      createMutateFlag('remote-parent', 'treatment', [], [], 'remote'),
+    ];
+    const mockHttpClient = new MockHttpClient(JSON.stringify(remoteFlags));
+
+    const applyVariantsSpy = jest.spyOn(
+      DefaultWebExperimentClient.prototype as any,
+      'applyVariants',
+    );
+
+    await DefaultWebExperimentClient.getInstance(
+      stringify(apiKey),
+      {
+        initialFlags: JSON.stringify(initialFlags),
+        pageObjects: JSON.stringify({
+          'remote-parent': createPageObject(
+            'A',
+            'url_change',
+            undefined,
+            'http://test.com',
+          ),
+          'local-dep': createPageObject(
+            'A',
+            'url_change',
+            undefined,
+            'http://test.com',
+          ),
+        }),
+      },
+      {
+        httpClient: mockHttpClient,
+      },
+    ).start();
+
+    // The first applyVariants call (for local flags) must not include local-dep
+    const firstCallFlagKeys: string[] =
+      (applyVariantsSpy.mock.calls[0]?.[0] as { flagKeys?: string[] })
+        ?.flagKeys ?? [];
+    expect(firstCallFlagKeys).not.toContain('local-dep');
+
+    // local-dep should be applied in the remote pass (after fetch)
+    const allCalledKeys: string[] = applyVariantsSpy.mock.calls.flatMap(
+      (call) => (call[0] as { flagKeys?: string[] })?.flagKeys ?? [],
+    );
+    expect(allCalledKeys).toContain('local-dep');
+  });
+
   test('remote evaluation - fetch fail, locally evaluate remote and local flags success', async () => {
     const initialFlags = [
       // remote flag

--- a/packages/experiment-tag/test/experiment.test.ts
+++ b/packages/experiment-tag/test/experiment.test.ts
@@ -610,16 +610,23 @@ describe('initializeExperiment', () => {
   });
 
   test('remote evaluation - local flag with remote dependency not applied before remote fetch', async () => {
-    // local-dep depends on remote-parent, so it must be treated as remote
-    // and must NOT appear in localFlagKeys (which would cause premature applyVariants)
+    // Depth-2 chain: local-grandchild → local-dep → remote-parent.
+    // initialFlags ordered [grandchild, dep, parent] — the adversarial ordering
+    // that a single forEach pass would fail on, proving the fixed-point loop is needed.
     const remoteParentFlag = {
       ...createMutateFlag('remote-parent', 'treatment', [], [], 'remote'),
     };
     const localDepFlag = {
-      ...createMutateFlag('local-dep', 'treatment', [DEFAULT_MUTATE_SCOPE]),
+      ...createMutateFlag('local-dep', 'treatment', []),
       dependencies: ['remote-parent'],
     };
-    const initialFlags = [remoteParentFlag, localDepFlag];
+    const localGrandchildFlag = {
+      ...createMutateFlag('local-grandchild', 'treatment', [
+        DEFAULT_MUTATE_SCOPE,
+      ]),
+      dependencies: ['local-dep'],
+    };
+    const initialFlags = [localGrandchildFlag, localDepFlag, remoteParentFlag];
     const remoteFlags = [
       createMutateFlag('remote-parent', 'treatment', [], [], 'remote'),
     ];
@@ -647,6 +654,12 @@ describe('initializeExperiment', () => {
             undefined,
             'http://test.com',
           ),
+          'local-grandchild': createPageObject(
+            'A',
+            'url_change',
+            undefined,
+            'http://test.com',
+          ),
         }),
       },
       {
@@ -654,17 +667,19 @@ describe('initializeExperiment', () => {
       },
     ).start();
 
-    // The first applyVariants call (for local flags) must not include local-dep
+    // The first applyVariants call (for local flags) must not include either transitive dep
     const firstCallFlagKeys: string[] =
       (applyVariantsSpy.mock.calls[0]?.[0] as { flagKeys?: string[] })
         ?.flagKeys ?? [];
     expect(firstCallFlagKeys).not.toContain('local-dep');
+    expect(firstCallFlagKeys).not.toContain('local-grandchild');
 
-    // local-dep should be applied in the remote pass (after fetch)
+    // Both should be applied in the remote pass (after fetch)
     const allCalledKeys: string[] = applyVariantsSpy.mock.calls.flatMap(
       (call) => (call[0] as { flagKeys?: string[] })?.flagKeys ?? [],
     );
     expect(allCalledKeys).toContain('local-dep');
+    expect(allCalledKeys).toContain('local-grandchild');
   });
 
   test('remote evaluation - fetch fail, locally evaluate remote and local flags success', async () => {


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

Support Mutex and Holdout groups for web experiment.

Flags that transitively depend on a remote-evaluated flag (e.g. a Mutex or Holdout parent) are now promoted to remote evaluation via a fixed-point dependency walk. This ensures child flags wait for their remote dependencies to be fetched before bucketing runs, preventing incorrect variant assignment.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes flag evaluation ordering and startup timing for experiments with flag dependencies or holdout/mutex flags, which can affect which variants users see on first paint.
> 
> **Overview**
> Web experiment startup now treats **local flags that depend on a remote flag** (including transitive chains) as remote so variant application waits until remote parents are fetched, avoiding wrong mutex/holdout bucketing from stale parent state. Only flags promoted via that dependency walk are removed from the early **local** apply pass; directly remote flags that are session-cached as local still get the fast-path local apply.
> 
> When any initial flag key starts with **`holdout-`** or **`mutex-`**, **`start()`** awaits **`integrationManager.ready()`** before applying variants so bucketing has **`user_id` / `device_id`** from the Amplitude integration setup.
> 
> Adds a test that a depth-2 local→local→remote dependency chain is not applied on the first local **`applyVariants`** call and is applied after remote fetch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d232bbfaa35c17d6f939f41e06942596b29c129a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->