### PR TITLE
fix(mutations): update dom-mutator version [WEB-72]

### DIFF
--- a/packages/experiment-tag/package.json
+++ b/packages/experiment-tag/package.json
@@ -31,7 +31,7 @@
     "@amplitude/analytics-types": "^2.11.0",
     "@amplitude/experiment-core": "^0.13.1",
     "@amplitude/experiment-js-client": "^1.21.1",
-    "dom-mutator": "git+ssh://git@github.com/amplitude/dom-mutator#07a72dddbc2969ea826bdfe2b55d461d5d340992",
+    "dom-mutator": "git+ssh://git@github.com/amplitude/dom-mutator#bb5f4b52273e6a3de39dcf6db6f428d66d988a7b",
     "rollup-plugin-license": "^3.6.0"
   },
   "devDependencies": {

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -15,8 +15,12 @@ import {
   Variants,
 } from '@amplitude/experiment-js-client';
 import * as FeatureExperiment from '@amplitude/experiment-js-client';
-import mutate, { MutationController } from 'dom-mutator';
+import mutate from 'dom-mutator';
 import * as domMutatorExports from 'dom-mutator';
+// `MutationController` (and the rest of the type definitions) moved out
+// of `dom-mutator`'s public entry in canonical PR #28; pull the type from
+// the dist subpath so this keeps compiling against the new bb5f4b5 pin.
+import type { MutationController } from 'dom-mutator/dist/types';
 
 import { BehavioralTargetingManager } from './behavioral-targeting';
 import { showPreviewModeModal } from './preview/preview';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3733,9 +3733,11 @@ dom-accessibility-api@^0.5.1:
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
   integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
 
-"dom-mutator@git+ssh://git@github.com/amplitude/dom-mutator#07a72dddbc2969ea826bdfe2b55d461d5d340992":
+"dom-mutator@git+ssh://git@github.com/amplitude/dom-mutator#bb5f4b52273e6a3de39dcf6db6f428d66d988a7b":
   version "0.7.1"
-  resolved "git+ssh://git@github.com/amplitude/dom-mutator#07a72dddbc2969ea826bdfe2b55d461d5d340992"
+  resolved "git+ssh://git@github.com/amplitude/dom-mutator#bb5f4b52273e6a3de39dcf6db6f428d66d988a7b"
+  dependencies:
+    morphdom "^2.7.8"
 
 domexception@^4.0.0:
   version "4.0.0"
@@ -6539,6 +6541,11 @@ moment@^2.30.1:
   version "2.30.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
   integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
+
+morphdom@^2.7.8:
+  version "2.7.8"
+  resolved "https://registry.yarnpkg.com/morphdom/-/morphdom-2.7.8.tgz#9a81aae144136702d58cfae8226470bfd64fe74c"
+  integrity sha512-D/fR4xgGUyVRbdMGU6Nejea1RFzYxYtyurG4Fbv2Fi/daKlWKuXGLOdXtl+3eIwL110cI2hz1ZojGICjjFLgTg==
 
 ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"


### PR DESCRIPTION
## Summary

Bumps `dom-mutator` from `07a72dd` to [`bb5f4b5`](https://github.com/amplitude/dom-mutator/commit/bb5f4b5) (canonical `origin/main` HEAD) in `packages/experiment-tag`.

Picks up everything since the last bump (#315):

- [#23 (WEB-68)](https://github.com/amplitude/dom-mutator/pull/23) — shadow DOM resolution. `shadowHosts?: string[]` on `Selector`; `resolveScope` / `resolveTargets` helpers.
- [#25 (WEB-69)](https://github.com/amplitude/dom-mutator/pull/25) — per-shadow `MutationObserver`s with opportunistic discovery and lazy activation. Light-only callers pay zero overhead.
- [#24](https://github.com/amplitude/dom-mutator/pull/24) — morphdom-based minimal patches for html mutations.
- [#26](https://github.com/amplitude/dom-mutator/pull/26) — selective observing for html mutations.
- [#28](https://github.com/amplitude/dom-mutator/pull/28) — new `insert` mutation type and type-export reorg.

Linear ticket: WEB-72. Pairs with [WEB-71 (javascript repo PR #121604)](https://github.com/amplitude/javascript/pull/121604) — the workspace fork sync. Both land at the same canonical SHA (`bb5f4b5`) to keep the SDK and the visual editor in lockstep.

## Consumer change

`packages/experiment-tag/src/experiment.ts` — `MutationController` import moved from the package entry to the `dist/types` subpath. Canonical PR #28 stopped re-exporting type definitions from `index.ts`, so `import { MutationController } from 'dom-mutator'` no longer resolves at compile time. Runtime imports (`mutate`, `pauseGlobalObserver`, `resumeGlobalObserver`) are unchanged.

## Testing

| Command | Result |
|---|---|
| `yarn workspace @amplitude/experiment-tag build` | clean |
| `yarn workspace @amplitude/experiment-tag test` | 161/161 pass (12 suites) |

Shadow-DOM and morphdom html-patching are opt-in via mutation payload shape; existing flag configs apply unchanged. The new `insert` mutation type from #28 is not yet emitted by skylab, so existing variant behavior is unaffected.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the DOM mutation stack used for web experiments; behavior changes in dom-mutator are mostly opt-in, but HTML mutation paths now use morphdom and new observer logic.
> 
> **Overview**
> **Updates `@amplitude/experiment-tag` to pin `dom-mutator` at canonical `bb5f4b5`**, replacing the previous git SHA in `package.json` and `yarn.lock`. That upstream revision adds shadow-DOM targeting/observers, morphdom-based HTML patching, selective observers, and an `insert` mutation type; the lockfile now pulls in **`morphdom`** as a transitive dependency.
> 
> Because **`dom-mutator` no longer re-exports types from its main entry** (upstream PR #28), **`experiment.ts` imports `MutationController` from `dom-mutator/dist/types`** instead of alongside `mutate`. Default runtime imports (`mutate`, `domMutatorExports`) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69a6771c363cd4341aa2f730ae2d6329c6ee7b7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->