### PR TITLE
fix: upload for chrome ext release

### DIFF
--- a/scripts/upload-to-s3.js
+++ b/scripts/upload-to-s3.js
@@ -158,7 +158,10 @@ const allPromises = packagesToUpload.flatMap((packageConfig) => {
         .send(headObject)
         .then(() => {
           // If branch name is provided, always overwrite to ensure latest branch version
-          if (branchName) {
+          if (
+            branchName ||
+            packageConfig.name === availablePackages['chrome-extension'].name
+          ) {
             console.log(
               `[Publish to AWS S3] ${key} exists in target bucket. Overwriting for branch deployment...`,
             );


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional change in the publish script; only affects whether chrome-extension artifacts are re-uploaded to S3.
> 
> **Overview**
> **Chrome extension S3 publishes** no longer get skipped when the target key already exists.
> 
> In `scripts/upload-to-s3.js`, the “object exists” path only overwrote uploads when `BRANCH_NAME` was set. The chrome extension artifact uses a **fixed, unversioned** key (`experiment-tag-latest-chrome-ext-v1-min.js`), so repeat release uploads were treated like immutable versioned libs and **skipped** instead of updating the live file.
> 
> The overwrite condition now also applies when `packageConfig.name` matches the chrome-extension package, so release uploads replace the existing object (still using long cache when no branch name is set).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acfc412880c1b224d5c51017de30a6a9b634a4d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->