### PR TITLE
fix: removeAntiFlickerCss should remove amp-exp-css element

### DIFF
--- a/packages/experiment-tag/src/util/anti-flicker.ts
+++ b/packages/experiment-tag/src/util/anti-flicker.ts
@@ -36,10 +36,13 @@ export const applyAntiFlickerCss = () => {
 };
 
 /**
- * Revert the anti-flicker stylesheet immediately. Idempotent — safe to call
- * even when no sheet is active.
+ * Revert the anti-flicker stylesheet immediately. Also removes any
+ * <style id="amp-exp-css"> element injected by customer snippets.
+ * Idempotent — safe to call even when no sheet is active.
  */
 export const removeAntiFlickerCss = (): void => {
   activeHandle?.revert();
   activeHandle = undefined;
+  const globalScope = getGlobalScope();
+  globalScope?.document.getElementById('amp-exp-css')?.remove();
 };

--- a/packages/experiment-tag/test/util/mocks.ts
+++ b/packages/experiment-tag/test/util/mocks.ts
@@ -26,6 +26,7 @@ export const createDocumentMock = (overrides?: Record<string, unknown>) => ({
   },
   querySelector: jest.fn(),
   createElement: jest.fn(),
+  getElementById: jest.fn().mockReturnValue(null),
   head: {
     appendChild: jest.fn(),
   },


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

`removeAntiFlickerCss` should remove `amp-exp-css` element specified in [dev docs](https://amplitude.com/docs/web-experiment/implementation#async-script-with-anti-flicker-snippet).

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, idempotent DOM cleanup in existing teardown paths; no auth or data changes.
> 
> **Overview**
> **`removeAntiFlickerCss`** now tears down both anti-flicker mechanisms: it still reverts the SDK’s constructable stylesheet, and it also removes any **`#amp-exp-css`** `<style>` node that customers add via the documented async anti-flicker snippet.
> 
> The document test mock gains **`getElementById`** (default `null`) so callers that hit this path don’t break in unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 209903cea5b6ca1e96536a612951cec064eebc82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->