### PR TITLE
fix(experiment-tag): wait for document.body before loading overlay script

### DIFF
--- a/packages/experiment-tag/src/util/messenger.ts
+++ b/packages/experiment-tag/src/util/messenger.ts
@@ -215,6 +215,21 @@ export const asyncLoadScript = (url: string) => {
     };
 
     DebugRecorder.push('readyState', document.readyState);
-    loadScript();
+
+    // Wait for document.body — the overlay's top-level setup calls
+    // document.body.appendChild and throws when body is null. rAF polling
+    // instead of addEventListener('load') because third-party scripts can
+    // proxy addEventListener and suppress those handlers.
+    const globalScope = getGlobalScope();
+    const waitForBody = () => {
+      if (document.body) {
+        loadScript();
+      } else if (globalScope?.requestAnimationFrame) {
+        globalScope.requestAnimationFrame(waitForBody);
+      } else {
+        loadScript();
+      }
+    };
+    waitForBody();
   });
 };


### PR DESCRIPTION
### Summary

Datadog synthetics occasionally fail opening the visual editor with:

> Uncaught TypeError: Cannot read properties of null (reading 'appendChild')
> at https://experiment-overlay.prod.us-west-2.amplitude.com/scripts/index.js:1794:19

The overlay's top-level setup ([entrypoint/index.tsx:531](https://github.com/amplitude/javascript/blob/main/apps/experiment-overlay/src/entrypoint/index.tsx#L531)) unconditionally calls `document.body.appendChild(renderIn)` to mount its shadow host. When the SDK dispatches the overlay script before the parser reaches `<body>`, body is null and the overlay crashes on startup.

The race was introduced by [#299](https://github.com/amplitude/experiment-js-client/pull/299), which removed the previous wait for `window.load` because third-party scripts that proxy `addEventListener` could swallow the load event and leave the overlay never loading.

This PR re-introduces a wait, but:

- Waits for `document.body` only (not full `readyState === 'complete'`), so it doesn't block on subresources.
- Uses `requestAnimationFrame` polling, so we don't depend on `addEventListener('DOMContentLoaded'/'load')` and stay safe against the proxy issue #299 was fixing.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the timing of overlay script injection by delaying loads until `document.body` exists, which could affect when/if the overlay loads in unusual runtime environments or if `requestAnimationFrame` is unavailable.
> 
> **Overview**
> Prevents early overlay startup crashes by delaying `asyncLoadScript` injection until `document.body` is available.
> 
> Instead of relying on `load`/`DOMContentLoaded`, it polls via `requestAnimationFrame` (with a fallback to immediate load) to avoid third-party `addEventListener` interference while still ensuring the overlay’s top-level `document.body.appendChild` won’t run with a null body.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3390ae453739f335b4ce6830c94d00f3b6303666. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->