### PR TITLE
fix(experiment-tag): keep anti-flicker overlay up during redirect navigation

### DIFF
--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -133,6 +133,10 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
   private readonly localFlagKeys: string[] = [];
   private remoteFlagKeys: string[] = [];
   private isRemoteBlocking = false;
+  // Public so the bootstrap (index.ts) can avoid removing anti-flicker CSS while
+  // a redirect is in-flight — location.replace() doesn't suspend painting, so
+  // tearing the overlay down before the navigation commits flashes the source page.
+  public isRedirecting = false;
   private customRedirectHandler: ((url: string) => void) | undefined;
   public isRunning = false;
   private readonly messageBus: MessageBus;
@@ -505,11 +509,12 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       keyToVariant: this.previewFlags,
     });
 
-    if (!this.isRemoteBlocking) {
+    if (!this.isRemoteBlocking && !this.isRedirecting) {
       removeAntiFlickerCss();
     }
 
     if (
+      this.isRedirecting ||
       // do not fetch remote flags if all remote flags are in preview mode
       this.remoteFlagKeys.every((key) =>
         Object.keys(this.previewFlags).includes(key),
@@ -1042,6 +1047,9 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     // set previous url - relevant for SPA if redirect happens before push/replaceState is complete
     this.previousUrl = this.globalScope.location.href;
     await setMarketingCookie(this.apiKey, this.globalScope.location.hostname);
+    // Mark redirect as in-flight so start() skips removeAntiFlickerCss and
+    // further processing after applyVariants returns.
+    this.isRedirecting = true;
     // perform redirection
     if (this.customRedirectHandler) {
       this.customRedirectHandler(targetUrl);

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -486,6 +486,17 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     });
     // Subscribe directly to url_change events to fire redirect impressions
     this.messageBus.subscribe('url_change', () => {
+      // A custom-redirect-handler (SPA soft nav) keeps this JS context alive, so
+      // isRedirecting would otherwise leak true forever — suppressing anti-flicker
+      // teardown and remote-flag handling on the destination route. url_change is
+      // the SDK's own post-navigation signal, so the first one after a redirect
+      // marks it committed: clear the flag and tear down the overlay. A hard
+      // location.replace() unloads the page before this fires, so it is a no-op
+      // there (which is correct — that path needs no reset).
+      if (this.isRedirecting) {
+        this.isRedirecting = false;
+        removeAntiFlickerCss();
+      }
       this.fireStoredRedirectImpressions().catch(() => {
         // do nothing
       });

--- a/packages/experiment-tag/src/index.ts
+++ b/packages/experiment-tag/src/index.ts
@@ -34,7 +34,10 @@ export const initialize = (
   if (shouldFetchConfigs) {
     applyAntiFlickerCss();
 
-    // Fetch latest configs and create client
+    // Fetch latest configs and create client. Anti-flicker teardown is delegated
+    // to startClient so it stays gated on isRedirecting — a redirect experiment
+    // surfaced in preview mode must keep the overlay up while navigation is
+    // in-flight, just like the normal path.
     fetchLatestConfigs(apiKey, config.serverZone)
       .then((previewState) => {
         const initialFlags = JSON.stringify(previewState.flags);
@@ -42,7 +45,7 @@ export const initialize = (
         const behavioralTargetingRules = JSON.stringify(
           previewState.behavioralTargetingRules,
         );
-        startClient(
+        return startClient(
           apiKey,
           {
             initialFlags,
@@ -54,10 +57,7 @@ export const initialize = (
       })
       .catch((error) => {
         console.warn('Failed to fetch latest configs for preview:', error);
-        startClient(apiKey, initConfigs, config);
-      })
-      .finally(() => {
-        removeAntiFlickerCss();
+        return startClient(apiKey, initConfigs, config);
       });
   } else {
     startClient(apiKey, initConfigs, config);
@@ -68,12 +68,22 @@ const startClient = (
   apiKey: string,
   initConfigs: InitConfigs,
   config: WebExperimentConfig,
-): void => {
-  DefaultWebExperimentClient.getInstance(apiKey, initConfigs, config)
-    .start()
-    .finally(() => {
+): Promise<void> => {
+  const client = DefaultWebExperimentClient.getInstance(
+    apiKey,
+    initConfigs,
+    config,
+  );
+  return client.start().finally(() => {
+    // Don't tear down anti-flicker while a redirect is in-flight. start()
+    // resolves immediately after location.replace() is called, but the browser
+    // keeps painting the current page until the destination commits — removing
+    // the overlay (including a customer's #amp-exp-css) here would flash the
+    // source page during the redirect's network wait.
+    if (!client.isRedirecting) {
       removeAntiFlickerCss();
-    });
+    }
+  });
 };
 
 const fetchLatestConfigs = async (apiKey: string, serverZone?: string) => {

--- a/packages/experiment-tag/test/experiment.test.ts
+++ b/packages/experiment-tag/test/experiment.test.ts
@@ -279,6 +279,54 @@ describe('initializeExperiment', () => {
     }
   });
 
+  test('custom redirect handler - url_change clears isRedirecting and tears down anti-flicker', async () => {
+    mockGlobal = newMockGlobal();
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    mockGetGlobalScope.mockReturnValue(mockGlobal);
+
+    const removeAntiFlickerSpy = jest.spyOn(
+      antiFlickerUtils,
+      'removeAntiFlickerCss',
+    );
+
+    const client = DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+      initialFlags: JSON.stringify([
+        createRedirectFlag(
+          'test',
+          'treatment',
+          'http://test.com/2',
+          undefined,
+          DEFAULT_REDIRECT_SCOPE,
+        ),
+      ]),
+      pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+    });
+
+    // Route the redirect through a custom handler (SPA soft nav): the JS context
+    // survives, so a hard location.replace() is never called.
+    const customHandler = jest.fn();
+    client.setRedirectHandler(customHandler);
+
+    await client.start();
+
+    // Custom handler drives navigation; no hard redirect.
+    expect(customHandler).toHaveBeenCalledWith('http://test.com/2');
+    expect(mockGlobal.location.replace).toHaveBeenCalledTimes(0);
+
+    // While the soft nav is in-flight the overlay must stay up.
+    expect((client as any).isRedirecting).toBe(true);
+    removeAntiFlickerSpy.mockClear();
+
+    // The soft nav commits and emits url_change: isRedirecting must reset and the
+    // overlay must be torn down so it (and any customer #amp-exp-css) is not left
+    // covering the destination route.
+    (client as any).messageBus.publish('url_change', {});
+
+    expect((client as any).isRedirecting).toBe(false);
+    expect(removeAntiFlickerSpy).toHaveBeenCalledTimes(1);
+  });
+
   test('control variant on control page - should not redirect but call exposure', async () => {
     await DefaultWebExperimentClient.getInstance(stringify(apiKey), {
       initialFlags: JSON.stringify([

--- a/packages/experiment-tag/test/experiment.test.ts
+++ b/packages/experiment-tag/test/experiment.test.ts
@@ -243,6 +243,10 @@ describe('initializeExperiment', () => {
       'http://test.com/2',
     );
 
+    // isRedirecting must be set so the bootstrap (index.ts) skips
+    // removeAntiFlickerCss while the redirect navigation is in-flight.
+    expect((client as any).isRedirecting).toBe(true);
+
     // Directly check if the value was stored in sessionStorage
     const storedValue = mockGlobal.sessionStorage.getItem(redirectStorageKey);
     expect(storedValue).not.toBeNull();


### PR DESCRIPTION
## Summary

Fixes a redirect "flash" in cross-subdomain redirect experiments.

#238 (cross-subdomain redirect impression tracking) made the redirect path **async**: `applyVariants` / `handleRedirect` became async and `handleRedirect` now `await`s `setMarketingCookie`, which resolves the registrable domain. `location.replace()` only *queues* navigation — JS keeps running and the browser keeps painting the source page until the destination commits. The anti-flicker teardown (`removeAntiFlickerCss`) ran inside that window and stripped the overlay (including a customer's `#amp-exp-css` snippet), flashing the original page mid-redirect.

The previously released version was not affected because its redirect path was synchronous (fire-and-forget cookie write, no `await` before `location.replace()`), so there was no gap for the overlay to be torn down. The flash is specific to the async redirect path introduced in #238.

## Changes

Gate every anti-flicker teardown path on a new `isRedirecting` flag:
- **`experiment.ts`** — set `isRedirecting = true` before `location.replace()`; skip `removeAntiFlickerCss()` and further remote processing in `start()` while a redirect is in-flight.
- **`index.ts`** — the bootstrap `.finally()` and the preview/extension path skip `removeAntiFlickerCss()` when `client.isRedirecting`. The preview path returns the `startClient` promise so teardown flows through the single `isRedirecting`-gated `finally`.

## Test plan
- [x] `experiment.test.ts` green (36 tests); asserts `isRedirecting` is set on the redirect path so the bootstrap skips teardown.
- [x] eslint + prettier clean (0 errors).
- [ ] Manual: trigger a cross-subdomain redirect experiment and confirm no flash of the source page during navigation (normal + preview/extension paths).

## Notes
- Builds on the async redirect path from #238; merge this before / together with that cross-subdomain redirect work shipping in a release — otherwise the flash surfaces for all customers once that async path ships.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core startup and redirect UX paths (anti-flicker timing and early return from remote fetch during redirects); behavior change is intentional but affects all redirect experiments and preview/extension bootstrap.
> 
> **Overview**
> Fixes a **flash of the source page** during redirect experiments when `start()` finishes before the browser commits navigation (notably after async `setMarketingCookie` before `location.replace()`).
> 
> Introduces **`isRedirecting`**, set in `handleRedirect` before navigation. **`removeAntiFlickerCss`** and early exit from remote-flag work in **`start()`** are skipped while that flag is true. **`index.ts`** routes preview/extension bootstrap teardown through **`startClient`’s `finally`**, which only removes anti-flicker when **`!client.isRedirecting`**.
> 
> For **SPA custom redirect handlers**, the first **`url_change`** after navigation clears **`isRedirecting`** and tears down the overlay so the flag does not stick and block teardown on the destination route.
> 
> Tests assert **`isRedirecting`** on hard redirect and the custom-handler **`url_change`** cleanup path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecb40323037c9f91e6c8cc97349b3adee445aef7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->