### PR TITLE
feat(experiment-tag): add cross-subdomain web_exp_id_v2 and first_seen cookies

### DIFF
--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -407,7 +407,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       expirationDays: 365,
     });
 
-    const webExpIdV2CookieKey = `${experimentStorageName}_id_v2`;
+    const webExpIdV2CookieKey = `${experimentStorageName}_web_exp_id_v2`;
     const webExpIdV2LocalFallback = user.web_exp_id_v2 ?? user.web_exp_id;
     let generatedSharedId: string | undefined;
     const webExpIdV2 = await resolveCrossSubdomainValue(

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -416,7 +416,9 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
 
     // Resolve web_exp_id_v2 and web_exp_first_seen as root-domain cookies for
     // cross-subdomain identity. Cookie is authoritative; localStorage is the
-    // migration source / backup when no cookie exists yet.
+    // migration / backup source when no cookie exists yet. When seeding v2,
+    // prefer existing web_exp_id_v2 local value, then web_exp_id; if neither
+    // exists, generate one UUID and assign to both.
     const rootDomain = await getTopLevelDomain(
       this.globalScope.location.hostname,
     );
@@ -426,13 +428,23 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       expirationDays: 365,
     });
 
+    const webExpIdV2CookieKey = `${experimentStorageName}_id_v2`;
+    const webExpIdV2LocalFallback = user.web_exp_id_v2 ?? user.web_exp_id;
+    let generatedSharedId: string | undefined;
     const webExpIdV2 = await resolveCrossSubdomainValue(
       crossSubdomainCookieStorage,
-      `${experimentStorageName}_id_v2`,
-      user.web_exp_id_v2,
-      UUID,
+      webExpIdV2CookieKey,
+      webExpIdV2LocalFallback,
+      () => {
+        generatedSharedId = UUID();
+        return generatedSharedId;
+      },
     );
     user.web_exp_id_v2 = webExpIdV2;
+    if (generatedSharedId) {
+      user.web_exp_id = generatedSharedId;
+      delete user.device_id;
+    }
     setStorageItem('localStorage', experimentStorageName, user);
 
     const defaultUserProviderStorageKey = `${experimentStorageName}_DEFAULT_USER_PROVIDER`;

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -410,6 +410,26 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       }
     }
 
+    // Initialize web_exp_id_v2 as a root-domain cookie for cross-subdomain identity.
+    // Unlike web_exp_id (localStorage, per-origin), web_exp_id_v2 is shared across
+    // all subdomains of the same root domain (e.g. www.example.com and app.example.com).
+    // New experiments created after the cutover use web_exp_id_v2 for bucketing.
+    const v2CookieKey = `${experimentStorageName}_id_v2`;
+    const rootDomain = await getTopLevelDomain(
+      this.globalScope.location.hostname,
+    );
+    const v2CookieStorage = new CookieStorage<string>({
+      ...(rootDomain && { domain: rootDomain }),
+      sameSite: 'Lax',
+      expirationDays: 365,
+    });
+    let webExpIdV2 = await v2CookieStorage.get(v2CookieKey);
+    if (!webExpIdV2) {
+      webExpIdV2 = UUID();
+      await v2CookieStorage.set(v2CookieKey, webExpIdV2);
+    }
+    user.web_exp_id_v2 = webExpIdV2;
+
     const enrichedUser = await enrichUserWithCampaignData(this.apiKey, user);
 
     // If no integration has been set, use an Amplitude integration.

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -49,7 +49,11 @@ import {
 import type { AudienceEvaluationDebugInfo, DebugState } from './types/debug';
 import { applyAntiFlickerCss, removeAntiFlickerCss } from './util/anti-flicker';
 import { enrichUserWithCampaignData } from './util/campaign';
-import { getTopLevelDomain, setMarketingCookie } from './util/cookie';
+import {
+  getTopLevelDomain,
+  resolveCrossSubdomainValue,
+  setMarketingCookie,
+} from './util/cookie';
 import {
   cspSafeStyleSheet,
   type StyleSheetHandle,
@@ -410,25 +414,48 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       }
     }
 
-    // Initialize web_exp_id_v2 as a root-domain cookie for cross-subdomain identity.
-    // Unlike web_exp_id (localStorage, per-origin), web_exp_id_v2 is shared across
-    // all subdomains of the same root domain (e.g. www.example.com and app.example.com).
-    // New experiments created after the cutover use web_exp_id_v2 for bucketing.
-    const v2CookieKey = `${experimentStorageName}_id_v2`;
+    // Resolve web_exp_id_v2 and web_exp_first_seen as root-domain cookies for
+    // cross-subdomain identity. Cookie is authoritative; localStorage is the
+    // migration source / backup when no cookie exists yet.
     const rootDomain = await getTopLevelDomain(
       this.globalScope.location.hostname,
     );
-    const v2CookieStorage = new CookieStorage<string>({
+    const crossSubdomainCookieStorage = new CookieStorage<string>({
       ...(rootDomain && { domain: rootDomain }),
       sameSite: 'Lax',
       expirationDays: 365,
     });
-    let webExpIdV2 = await v2CookieStorage.get(v2CookieKey);
-    if (!webExpIdV2) {
-      webExpIdV2 = UUID();
-      await v2CookieStorage.set(v2CookieKey, webExpIdV2);
-    }
+
+    const webExpIdV2 = await resolveCrossSubdomainValue(
+      crossSubdomainCookieStorage,
+      `${experimentStorageName}_id_v2`,
+      user.web_exp_id_v2,
+      UUID,
+    );
     user.web_exp_id_v2 = webExpIdV2;
+    setStorageItem('localStorage', experimentStorageName, user);
+
+    const defaultUserProviderStorageKey = `${experimentStorageName}_DEFAULT_USER_PROVIDER`;
+    const defaultUserProviderData =
+      getStorageItem<{ first_seen?: string }>(
+        'localStorage',
+        defaultUserProviderStorageKey,
+      ) || {};
+    const firstSeen = await resolveCrossSubdomainValue(
+      crossSubdomainCookieStorage,
+      `${experimentStorageName}_first_seen`,
+      defaultUserProviderData.first_seen,
+      () => (Date.now() / 1000).toString(),
+    );
+    if (firstSeen !== defaultUserProviderData.first_seen) {
+      defaultUserProviderData.first_seen = firstSeen;
+      setStorageItem(
+        'localStorage',
+        defaultUserProviderStorageKey,
+        defaultUserProviderData,
+      );
+    }
+    user.first_seen = firstSeen;
 
     const enrichedUser = await enrichUserWithCampaignData(this.apiKey, user);
 

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -408,22 +408,13 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     });
 
     const webExpIdV2CookieKey = `${experimentStorageName}_web_exp_id_v2`;
-    const webExpIdV2LocalFallback = user.web_exp_id_v2 ?? user.web_exp_id;
-    let generatedSharedId: string | undefined;
-    const webExpIdV2 = await resolveCrossSubdomainValue(
+    // web_exp_id is guaranteed above; seed v2 from it when no cookie or local v2 exists.
+    user.web_exp_id_v2 = await resolveCrossSubdomainValue(
       crossSubdomainCookieStorage,
       webExpIdV2CookieKey,
-      webExpIdV2LocalFallback,
-      () => {
-        generatedSharedId = UUID();
-        return generatedSharedId;
-      },
+      user.web_exp_id_v2 ?? user.web_exp_id,
+      UUID,
     );
-    user.web_exp_id_v2 = webExpIdV2;
-    if (generatedSharedId) {
-      user.web_exp_id = generatedSharedId;
-      delete user.device_id;
-    }
     setStorageItem('localStorage', experimentStorageName, user);
 
     const defaultUserProviderStorageKey = `${experimentStorageName}_DEFAULT_USER_PROVIDER`;

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -395,30 +395,9 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       setStorageItem('localStorage', experimentStorageName, user);
     }
 
-    // evaluate variants for page targeting
-    const variants: Variants = this.getVariants();
-
-    for (const [flagKey, variant] of Object.entries(variants)) {
-      // only apply anti-flicker for remote flags active on the page
-      if (
-        this.remoteFlagKeys.includes(flagKey) &&
-        variant.metadata?.blockingEvaluation &&
-        Object.keys(this.activePages).includes(flagKey) &&
-        !this.remoteFlagKeys.every((key) =>
-          Object.keys(this.previewFlags).includes(key),
-        )
-      ) {
-        this.isRemoteBlocking = true;
-        // Apply anti-flicker CSS to prevent UI flicker
-        applyAntiFlickerCss();
-      }
-    }
-
-    // Resolve web_exp_id_v2 and web_exp_first_seen as root-domain cookies for
-    // cross-subdomain identity. Cookie is authoritative; localStorage is the
-    // migration / backup source when no cookie exists yet. When seeding v2,
-    // prefer existing web_exp_id_v2 local value, then web_exp_id; if neither
-    // exists, generate one UUID and assign to both.
+    // Resolve web_exp_id_v2 and first_seen as root-domain cookies for
+    // cross-subdomain identity before getVariants() so anti-flicker and
+    // local evaluation use the shared first_seen, not a subdomain-local mint.
     const rootDomain = await getTopLevelDomain(
       this.globalScope.location.hostname,
     );
@@ -468,6 +447,26 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       );
     }
     user.first_seen = firstSeen;
+    this.experimentClient.setUser(user);
+
+    // evaluate variants for page targeting
+    const variants: Variants = this.getVariants();
+
+    for (const [flagKey, variant] of Object.entries(variants)) {
+      // only apply anti-flicker for remote flags active on the page
+      if (
+        this.remoteFlagKeys.includes(flagKey) &&
+        variant.metadata?.blockingEvaluation &&
+        Object.keys(this.activePages).includes(flagKey) &&
+        !this.remoteFlagKeys.every((key) =>
+          Object.keys(this.previewFlags).includes(key),
+        )
+      ) {
+        this.isRemoteBlocking = true;
+        // Apply anti-flicker CSS to prevent UI flicker
+        applyAntiFlickerCss();
+      }
+    }
 
     const enrichedUser = await enrichUserWithCampaignData(this.apiKey, user);
 

--- a/packages/experiment-tag/src/types.ts
+++ b/packages/experiment-tag/src/types.ts
@@ -173,6 +173,7 @@ export interface WebExperimentClient {
 
 export type WebExperimentUser = {
   web_exp_id?: string;
+  web_exp_id_v2?: string;
 } & ExperimentUser;
 
 export type InitConfigs = {

--- a/packages/experiment-tag/src/util/cookie.ts
+++ b/packages/experiment-tag/src/util/cookie.ts
@@ -151,7 +151,8 @@ export async function getTopLevelDomain(hostname: string): Promise<string> {
 /**
  * Resolves a cross-subdomain value using cookie storage as the authoritative
  * source. Falls back to a provided localStorage value (migration path), then
- * generates a new value if neither exists. Always ensures the cookie is set.
+ * generates a new value if neither exists. Attempts to set the cookie when
+ * missing; cookie I/O failures fall back to localStorage / generateNew.
  * Callers are responsible for syncing the returned value back to localStorage.
  */
 export async function resolveCrossSubdomainValue(
@@ -160,12 +161,20 @@ export async function resolveCrossSubdomainValue(
   localStorageValue: string | undefined,
   generateNew: () => string,
 ): Promise<string> {
-  const cookieValue = await cookieStorage.get(cookieKey);
-  if (cookieValue) {
-    return cookieValue;
+  try {
+    const cookieValue = await cookieStorage.get(cookieKey);
+    if (cookieValue) {
+      return cookieValue;
+    }
+  } catch {
+    // Cookie read blocked; fall through to localStorage / generateNew.
   }
   const value = localStorageValue ?? generateNew();
-  await cookieStorage.set(cookieKey, value);
+  try {
+    await cookieStorage.set(cookieKey, value);
+  } catch {
+    // Cookie write blocked; return value for localStorage-only persistence.
+  }
   return value;
 }
 

--- a/packages/experiment-tag/src/util/cookie.ts
+++ b/packages/experiment-tag/src/util/cookie.ts
@@ -148,6 +148,27 @@ export async function getTopLevelDomain(hostname: string): Promise<string> {
   return (cachedDomain = '');
 }
 
+/**
+ * Resolves a cross-subdomain value using cookie storage as the authoritative
+ * source. Falls back to a provided localStorage value (migration path), then
+ * generates a new value if neither exists. Always ensures the cookie is set.
+ * Callers are responsible for syncing the returned value back to localStorage.
+ */
+export async function resolveCrossSubdomainValue(
+  cookieStorage: CookieStorage<string>,
+  cookieKey: string,
+  localStorageValue: string | undefined,
+  generateNew: () => string,
+): Promise<string> {
+  const cookieValue = await cookieStorage.get(cookieKey);
+  if (cookieValue) {
+    return cookieValue;
+  }
+  const value = localStorageValue ?? generateNew();
+  await cookieStorage.set(cookieKey, value);
+  return value;
+}
+
 export async function setMarketingCookie(apiKey: string, hostname: string) {
   const domain = await getTopLevelDomain(hostname);
   const storage = new CookieStorage<Campaign>({

--- a/packages/experiment-tag/test/experiment.test.ts
+++ b/packages/experiment-tag/test/experiment.test.ts
@@ -127,7 +127,7 @@ describe('initializeExperiment', () => {
   test('seeds web_exp_id_v2 from existing web_exp_id when cookie is missing', async () => {
     const key = stringify(apiKey);
     const storageKey = 'EXP_' + key;
-    const cookieKey = storageKey + '_id_v2';
+    const cookieKey = storageKey + '_web_exp_id_v2';
     mockGlobal.localStorage.getItem.mockImplementation((name: string) => {
       if (name === storageKey) {
         return JSON.stringify({ web_exp_id: 'existing-id' });

--- a/packages/experiment-tag/test/experiment.test.ts
+++ b/packages/experiment-tag/test/experiment.test.ts
@@ -1039,7 +1039,7 @@ describe('initializeExperiment', () => {
     expect(antiFlickerSpy).toHaveBeenCalledTimes(1);
   });
 
-  test('remote evaluation - fetch fail, test initialFlags variant actions called', () => {
+  test('remote evaluation - fetch fail, test initialFlags variant actions called', async () => {
     const initialFlags = [
       // remote flag
       createMutateFlag(
@@ -1053,7 +1053,7 @@ describe('initializeExperiment', () => {
 
     const mockHttpClient = new MockHttpClient('', 404);
 
-    DefaultWebExperimentClient.getInstance(
+    await DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
       {
         initialFlags: JSON.stringify(initialFlags),
@@ -1062,15 +1062,10 @@ describe('initializeExperiment', () => {
       {
         httpClient: mockHttpClient,
       },
-    )
-      .start()
-      .then(() => {
-        // check remote variant actions applied
-        expect(mockExposure).toHaveBeenCalledTimes(1);
-        expect(mockExposure).toHaveBeenCalledWith('test');
-      });
-    // check local flag variant actions called
-    expect(mockExposure).toHaveBeenCalledTimes(0);
+    ).start();
+    // check remote variant actions applied
+    expect(mockExposure).toHaveBeenCalledTimes(1);
+    expect(mockExposure).toHaveBeenCalledWith('test');
     expect(antiFlickerSpy).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/experiment-tag/test/experiment.test.ts
+++ b/packages/experiment-tag/test/experiment.test.ts
@@ -120,7 +120,39 @@ describe('initializeExperiment', () => {
     );
     expect(mockGlobal.localStorage.setItem).toHaveBeenCalledWith(
       'EXP_' + stringify(apiKey),
-      JSON.stringify({ web_exp_id: 'mock' }),
+      JSON.stringify({ web_exp_id: 'mock', web_exp_id_v2: 'mock' }),
+    );
+  });
+
+  test('seeds web_exp_id_v2 from existing web_exp_id when cookie is missing', async () => {
+    const key = stringify(apiKey);
+    const storageKey = 'EXP_' + key;
+    const cookieKey = storageKey + '_id_v2';
+    mockGlobal.localStorage.getItem.mockImplementation((name: string) => {
+      if (name === storageKey) {
+        return JSON.stringify({ web_exp_id: 'existing-id' });
+      }
+      return null;
+    });
+
+    await DefaultWebExperimentClient.getInstance(key, {
+      initialFlags: JSON.stringify([]),
+      pageObjects: JSON.stringify({}),
+    }).start();
+
+    expect(ExperimentClient.prototype.setUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        web_exp_id: 'existing-id',
+        web_exp_id_v2: 'existing-id',
+      }),
+    );
+    expect(cookieStore[cookieKey]).toBe('existing-id');
+    expect(mockGlobal.localStorage.setItem).toHaveBeenCalledWith(
+      storageKey,
+      JSON.stringify({
+        web_exp_id: 'existing-id',
+        web_exp_id_v2: 'existing-id',
+      }),
     );
   });
 

--- a/packages/experiment-tag/test/experiment.test.ts
+++ b/packages/experiment-tag/test/experiment.test.ts
@@ -112,9 +112,12 @@ describe('initializeExperiment', () => {
       initialFlags: JSON.stringify([]),
       pageObjects: JSON.stringify({}),
     }).start();
-    expect(ExperimentClient.prototype.setUser).toHaveBeenCalledWith({
-      web_exp_id: 'mock',
-    });
+    expect(ExperimentClient.prototype.setUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        web_exp_id: 'mock',
+        web_exp_id_v2: expect.any(String),
+      }),
+    );
     expect(mockGlobal.localStorage.setItem).toHaveBeenCalledWith(
       'EXP_' + stringify(apiKey),
       JSON.stringify({ web_exp_id: 'mock' }),


### PR DESCRIPTION
### Summary

SDK-side **Plan B** identity for cross-subdomain web experiments. Resolves `web_exp_id_v2` and `first_seen` as root-domain cookies on `start()`, sets both on the user before `getVariants()` / anti-flicker.

**Product scope:** Old experiments are **not** expected to bucket consistently across subdomains (per-origin `web_exp_id` unchanged). This PR enables:
- **New experiments** — shared `web_exp_id_v2` for cross-subdomain bucketing when paired with [nova#31098](https://github.com/amplitude/nova/pull/31098) (new-experiment `createdAt` cutoff)
- **RTBT** — shared `web_exp_id_v2` for relay storage (`EXP_{slice}_{web_exp_id_v2}_*`)

### `web_exp_id_v2` resolution (cookie authoritative)

1. `EXP_{slice}_web_exp_id_v2` cookie exists → use it
2. Else `web_exp_id_v2` in per-origin localStorage → restore cookie
3. Else `web_exp_id` in per-origin localStorage → seed v2 from same value, set cookie
4. Else generate UUID → assign to **both** `web_exp_id` and `web_exp_id_v2`, set cookie

Mirrors resolved values back to per-origin `EXP_{slice}` localStorage for ITP recovery.

### `first_seen`

- Root-domain cookie `EXP_{slice}_first_seen`
- Migrates from `EXP_{slice}_DEFAULT_USER_PROVIDER` localStorage on first load
- Resolved **before** `getVariants()` so anti-flicker uses shared `first_seen`

### Helper

`resolveCrossSubdomainValue()` in `cookie.ts` — cookie → localStorage fallback → generate → set cookie (reused by the #336 session cookie later).

### Related PRs / merge order

1. **This PR** — client identity
2. [nova#31098](https://github.com/amplitude/nova/pull/31098) — skylab bucketing key (`web_exp_id_v2` for new experiments)
3. [#333](https://github.com/amplitude/experiment-js-client/pull/333) → [#335](https://github.com/amplitude/experiment-js-client/pull/335) / [#334](https://github.com/amplitude/experiment-js-client/pull/334) — relay wiring + dual-write
4. [nova#31184](https://github.com/amplitude/nova/pull/31184) — relay hosting

### Test plan

- [x] `npm test -- experiment.test.ts` (experiment-tag) — 36 tests, including seed-from-`web_exp_id`
- [ ] Manual: verify cookie + localStorage on two subdomains of same registrable domain

### Checklist

- [x] PR title follows [conventional commit format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)
- Breaking change: No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes experiment user identity and `first_seen` timing at SDK startup, which affects bucketing, anti-flicker, and downstream server pairing; cookie/localStorage migration paths add edge cases when cookies are blocked.
> 
> **Overview**
> Adds **cross-subdomain identity** on web experiment `start()` by resolving `web_exp_id_v2` and `first_seen` from root-domain cookies **before** `getVariants()` and anti-flicker, so bucketing and timing attributes align across subdomains.
> 
> **`web_exp_id_v2`** uses cookie-first resolution (with localStorage seed from existing `web_exp_id` when needed), syncs back to `EXP_{slice}` localStorage, and extends `WebExperimentUser`. Legacy per-origin `web_exp_id` behavior is unchanged.
> 
> **`first_seen`** is resolved the same way from `EXP_{slice}_first_seen` cookies, migrating from `DEFAULT_USER_PROVIDER` localStorage when present, and is set on the user prior to variant evaluation.
> 
> New helper **`resolveCrossSubdomainValue`** in `cookie.ts` centralizes cookie → localStorage → generate → set-cookie with graceful I/O failure handling. Tests cover v2 seeding and async remote-fetch failure paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f90bdd3af3e7520ae036f4d480459285fbff862. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->