### PR TITLE
chore(eslint): enable jest/recommended ESLint rules and add commitlint [WEB-36]

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
+    'plugin:jest/recommended',
     'prettier',
     'prettier/@typescript-eslint',
   ],
@@ -27,5 +28,21 @@ module.exports = {
 
     // eslint-plugin-prettier
     'prettier/prettier': 'error',
+
+    // eslint-plugin-jest
+    'jest/expect-expect': [
+      'warn',
+      {
+        assertFunctionNames: [
+          'expect',
+          'assertMatch',
+          'assertNoMatch',
+          'assertInvalidVersion',
+          'assertValidVersion',
+          'assertVersionComparison',
+        ],
+      },
+    ],
+    'jest/no-conditional-expect': 'off',
   },
 };

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+set -e
+
+yarn commitlint --edit $1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,15 +7,20 @@ automatically (via husky).
 
 ### Lint and format hooks
 
-This repo enforces lint and formatting locally via git hooks:
+This repo enforces lint, formatting, and commit message format locally via git
+hooks:
 
 - **On commit**: `lint-staged` runs `eslint --fix` and `prettier --write` on
   staged files. Most formatting issues are fixed silently.
+- **On commit message**: `commitlint` enforces
+  [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) format
+  (for example, `feat:`, `fix:`, `chore:`). This matches what
+  [semantic-release](#release) expects.
 - **On push**: `yarn lint` runs across all packages. This is the same command CI
   runs, so if it passes locally it will pass in CI.
 
-If you need to bypass either hook in an emergency, use `git commit --no-verify`
-or `git push --no-verify`. CI will still enforce the check on the PR.
+If you need to bypass hooks in an emergency, use `git commit --no-verify` or
+`git push --no-verify`. CI will still enforce the check on the PR.
 
 #### Editor setup (recommended)
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+};

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "@babel/preset-typescript": "^7.10.4",
     "@babel/runtime": "^7.11.2",
     "@babel/types": "^7.11.0",
+    "@commitlint/cli": "^17.3.0",
+    "@commitlint/config-conventional": "^17.3.0",
     "@rollup/plugin-babel": "^5.2.0",
     "@rollup/plugin-commonjs": "^15.0.0",
     "@rollup/plugin-json": "^4.1.0",

--- a/packages/analytics-connector/test/identityStore.test.ts
+++ b/packages/analytics-connector/test/identityStore.test.ts
@@ -94,7 +94,7 @@ test('setIdentity with unchanged identity, identity listener not called', async 
   const expectedIdentity = { userId: 'user_id', deviceId: 'device_id' };
   identityStore.setIdentity(expectedIdentity);
   identityStore.addIdentityListener(() => {
-    fail('identity listener should not be called');
+    throw new Error('identity listener should not be called');
   });
   identityStore.setIdentity(expectedIdentity);
 });

--- a/packages/experiment-browser/test/client.test.ts
+++ b/packages/experiment-browser/test/client.test.ts
@@ -289,14 +289,14 @@ test('ExperimentClient.variant, with exposure tracking provider, track called on
     client.variant('key-that-does-not-exist');
   }
 
-  expect(trackSpy).toBeCalledTimes(0);
-  expect(logEventSpy).toBeCalledTimes(0);
+  expect(trackSpy).toHaveBeenCalledTimes(0);
+  expect(logEventSpy).toHaveBeenCalledTimes(0);
 
   for (let i = 0; i < 10; i++) {
     client.variant(serverKey);
   }
 
-  expect(trackSpy).toBeCalledTimes(1);
+  expect(trackSpy).toHaveBeenCalledTimes(1);
   expect(trackSpy).toHaveBeenCalledWith(
     expect.objectContaining({
       flag_key: serverKey,
@@ -321,8 +321,8 @@ test('ExperimentClient.variant, with analytics provider, exposure tracked, unset
   await client.fetch(testUser);
   client.variant(serverKey);
 
-  expect(spySet).toBeCalledTimes(1);
-  expect(spyTrack).toBeCalledTimes(1);
+  expect(spySet).toHaveBeenCalledTimes(1);
+  expect(spyTrack).toHaveBeenCalledTimes(1);
 
   const expectedEvent = {
     name: '[Experiment] Exposure',
@@ -341,15 +341,19 @@ test('ExperimentClient.variant, with analytics provider, exposure tracked, unset
     },
     userProperty: `[Experiment] ${serverKey}`,
   };
-  expect(spySet).lastCalledWith(expect.objectContaining(expectedEvent));
-  expect(spyTrack).lastCalledWith(expect.objectContaining(expectedEvent));
+  expect(spySet).toHaveBeenLastCalledWith(
+    expect.objectContaining(expectedEvent),
+  );
+  expect(spyTrack).toHaveBeenLastCalledWith(
+    expect.objectContaining(expectedEvent),
+  );
 
   // verify call order
   const spySetOrder = spySet.mock.invocationCallOrder[0];
   const spyTrackOrder = spyTrack.mock.invocationCallOrder[0];
   expect(spySetOrder).toBeLessThan(spyTrackOrder);
 
-  expect(spyUnset).toBeCalledTimes(0);
+  expect(spyUnset).toHaveBeenCalledTimes(0);
 });
 
 /**
@@ -1030,7 +1034,7 @@ describe('start', () => {
     mockClientStorage(client);
     const fetchSpy = jest.spyOn(client, 'fetch');
     await client.start();
-    expect(fetchSpy).toBeCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
     client.stop();
   }, 10000);
 
@@ -1044,7 +1048,7 @@ describe('start', () => {
     };
     const fetchSpy = jest.spyOn(client, 'fetch');
     await client.start();
-    expect(fetchSpy).toBeCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
     client.stop();
   });
 
@@ -1060,7 +1064,7 @@ describe('start', () => {
     };
     const fetchSpy = jest.spyOn(client, 'fetch');
     await client.start();
-    expect(fetchSpy).toBeCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
     client.stop();
   });
 
@@ -1071,7 +1075,7 @@ describe('start', () => {
     mockClientStorage(client);
     const fetchSpy = jest.spyOn(client, 'fetch');
     await client.start();
-    expect(fetchSpy).toBeCalledTimes(0);
+    expect(fetchSpy).toHaveBeenCalledTimes(0);
     client.stop();
   });
 
@@ -1363,7 +1367,7 @@ describe('throwOnError option', () => {
   });
 });
 
-test('test bootstrapping with v2 variants', async () => {
+test('bootstrapping with v2 variants', async () => {
   let exposureObject: Exposure;
   const client = new ExperimentClient(API_KEY, {
     initialVariants: {

--- a/packages/experiment-browser/test/defaultUserProvider.test.ts
+++ b/packages/experiment-browser/test/defaultUserProvider.test.ts
@@ -133,7 +133,7 @@ describe('DefaultUserProvider', () => {
     expect(actualUser).toEqual(expectedUser);
   });
 
-  test('test get from local and session storage', async () => {
+  test('get from local and session storage', async () => {
     mockLocalStorage['EXP_apikey_DEFAULT_USER_PROVIDER'] = '{"first_seen": 99}';
     mockSessionStorage['EXP_apikey_DEFAULT_USER_PROVIDER'] =
       '{"landing_url": "http://testtest.com"}';

--- a/packages/experiment-browser/test/integration/amplitude.test.ts
+++ b/packages/experiment-browser/test/integration/amplitude.test.ts
@@ -92,7 +92,7 @@ describe('AmplitudeIntegrationPlugin', () => {
           integration.setup(),
           new Promise<void>((resolve) => setTimeout(() => resolve(), 500)),
         ]);
-        fail('expected setup() to throw an error');
+        throw new Error('expected setup() to throw an error');
       } catch (e) {
         // Expected
       }

--- a/packages/experiment-browser/test/integration/manager.test.ts
+++ b/packages/experiment-browser/test/integration/manager.test.ts
@@ -283,7 +283,7 @@ describe('SessionDedupeCache', () => {
       safeGlobal.sessionStorage.getItem('EXP_sent_v2_$default_instance'),
     ).toBeNull();
   });
-  test('test storage key', () => {
+  test('storage key', () => {
     const instanceName = '$default_instance';
     const cache = new SessionDedupeCache(instanceName);
     expect(cache['storageKey']).toEqual('EXP_sent_v3_$default_instance');
@@ -572,7 +572,7 @@ describe('PersistentTrackingQueue', () => {
     safeGlobal.localStorage.clear();
   });
 
-  test('test storage key', () => {
+  test('storage key', () => {
     const instanceName = '$default_instance';
     const queue = new PersistentTrackingQueue(instanceName);
     expect(queue['storageKey']).toEqual('EXP_unsent_$default_instance');

--- a/packages/experiment-core/test/evaluation/evaluation-integration.test.ts
+++ b/packages/experiment-core/test/evaluation/evaluation-integration.test.ts
@@ -12,13 +12,13 @@ beforeAll(async () => {
 
 // Basic Tests
 
-test('test off', () => {
+test('off', () => {
   const user = userContext('user_id', 'device_id');
   const result = engine.evaluate(user, flags)['test-off'];
   expect(result?.key).toEqual('off');
 });
 
-test('test on', () => {
+test('on', () => {
   const user = userContext('user_id', 'device_id');
   const result = engine.evaluate(user, flags)['test-on'];
   expect(result?.key).toEqual('on');
@@ -26,7 +26,7 @@ test('test on', () => {
 
 // Opinionated Segment Tests
 
-test('test individual inclusions match', () => {
+test('individual inclusions match', () => {
   // Match user ID
   let user = userContext('user_id');
   let result = engine.evaluate(user, flags)['test-individual-inclusions'];
@@ -47,20 +47,20 @@ test('test individual inclusions match', () => {
   expect(result?.key).toEqual('off');
 });
 
-test('test flag dependencies on', () => {
+test('flag dependencies on', () => {
   const user = userContext('user_id', 'device_id');
   const result = engine.evaluate(user, flags)['test-flag-dependencies-on'];
   expect(result?.key).toEqual('on');
 });
 
-test('test flag dependencies off', () => {
+test('flag dependencies off', () => {
   const user = userContext('user_id', 'device_id');
   const result = engine.evaluate(user, flags)['test-flag-dependencies-off'];
   expect(result?.key).toEqual('off');
   expect(result?.metadata?.segmentName).toEqual('flag-dependencies');
 });
 
-test('test sticky bucketing', () => {
+test('sticky bucketing', () => {
   // On
   let user = userContext('user_id', 'device_id', undefined, {
     '[Experiment] test-sticky-bucketing': 'on',
@@ -86,14 +86,14 @@ test('test sticky bucketing', () => {
 
 // Experiment and Flag Segment Tests
 
-test('test experiment', () => {
+test('experiment', () => {
   const user = userContext('user_id', 'device_id');
   const result = engine.evaluate(user, flags)['test-experiment'];
   expect(result?.key).toEqual('on');
   expect(result?.metadata?.experimentKey).toEqual('exp-1');
 });
 
-test('test flag', () => {
+test('flag', () => {
   const user = userContext('user_id', 'device_id');
   const result = engine.evaluate(user, flags)['test-flag'];
   expect(result?.key).toEqual('on');
@@ -102,7 +102,7 @@ test('test flag', () => {
 
 // Conditional Logic Tests
 
-test('test multiple conditions and values', () => {
+test('multiple conditions and values', () => {
   // All match
   let user = userContext('user_id', 'device_id', undefined, {
     'key-1': 'value-1',
@@ -124,7 +124,7 @@ test('test multiple conditions and values', () => {
 
 // Conditional Property Targeting Tests
 
-test('test amplitude property targeting', () => {
+test('amplitude property targeting', () => {
   const user = userContext('user_id');
   const result = engine.evaluate(user, flags)[
     'test-amplitude-property-targeting'
@@ -132,7 +132,7 @@ test('test amplitude property targeting', () => {
   expect(result?.key).toEqual('on');
 });
 
-test('test cohort targeting', () => {
+test('cohort targeting', () => {
   let user = userContext(undefined, undefined, undefined, undefined, [
     'u0qtvwla',
     '12345678',
@@ -147,13 +147,13 @@ test('test cohort targeting', () => {
   expect(result?.key).toEqual('off');
 });
 
-test('test group name targeting', () => {
+test('group name targeting', () => {
   const user = groupContext('org name', 'amplitude');
   const result = engine.evaluate(user, flags)['test-group-name-targeting'];
   expect(result?.key).toEqual('on');
 });
 
-test('test group property targeting', () => {
+test('group property targeting', () => {
   const user = groupContext('org name', 'amplitude', {
     'org plan': 'enterprise2',
   });
@@ -163,25 +163,25 @@ test('test group property targeting', () => {
 
 // Bucketing Tests
 
-test('test amplitude id bucketing', () => {
+test('amplitude id bucketing', () => {
   const user = userContext(undefined, undefined, '1234567890');
   const result = engine.evaluate(user, flags)['test-amplitude-id-bucketing'];
   expect(result?.key).toEqual('on');
 });
 
-test('test user id bucketing', () => {
+test('user id bucketing', () => {
   const user = userContext('user_id');
   const result = engine.evaluate(user, flags)['test-user-id-bucketing'];
   expect(result?.key).toEqual('on');
 });
 
-test('test device id bucketing', () => {
+test('device id bucketing', () => {
   const user = userContext(undefined, 'device_id');
   const result = engine.evaluate(user, flags)['test-device-id-bucketing'];
   expect(result?.key).toEqual('on');
 });
 
-test('test custom user property bucketing', () => {
+test('custom user property bucketing', () => {
   const user = userContext(undefined, undefined, undefined, { key: 'value' });
   const result = engine.evaluate(user, flags)[
     'test-custom-user-property-bucketing'
@@ -189,13 +189,13 @@ test('test custom user property bucketing', () => {
   expect(result?.key).toEqual('on');
 });
 
-test('test group name bucketing', () => {
+test('group name bucketing', () => {
   const user = groupContext('org name', 'amplitude');
   const result = engine.evaluate(user, flags)['test-group-name-bucketing'];
   expect(result?.key).toEqual('on');
 });
 
-test('test group property bucketing', () => {
+test('group property bucketing', () => {
   const user = groupContext('org name', 'amplitude', {
     'org plan': 'enterprise2',
   });
@@ -205,7 +205,7 @@ test('test group property bucketing', () => {
 
 // Bucketing Allocation Tests
 
-test('test 1 percent allocation', () => {
+test('1 percent allocation', () => {
   let on = 0;
   for (let i = 0; i < 10000; i++) {
     const user = userContext(undefined, `${i + 1}`);
@@ -217,7 +217,7 @@ test('test 1 percent allocation', () => {
   expect(on).toEqual(107);
 });
 
-test('test 50 percent allocation', () => {
+test('50 percent allocation', () => {
   let on = 0;
   for (let i = 0; i < 10000; i++) {
     const user = userContext(undefined, `${i + 1}`);
@@ -229,7 +229,7 @@ test('test 50 percent allocation', () => {
   expect(on).toEqual(5009);
 });
 
-test('test 99 percent allocation', () => {
+test('99 percent allocation', () => {
   let on = 0;
   for (let i = 0; i < 10000; i++) {
     const user = userContext(undefined, `${i + 1}`);
@@ -243,7 +243,7 @@ test('test 99 percent allocation', () => {
 
 // Bucketing Distribution Tests
 
-test('test 1 percent distribution', () => {
+test('1 percent distribution', () => {
   let control = 0;
   let treatment = 0;
   for (let i = 0; i < 10000; i++) {
@@ -259,7 +259,7 @@ test('test 1 percent distribution', () => {
   expect(treatment).toEqual(9894);
 });
 
-test('test 50 percent distribution', () => {
+test('50 percent distribution', () => {
   let control = 0;
   let treatment = 0;
   for (let i = 0; i < 10000; i++) {
@@ -275,7 +275,7 @@ test('test 50 percent distribution', () => {
   expect(treatment).toEqual(5010);
 });
 
-test('test 99 percent distribution', () => {
+test('99 percent distribution', () => {
   let control = 0;
   let treatment = 0;
   for (let i = 0; i < 10000; i++) {
@@ -291,7 +291,7 @@ test('test 99 percent distribution', () => {
   expect(treatment).toEqual(91);
 });
 
-test('test multiple distributions', () => {
+test('multiple distributions', () => {
   let a = 0;
   let b = 0;
   let c = 0;
@@ -317,7 +317,7 @@ test('test multiple distributions', () => {
 
 // Operator Tests
 
-test('test is', () => {
+test('is', () => {
   const user = userContext(undefined, undefined, undefined, {
     key: 'value',
   });
@@ -325,7 +325,7 @@ test('test is', () => {
   expect(result?.key).toEqual('on');
 });
 
-test('test is not', () => {
+test('is not', () => {
   const user = userContext(undefined, undefined, undefined, {
     key: 'value',
   });
@@ -333,7 +333,7 @@ test('test is not', () => {
   expect(result?.key).toEqual('on');
 });
 
-test('test contains', () => {
+test('contains', () => {
   const user = userContext(undefined, undefined, undefined, {
     key: 'value',
   });
@@ -341,7 +341,7 @@ test('test contains', () => {
   expect(result?.key).toEqual('on');
 });
 
-test('test does not contain', () => {
+test('does not contain', () => {
   const user = userContext(undefined, undefined, undefined, {
     key: 'value',
   });
@@ -349,7 +349,7 @@ test('test does not contain', () => {
   expect(result?.key).toEqual('on');
 });
 
-test('test less', () => {
+test('less', () => {
   const user = userContext(undefined, undefined, undefined, {
     key: '-1',
   });
@@ -357,7 +357,7 @@ test('test less', () => {
   expect(result?.key).toEqual('on');
 });
 
-test('test less or equal', () => {
+test('less or equal', () => {
   const user = userContext(undefined, undefined, undefined, {
     key: '0',
   });
@@ -365,7 +365,7 @@ test('test less or equal', () => {
   expect(result?.key).toEqual('on');
 });
 
-test('test greater', () => {
+test('greater', () => {
   const user = userContext(undefined, undefined, undefined, {
     key: '1',
   });
@@ -373,7 +373,7 @@ test('test greater', () => {
   expect(result?.key).toEqual('on');
 });
 
-test('test greater or equal', () => {
+test('greater or equal', () => {
   const user = userContext(undefined, undefined, undefined, {
     key: '0',
   });
@@ -381,7 +381,7 @@ test('test greater or equal', () => {
   expect(result?.key).toEqual('on');
 });
 
-test('test version less', () => {
+test('version less', () => {
   const user = freeformUserContext({
     version: '1.9.0',
   });
@@ -389,7 +389,7 @@ test('test version less', () => {
   expect(result?.key).toEqual('on');
 });
 
-test('test version less or equal', () => {
+test('version less or equal', () => {
   const user = freeformUserContext({
     version: '1.10.0',
   });
@@ -397,7 +397,7 @@ test('test version less or equal', () => {
   expect(result?.key).toEqual('on');
 });
 
-test('test version greater', () => {
+test('version greater', () => {
   const user = freeformUserContext({
     version: '1.10.0',
   });
@@ -405,7 +405,7 @@ test('test version greater', () => {
   expect(result?.key).toEqual('on');
 });
 
-test('test version greater or equal', () => {
+test('version greater or equal', () => {
   const user = freeformUserContext({
     version: '1.9.0',
   });
@@ -413,7 +413,7 @@ test('test version greater or equal', () => {
   expect(result?.key).toEqual('on');
 });
 
-test('test set is', () => {
+test('set is', () => {
   const user = userContext(undefined, undefined, undefined, {
     key: ['1', '2', '3'],
   });
@@ -421,7 +421,7 @@ test('test set is', () => {
   expect(result?.key).toEqual('on');
 });
 
-test('test set is not', () => {
+test('set is not', () => {
   const user = userContext(undefined, undefined, undefined, {
     key: ['1', '2'],
   });
@@ -429,7 +429,7 @@ test('test set is not', () => {
   expect(result?.key).toEqual('on');
 });
 
-test('test set contains', () => {
+test('set contains', () => {
   const user = userContext(undefined, undefined, undefined, {
     key: ['1', '2', '3', '4'],
   });
@@ -437,7 +437,7 @@ test('test set contains', () => {
   expect(result?.key).toEqual('on');
 });
 
-test('test set does not contain', () => {
+test('set does not contain', () => {
   const user = userContext(undefined, undefined, undefined, {
     key: ['1', '2', '4'],
   });
@@ -445,7 +445,7 @@ test('test set does not contain', () => {
   expect(result?.key).toEqual('on');
 });
 
-test('test set contains any', () => {
+test('set contains any', () => {
   const user = userContext(undefined, undefined, undefined, undefined, [
     'u0qtvwla',
     '12345678',
@@ -454,7 +454,7 @@ test('test set contains any', () => {
   expect(result?.key).toEqual('on');
 });
 
-test('test set does not contain any', () => {
+test('set does not contain any', () => {
   const user = userContext(undefined, undefined, undefined, undefined, [
     '12345678',
     '87654321',
@@ -463,7 +463,7 @@ test('test set does not contain any', () => {
   expect(result?.key).toEqual('on');
 });
 
-test('test glob match', () => {
+test('glob match', () => {
   const user = userContext(undefined, undefined, undefined, {
     key: '/path/1/2/3/end',
   });
@@ -471,7 +471,7 @@ test('test glob match', () => {
   expect(result?.key).toEqual('on');
 });
 
-test('test glob does not match', () => {
+test('glob does not match', () => {
   const user = userContext(undefined, undefined, undefined, {
     key: '/path/1/2/3',
   });
@@ -481,7 +481,7 @@ test('test glob does not match', () => {
 
 // Test specific functionality
 
-test('test is with booleans', () => {
+test('is with booleans', () => {
   let user = userContext(undefined, undefined, undefined, {
     true: 'TRUE',
     false: 'FALSE',
@@ -504,7 +504,7 @@ test('test is with booleans', () => {
 
 // Multi-value array property tests
 
-test('test set is with JSON array string', () => {
+test('set is with JSON array string', () => {
   const user = userContext(undefined, undefined, undefined, {
     key: '["1", "2", "3"]',
   });
@@ -512,7 +512,7 @@ test('test set is with JSON array string', () => {
   expect(result?.key).toEqual('on');
 });
 
-test('test is with array (collection)', () => {
+test('is with array (collection)', () => {
   const user = userContext(undefined, undefined, undefined, {
     key: ['value1', 'value2'],
   });
@@ -520,7 +520,7 @@ test('test is with array (collection)', () => {
   expect(result?.key).toEqual('on');
 });
 
-test('test is not with array', () => {
+test('is not with array', () => {
   const user = userContext(undefined, undefined, undefined, {
     key: ['value3', 'value4'],
   });
@@ -528,7 +528,7 @@ test('test is not with array', () => {
   expect(result?.key).toEqual('on');
 });
 
-test('test contains with array', () => {
+test('contains with array', () => {
   const user = userContext(undefined, undefined, undefined, {
     key: ['has-target-value', 'has', 'value'],
   });
@@ -536,7 +536,7 @@ test('test contains with array', () => {
   expect(result?.key).toEqual('on');
 });
 
-test('test does not contain with array', () => {
+test('does not contain with array', () => {
   const user = userContext(undefined, undefined, undefined, {
     key: ['has-value', 'has', 'value'],
   });
@@ -544,7 +544,7 @@ test('test does not contain with array', () => {
   expect(result?.key).toEqual('on');
 });
 
-test('test is with JSON array string', () => {
+test('is with JSON array string', () => {
   const user = userContext(undefined, undefined, undefined, {
     key: '["value1", "value2"]',
   });
@@ -552,7 +552,7 @@ test('test is with JSON array string', () => {
   expect(result?.key).toEqual('on');
 });
 
-test('test does not contain with JSON array string', () => {
+test('does not contain with JSON array string', () => {
   const user = userContext(undefined, undefined, undefined, {
     key: '["has-value", "has", "value"]',
   });

--- a/packages/experiment-core/test/evaluation/murmur3.test.ts
+++ b/packages/experiment-core/test/evaluation/murmur3.test.ts
@@ -2,13 +2,13 @@ import { hash32x86 } from '../../src/evaluation/murmur3';
 
 const MURMUR_SEED = 0x7f3a21ea;
 
-test('test murmur3 hash simple', () => {
+test('murmur3 hash simple', () => {
   const input = 'brian';
   const result = hash32x86(input, MURMUR_SEED);
   expect(result).toEqual(3948467465);
 });
 
-test('test murmur3 hash english words', () => {
+test('murmur3 hash english words', () => {
   const inputs = ENGLISH_WORDS.split('\n');
   const outputs = MURMUR3_X86_32.split('\n');
   for (let i = 0; i < inputs.length; i++) {
@@ -19,7 +19,7 @@ test('test murmur3 hash english words', () => {
   }
 });
 
-test('test unicode strings', () => {
+test('unicode strings', () => {
   expect(hash32x86('My hovercraft is full of eels.')).toEqual(2953494853);
   expect(hash32x86('My 🚀 is full of 🦎.')).toEqual(1818098979);
   expect(hash32x86('吉 星 高 照')).toEqual(3435142074);

--- a/packages/experiment-core/test/evaluation/selector.test.ts
+++ b/packages/experiment-core/test/evaluation/selector.test.ts
@@ -11,7 +11,7 @@ const nestedObject = {
   object: primitiveObject,
 };
 
-test('test selector evaluation context types', () => {
+test('selector evaluation context types', () => {
   const context = nestedObject;
   expect(select(context, ['does', 'not', 'exist'])).toBeUndefined();
   expect(select(context, ['null'])).toBeUndefined();

--- a/packages/experiment-core/test/util/global.test.ts
+++ b/packages/experiment-core/test/util/global.test.ts
@@ -93,34 +93,36 @@ describe('getFetch', () => {
 });
 
 describe('getSetTimeout / getClearTimeout', () => {
-  it('returned setTimeout schedules the callback and clearTimeout cancels it', (done) => {
+  it('returned setTimeout schedules the callback and clearTimeout cancels it', async () => {
     const setTimeoutFn = getSetTimeout();
     const clearTimeoutFn = getClearTimeout();
     if (!setTimeoutFn || !clearTimeoutFn) {
-      done.fail('expected setTimeout/clearTimeout to be defined');
-      return;
+      throw new Error('expected setTimeout/clearTimeout to be defined');
     }
 
     let cancelled = false;
     const handle = setTimeoutFn(() => {
       if (cancelled) {
-        done.fail('cancelled timeout fired');
+        throw new Error('cancelled timeout fired');
       }
     }, 50);
     clearTimeoutFn(handle);
     cancelled = true;
 
-    setTimeoutFn(() => done(), 100);
+    await new Promise<void>((resolve) => setTimeoutFn(resolve, 100));
+    expect(cancelled).toBe(true);
   });
 });
 
 describe('getSetInterval / getClearInterval', () => {
-  it('returned setInterval schedules and clearInterval cancels', (done) => {
+  it('returned setInterval schedules and clearInterval cancels', async () => {
     const setIntervalFn = getSetInterval();
     const clearIntervalFn = getClearInterval();
-    if (!setIntervalFn || !clearIntervalFn) {
-      done.fail('expected setInterval/clearInterval to be defined');
-      return;
+    const setTimeoutFn = getSetTimeout();
+    if (!setIntervalFn || !clearIntervalFn || !setTimeoutFn) {
+      throw new Error(
+        'expected setInterval/clearInterval/setTimeout to be defined',
+      );
     }
 
     let calls = 0;
@@ -128,13 +130,10 @@ describe('getSetInterval / getClearInterval', () => {
       calls += 1;
     }, 25);
 
-    setTimeout(() => {
-      clearIntervalFn(handle);
-      const callsAtCancel = calls;
-      setTimeout(() => {
-        expect(calls).toBe(callsAtCancel);
-        done();
-      }, 75);
-    }, 80);
+    await new Promise<void>((resolve) => setTimeoutFn(resolve, 80));
+    clearIntervalFn(handle);
+    const callsAtCancel = calls;
+    await new Promise<void>((resolve) => setTimeoutFn(resolve, 75));
+    expect(calls).toBe(callsAtCancel);
   });
 });

--- a/packages/experiment-tag/test/experiment.test.ts
+++ b/packages/experiment-tag/test/experiment.test.ts
@@ -25,8 +25,8 @@ const DEFAULT_MUTATE_SCOPE = { metadata: { scope: ['A'] } };
 // Mock CookieStorage to use an in-memory store for testing
 const cookieStore: Record<string, any> = {};
 
-export const getCookieStore = () => cookieStore;
-export const clearCookieStore = () => {
+const getCookieStore = () => cookieStore;
+const clearCookieStore = () => {
   Object.keys(cookieStore).forEach((key) => delete cookieStore[key]);
 };
 
@@ -290,13 +290,13 @@ describe('initializeExperiment', () => {
     }).start();
 
     // No redirect should happen
-    expect(mockGlobal.location.replace).toBeCalledTimes(0);
+    expect(mockGlobal.location.replace).toHaveBeenCalledTimes(0);
 
     // Exposure should be tracked
     expect(mockExposure).toHaveBeenCalledWith('test');
 
     // No history manipulation
-    expect(mockGlobal.history.replaceState).toBeCalledTimes(0);
+    expect(mockGlobal.history.replaceState).toHaveBeenCalledTimes(0);
 
     // No redirect info should be stored
     const redirectStorageKey = `EXP_${apiKey.toString().slice(0, 10)}_REDIRECT`;
@@ -833,7 +833,7 @@ describe('initializeExperiment', () => {
     expect(mockExposure).not.toHaveBeenCalled();
   });
 
-  test('remote evaluation - request web remote flags', () => {
+  test('remote evaluation - request web remote flags', async () => {
     const mockUser = { user_id: 'user_id', device_id: 'device_id' };
     jest.spyOn(ExperimentClient.prototype, 'getUser').mockReturnValue(mockUser);
 
@@ -844,7 +844,7 @@ describe('initializeExperiment', () => {
 
     const mockHttpClient = new MockHttpClient(JSON.stringify([]));
 
-    DefaultWebExperimentClient.getInstance(
+    await DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
       {
         initialFlags: JSON.stringify(initialFlags),
@@ -853,17 +853,15 @@ describe('initializeExperiment', () => {
       {
         httpClient: mockHttpClient,
       },
-    )
-      .start()
-      .then(() => {
-        expect(mockHttpClient.requestUrl).toBe(
-          'https://flag.lab.amplitude.com/sdk/v2/flags?delivery_method=web',
-        );
-        // check flag fetch called with correct query param and header
-        expect(mockHttpClient.requestHeader['X-Amp-Exp-User']).toBe(
-          Base64.encodeURL(JSON.stringify(mockUser)),
-        );
-      });
+    ).start();
+
+    expect(mockHttpClient.requestUrl).toBe(
+      'https://flag.lab.amplitude.com/sdk/v2/flags?delivery_method=web',
+    );
+    // check flag fetch called with correct query param and header
+    expect(mockHttpClient.requestHeader['X-Amp-Exp-User']).toBe(
+      Base64.encodeURL(JSON.stringify(mockUser)),
+    );
   });
 
   test('remote evaluation - fetch successful, antiflicker applied', async () => {
@@ -1075,7 +1073,7 @@ describe('initializeExperiment', () => {
     expect(antiFlickerSpy).toHaveBeenCalledTimes(1);
   });
 
-  test('remote evaluation - test preview successful, does not fetch remote flags', () => {
+  test('remote evaluation - test preview successful, does not fetch remote flags', async () => {
     const mockGlobal = newMockGlobal({
       location: {
         href: 'http://test.com/',
@@ -1096,7 +1094,7 @@ describe('initializeExperiment', () => {
       ExperimentClient.prototype as any,
       'doFlags',
     );
-    DefaultWebExperimentClient.getInstance(
+    await DefaultWebExperimentClient.getInstance(
       stringify(apiKey),
       {
         initialFlags: JSON.stringify(initialFlags),
@@ -1105,12 +1103,10 @@ describe('initializeExperiment', () => {
       {
         httpClient: mockHttpClient,
       },
-    )
-      .start()
-      .then(() => {
-        // check remote fetch not called
-        expect(doFlagsMock).toHaveBeenCalledTimes(0);
-      });
+    ).start();
+
+    // check remote fetch not called
+    expect(doFlagsMock).toHaveBeenCalledTimes(0);
     expect(antiFlickerSpy).toHaveBeenCalledTimes(0);
   });
 
@@ -1621,7 +1617,7 @@ describe('initializeExperiment', () => {
       );
       expect(flags['test'].metadata.flagVersion).toEqual(4);
       expect(flags['test'].metadata.evaluationMode).toEqual('local');
-      expect(integrationManagerTrack).toBeCalledTimes(1);
+      expect(integrationManagerTrack).toHaveBeenCalledTimes(1);
       const call = integrationManagerTrack.mock.calls[0][0] as unknown as {
         flag_key: string;
         metadata: Record<string, unknown>;
@@ -1705,7 +1701,7 @@ describe('initializeExperiment', () => {
       );
       expect(flags['test'].metadata.flagVersion).toEqual(4);
       expect(flags['test'].metadata.evaluationMode).toEqual('local');
-      expect(integrationManagerTrack).toBeCalledTimes(2);
+      expect(integrationManagerTrack).toHaveBeenCalledTimes(2);
       const call1 = integrationManagerTrack.mock.calls[0][0] as unknown as {
         flag_key: string;
         variant: string;

--- a/packages/plugin-segment/test/plugin.test.ts
+++ b/packages/plugin-segment/test/plugin.test.ts
@@ -4,7 +4,7 @@ import { Analytics } from '@segment/analytics-next';
 import { segmentIntegrationPlugin } from 'src/plugin';
 import { snippetInstance } from 'src/snippet';
 
-export const sleep = (time: number): Promise<void> =>
+const sleep = (time: number): Promise<void> =>
   new Promise((resolve) => {
     setTimeout(resolve, time);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -986,6 +986,174 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@commitlint/cli@^17.3.0":
+  version "17.8.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-17.8.1.tgz#10492114a022c91dcfb1d84dac773abb3db76d33"
+  integrity sha512-ay+WbzQesE0Rv4EQKfNbSMiJJ12KdKTDzIt0tcK4k11FdsWmtwP0Kp1NWMOUswfIWo6Eb7p7Ln721Nx9FLNBjg==
+  dependencies:
+    "@commitlint/format" "^17.8.1"
+    "@commitlint/lint" "^17.8.1"
+    "@commitlint/load" "^17.8.1"
+    "@commitlint/read" "^17.8.1"
+    "@commitlint/types" "^17.8.1"
+    execa "^5.0.0"
+    lodash.isfunction "^3.0.9"
+    resolve-from "5.0.0"
+    resolve-global "1.0.0"
+    yargs "^17.0.0"
+
+"@commitlint/config-conventional@^17.3.0":
+  version "17.8.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/config-conventional/-/config-conventional-17.8.1.tgz#e5bcf0cfec8da7ac50bc04dc92e0a4ea74964ce0"
+  integrity sha512-NxCOHx1kgneig3VLauWJcDWS40DVjg7nKOpBEEK9E5fjJpQqLCilcnKkIIjdBH98kEO1q3NpE5NSrZ2kl/QGJg==
+  dependencies:
+    conventional-changelog-conventionalcommits "^6.1.0"
+
+"@commitlint/config-validator@^17.8.1":
+  version "17.8.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/config-validator/-/config-validator-17.8.1.tgz#5cc93b6b49d5524c9cc345a60e5bf74bcca2b7f9"
+  integrity sha512-UUgUC+sNiiMwkyiuIFR7JG2cfd9t/7MV8VB4TZ+q02ZFkHoduUS4tJGsCBWvBOGD9Btev6IecPMvlWUfJorkEA==
+  dependencies:
+    "@commitlint/types" "^17.8.1"
+    ajv "^8.11.0"
+
+"@commitlint/ensure@^17.8.1":
+  version "17.8.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/ensure/-/ensure-17.8.1.tgz#59183557844999dbb6aab6d03629a3d104d01a8d"
+  integrity sha512-xjafwKxid8s1K23NFpL8JNo6JnY/ysetKo8kegVM7c8vs+kWLP8VrQq+NbhgVlmCojhEDbzQKp4eRXSjVOGsow==
+  dependencies:
+    "@commitlint/types" "^17.8.1"
+    lodash.camelcase "^4.3.0"
+    lodash.kebabcase "^4.1.1"
+    lodash.snakecase "^4.1.1"
+    lodash.startcase "^4.4.0"
+    lodash.upperfirst "^4.3.1"
+
+"@commitlint/execute-rule@^17.8.1":
+  version "17.8.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/execute-rule/-/execute-rule-17.8.1.tgz#504ed69eb61044eeb84fdfd10cc18f0dab14f34c"
+  integrity sha512-JHVupQeSdNI6xzA9SqMF+p/JjrHTcrJdI02PwesQIDCIGUrv04hicJgCcws5nzaoZbROapPs0s6zeVHoxpMwFQ==
+
+"@commitlint/format@^17.8.1":
+  version "17.8.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/format/-/format-17.8.1.tgz#6108bb6b4408e711006680649927e1b559bdc5f8"
+  integrity sha512-f3oMTyZ84M9ht7fb93wbCKmWxO5/kKSbwuYvS867duVomoOsgrgljkGGIztmT/srZnaiGbaK8+Wf8Ik2tSr5eg==
+  dependencies:
+    "@commitlint/types" "^17.8.1"
+    chalk "^4.1.0"
+
+"@commitlint/is-ignored@^17.8.1":
+  version "17.8.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/is-ignored/-/is-ignored-17.8.1.tgz#cf25bcd8409c79684b63f8bdeb35df48edda244e"
+  integrity sha512-UshMi4Ltb4ZlNn4F7WtSEugFDZmctzFpmbqvpyxD3la510J+PLcnyhf9chs7EryaRFJMdAKwsEKfNK0jL/QM4g==
+  dependencies:
+    "@commitlint/types" "^17.8.1"
+    semver "7.5.4"
+
+"@commitlint/lint@^17.8.1":
+  version "17.8.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/lint/-/lint-17.8.1.tgz#bfc21215f6b18d41d4d43e2aa3cb79a5d7726cd8"
+  integrity sha512-aQUlwIR1/VMv2D4GXSk7PfL5hIaFSfy6hSHV94O8Y27T5q+DlDEgd/cZ4KmVI+MWKzFfCTiTuWqjfRSfdRllCA==
+  dependencies:
+    "@commitlint/is-ignored" "^17.8.1"
+    "@commitlint/parse" "^17.8.1"
+    "@commitlint/rules" "^17.8.1"
+    "@commitlint/types" "^17.8.1"
+
+"@commitlint/load@^17.8.1":
+  version "17.8.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/load/-/load-17.8.1.tgz#fa061e7bfa53281eb03ca8517ca26d66a189030c"
+  integrity sha512-iF4CL7KDFstP1kpVUkT8K2Wl17h2yx9VaR1ztTc8vzByWWcbO/WaKwxsnCOqow9tVAlzPfo1ywk9m2oJ9ucMqA==
+  dependencies:
+    "@commitlint/config-validator" "^17.8.1"
+    "@commitlint/execute-rule" "^17.8.1"
+    "@commitlint/resolve-extends" "^17.8.1"
+    "@commitlint/types" "^17.8.1"
+    "@types/node" "20.5.1"
+    chalk "^4.1.0"
+    cosmiconfig "^8.0.0"
+    cosmiconfig-typescript-loader "^4.0.0"
+    lodash.isplainobject "^4.0.6"
+    lodash.merge "^4.6.2"
+    lodash.uniq "^4.5.0"
+    resolve-from "^5.0.0"
+    ts-node "^10.8.1"
+    typescript "^4.6.4 || ^5.2.2"
+
+"@commitlint/message@^17.8.1":
+  version "17.8.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/message/-/message-17.8.1.tgz#a5cd226c419be20ee03c3d237db6ac37b95958b3"
+  integrity sha512-6bYL1GUQsD6bLhTH3QQty8pVFoETfFQlMn2Nzmz3AOLqRVfNNtXBaSY0dhZ0dM6A2MEq4+2d7L/2LP8TjqGRkA==
+
+"@commitlint/parse@^17.8.1":
+  version "17.8.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/parse/-/parse-17.8.1.tgz#6e00b8f50ebd63562d25dcf4230da2c9f984e626"
+  integrity sha512-/wLUickTo0rNpQgWwLPavTm7WbwkZoBy3X8PpkUmlSmQJyWQTj0m6bDjiykMaDt41qcUbfeFfaCvXfiR4EGnfw==
+  dependencies:
+    "@commitlint/types" "^17.8.1"
+    conventional-changelog-angular "^6.0.0"
+    conventional-commits-parser "^4.0.0"
+
+"@commitlint/read@^17.8.1":
+  version "17.8.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/read/-/read-17.8.1.tgz#b3f28777607c756078356cc133368b0e8c08092f"
+  integrity sha512-Fd55Oaz9irzBESPCdMd8vWWgxsW3OWR99wOntBDHgf9h7Y6OOHjWEdS9Xzen1GFndqgyoaFplQS5y7KZe0kO2w==
+  dependencies:
+    "@commitlint/top-level" "^17.8.1"
+    "@commitlint/types" "^17.8.1"
+    fs-extra "^11.0.0"
+    git-raw-commits "^2.0.11"
+    minimist "^1.2.6"
+
+"@commitlint/resolve-extends@^17.8.1":
+  version "17.8.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/resolve-extends/-/resolve-extends-17.8.1.tgz#9af01432bf2fd9ce3dd5a00d266cce14e4c977e7"
+  integrity sha512-W/ryRoQ0TSVXqJrx5SGkaYuAaE/BUontL1j1HsKckvM6e5ZaG0M9126zcwL6peKSuIetJi7E87PRQF8O86EW0Q==
+  dependencies:
+    "@commitlint/config-validator" "^17.8.1"
+    "@commitlint/types" "^17.8.1"
+    import-fresh "^3.0.0"
+    lodash.mergewith "^4.6.2"
+    resolve-from "^5.0.0"
+    resolve-global "^1.0.0"
+
+"@commitlint/rules@^17.8.1":
+  version "17.8.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/rules/-/rules-17.8.1.tgz#da49cab1b7ebaf90d108de9f58f684dc4ccb65a0"
+  integrity sha512-2b7OdVbN7MTAt9U0vKOYKCDsOvESVXxQmrvuVUZ0rGFMCrCPJWWP1GJ7f0lAypbDAhaGb8zqtdOr47192LBrIA==
+  dependencies:
+    "@commitlint/ensure" "^17.8.1"
+    "@commitlint/message" "^17.8.1"
+    "@commitlint/to-lines" "^17.8.1"
+    "@commitlint/types" "^17.8.1"
+    execa "^5.0.0"
+
+"@commitlint/to-lines@^17.8.1":
+  version "17.8.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/to-lines/-/to-lines-17.8.1.tgz#a5c4a7cf7dff3dbdd69289fc0eb19b66f3cfe017"
+  integrity sha512-LE0jb8CuR/mj6xJyrIk8VLz03OEzXFgLdivBytoooKO5xLt5yalc8Ma5guTWobw998sbR3ogDd+2jed03CFmJA==
+
+"@commitlint/top-level@^17.8.1":
+  version "17.8.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/top-level/-/top-level-17.8.1.tgz#206d37d6782f33c9572e44fbe3758392fdeea7bc"
+  integrity sha512-l6+Z6rrNf5p333SHfEte6r+WkOxGlWK4bLuZKbtf/2TXRN+qhrvn1XE63VhD8Oe9oIHQ7F7W1nG2k/TJFhx2yA==
+  dependencies:
+    find-up "^5.0.0"
+
+"@commitlint/types@^17.8.1":
+  version "17.8.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/types/-/types-17.8.1.tgz#883a0ad35c5206d5fef7bc6ce1bbe648118af44e"
+  integrity sha512-PXDQXkAmiMEG162Bqdh9ChML/GJZo6vU+7F03ALKDK8zYc6SuAr47LjG7hGYRqUOz+WK0dU7bQ0xzuqFMdxzeQ==
+  dependencies:
+    chalk "^4.1.0"
+
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
 "@emnapi/core@^1.1.0":
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.9.1.tgz#2143069c744ca2442074f8078462e51edd63c7bd"
@@ -1484,7 +1652,7 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@jridgewell/resolve-uri@^3.1.0":
+"@jridgewell/resolve-uri@^3.0.3", "@jridgewell/resolve-uri@^3.1.0":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
   integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
@@ -1497,10 +1665,18 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.25"
 
-"@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0", "@jridgewell/sourcemap-codec@^1.5.5":
+"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0", "@jridgewell/sourcemap-codec@^1.5.5":
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.28":
   version "0.3.31"
@@ -2231,6 +2407,26 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
+"@tsconfig/node10@^1.0.7":
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.12.tgz#be57ceac1e4692b41be9de6be8c32a106636dba4"
+  integrity sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
+  integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
+
 "@tufjs/canonical-json@2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz#a52f61a3d7374833fca945b2549bc30a2dd40d0a"
@@ -2375,6 +2571,11 @@
   integrity sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==
   dependencies:
     undici-types "~7.18.0"
+
+"@types/node@20.5.1":
+  version "20.5.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.5.1.tgz#178d58ee7e4834152b0e8b4d30cbfab578b9bb30"
+  integrity sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg==
 
 "@types/node@^22.0.0":
   version "22.19.15"
@@ -2579,7 +2780,7 @@ acorn-jsx@^5.3.1:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn-walk@^8.0.2:
+acorn-walk@^8.0.2, acorn-walk@^8.1.1:
   version "8.3.5"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.5.tgz#8a6b8ca8fc5b34685af15dabb44118663c296496"
   integrity sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==
@@ -2595,6 +2796,11 @@ acorn@^8.1.0, acorn@^8.11.0, acorn@^8.15.0, acorn@^8.8.1:
   version "8.16.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
+
+acorn@^8.4.1:
+  version "8.17.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.17.0.tgz#1785adb84faf8d8add10369b93826fc2bd08f1fe"
+  integrity sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==
 
 add-stream@^1.0.0:
   version "1.0.0"
@@ -2635,6 +2841,16 @@ ajv@^8.0.1:
   version "8.18.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.18.0.tgz#8864186b6738d003eb3a933172bb3833e10cefbc"
   integrity sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+
+ajv@^8.11.0:
+  version "8.20.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.20.0.tgz#304b3636add88ba7d936760dd50ece006dea95f9"
+  integrity sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==
   dependencies:
     fast-deep-equal "^3.1.3"
     fast-uri "^3.0.1"
@@ -2718,6 +2934,11 @@ aproba@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
   integrity sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -3412,6 +3633,20 @@ conventional-changelog-angular@7.0.0:
   dependencies:
     compare-func "^2.0.0"
 
+conventional-changelog-angular@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-6.0.0.tgz#a9a9494c28b7165889144fd5b91573c4aa9ca541"
+  integrity sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==
+  dependencies:
+    compare-func "^2.0.0"
+
+conventional-changelog-conventionalcommits@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-6.1.0.tgz#3bad05f4eea64e423d3d90fc50c17d2c8cf17652"
+  integrity sha512-3cS3GEtR78zTfMzk0AizXKKIdN4OvSh7ibNz6/DPbhWWQu7LqE/8+/GqSodV+sywUR2gpJAdP/1JFf4XtN7Zpw==
+  dependencies:
+    compare-func "^2.0.0"
+
 conventional-changelog-core@5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/conventional-changelog-core/-/conventional-changelog-core-5.0.1.tgz#3c331b155d5b9850f47b4760aeddfc983a92ad49"
@@ -3500,6 +3735,11 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
+cosmiconfig-typescript-loader@^4.0.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.4.0.tgz#f3feae459ea090f131df5474ce4b1222912319f9"
+  integrity sha512-BabizFdC3wBHhbI4kJh0VkQP9GkBfoHPydD0COMce1nJ1kJAB3F2TmJ/I7diULBKtmEWSwEbuN/KDtgnmUUVmw==
+
 cosmiconfig@9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-9.0.0.tgz#34c3fc58287b915f3ae905ab6dc3de258b55ad9d"
@@ -3509,6 +3749,16 @@ cosmiconfig@9.0.0:
     import-fresh "^3.3.0"
     js-yaml "^4.1.0"
     parse-json "^5.2.0"
+
+cosmiconfig@^8.0.0:
+  version "8.3.6"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-8.3.6.tgz#060a2b871d66dba6c8538ea1118ba1ac16f5fae3"
+  integrity sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==
+  dependencies:
+    import-fresh "^3.3.0"
+    js-yaml "^4.1.0"
+    parse-json "^5.2.0"
+    path-type "^4.0.0"
 
 create-jest@^29.7.0:
   version "29.7.0"
@@ -3522,6 +3772,11 @@ create-jest@^29.7.0:
     jest-config "^29.7.0"
     jest-util "^29.7.0"
     prompts "^2.0.1"
+
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-spawn@^7.0.2, cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
@@ -3706,6 +3961,11 @@ diff-sequences@^29.6.3:
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
   integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
+
+diff@^4.0.1:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.4.tgz#7a6dbfda325f25f07517e9b518f897c08332e07d"
+  integrity sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -4381,6 +4641,14 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
+
 flat-cache@^3.0.4:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.2.0.tgz#2c0c2d5040c99b1632771a9d105725c0115363ee"
@@ -4442,6 +4710,15 @@ fs-constants@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
+
+fs-extra@^11.0.0:
+  version "11.3.6"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.6.tgz#f7cb80e9df550cd1db6f537fa5cdd568d3e70d10"
+  integrity sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-extra@^11.2.0:
   version "11.3.4"
@@ -4584,6 +4861,17 @@ get-symbol-description@^1.1.0:
     es-errors "^1.3.0"
     get-intrinsic "^1.2.6"
 
+git-raw-commits@^2.0.11:
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-2.0.11.tgz#bc3576638071d18655e1cc60d7f524920008d723"
+  integrity sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==
+  dependencies:
+    dargs "^7.0.0"
+    lodash "^4.17.15"
+    meow "^8.0.0"
+    split2 "^3.0.0"
+    through2 "^4.0.0"
+
 git-raw-commits@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-3.0.0.tgz#5432f053a9744f67e8db03dbc48add81252cfdeb"
@@ -4677,6 +4965,13 @@ glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+global-dirs@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.1.tgz#b319c0dd4607f353f3be9cca4c72fc148c49f445"
+  integrity sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==
+  dependencies:
+    ini "^1.3.4"
 
 globals@^13.6.0, globals@^13.9.0:
   version "13.24.0"
@@ -4969,7 +5264,7 @@ inherits@2, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-ini@^1.3.2, ini@^1.3.8:
+ini@^1.3.2, ini@^1.3.4, ini@^1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
@@ -6157,15 +6452,42 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
+
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
 
+lodash.isfunction@^3.0.9:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
+  integrity sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==
+
 lodash.ismatch@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
   integrity sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
+
+lodash.kebabcase@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
+  integrity sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==
 
 lodash.memoize@^4.1.2:
   version "4.1.2"
@@ -6177,10 +6499,40 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
+lodash.mergewith@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
+  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
+
+lodash.snakecase@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
+  integrity sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==
+
+lodash.startcase@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.startcase/-/lodash.startcase-4.4.0.tgz#9436e34ed26093ed7ffae1936144350915d9add8"
+  integrity sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==
+
 lodash.truncate@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
+
+lodash.uniq@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
+  integrity sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==
+
+lodash.upperfirst@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
+  integrity sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==
+
+lodash@^4.17.15:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 lodash@^4.17.21:
   version "4.17.23"
@@ -6261,7 +6613,7 @@ make-dir@^4.0.0:
   dependencies:
     semver "^7.5.3"
 
-make-error@^1.3.6:
+make-error@^1.1.1, make-error@^1.3.6:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -6340,7 +6692,7 @@ mdurl@^2.0.0:
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-2.0.0.tgz#80676ec0433025dd3e17ee983d0fe8de5a2237e0"
   integrity sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==
 
-meow@^8.1.2:
+meow@^8.0.0, meow@^8.1.2:
   version "8.1.2"
   resolved "https://registry.yarnpkg.com/meow/-/meow-8.1.2.tgz#bcbe45bda0ee1729d350c03cffc8395a36c4e897"
   integrity sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==
@@ -7013,7 +7365,7 @@ p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^3.1.0:
+p-limit@^3.0.2, p-limit@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
@@ -7033,6 +7385,13 @@ p-locate@^4.1.0:
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
+
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
 
 p-map-series@2.1.0:
   version "2.1.0"
@@ -7538,7 +7897,7 @@ read@^4.0.0:
   dependencies:
     mute-stream "^2.0.0"
 
-readable-stream@^3.0.0, readable-stream@^3.0.2, readable-stream@^3.1.1, readable-stream@^3.4.0:
+readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.0.2, readable-stream@^3.1.1, readable-stream@^3.4.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
   integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
@@ -7657,15 +8016,22 @@ resolve-cwd@^3.0.0:
   dependencies:
     resolve-from "^5.0.0"
 
+resolve-from@5.0.0, resolve-from@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
+  integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
-resolve-from@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
-  integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+resolve-global@1.0.0, resolve-global@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-global/-/resolve-global-1.0.0.tgz#a2a79df4af2ca3f49bf77ef9ddacd322dad19255"
+  integrity sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==
+  dependencies:
+    global-dirs "^0.1.1"
 
 resolve.exports@2.0.3, resolve.exports@^2.0.0:
   version "2.0.3"
@@ -7828,6 +8194,13 @@ saxes@^6.0.0:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
+
+semver@7.5.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  dependencies:
+    lru-cache "^6.0.0"
 
 semver@7.7.2:
   version "7.7.2"
@@ -8113,7 +8486,7 @@ split-on-first@^3.0.0:
   resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-3.0.0.tgz#f04959c9ea8101b9b0bbf35a61b9ebea784a23e7"
   integrity sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==
 
-split2@^3.2.2:
+split2@^3.0.0, split2@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/split2/-/split2-3.2.2.tgz#bf2cf2a37d838312c249c89206fd7a17dd12365f"
   integrity sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==
@@ -8385,6 +8758,13 @@ through2@^2.0.0:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
+through2@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-4.0.2.tgz#a7ce3ac2a7a8b0b966c80e7c49f0484c3b239764"
+  integrity sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==
+  dependencies:
+    readable-stream "3"
+
 through@2, through@2.3.8, "through@>=2.2.7 <3":
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
@@ -8474,6 +8854,25 @@ ts-jest@^29.1.0:
     semver "^7.7.3"
     type-fest "^4.41.0"
     yargs-parser "^21.1.1"
+
+ts-node@^10.8.1:
+  version "10.9.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
+  integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
 
 tsconfig-paths@^3.15.0:
   version "3.15.0"
@@ -8623,7 +9022,7 @@ typedoc@^0.28.5:
     minimatch "^9.0.5"
     yaml "^2.8.1"
 
-"typescript@>=3 < 6", typescript@^5.0.4:
+"typescript@>=3 < 6", "typescript@^4.6.4 || ^5.2.2", typescript@^5.0.4:
   version "5.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
@@ -8743,6 +9142,11 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-compile-cache@^2.0.3:
   version "2.4.0"
@@ -9072,6 +9476,24 @@ yargs@^16.2.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yargs@^17.0.0:
+  version "17.7.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.3.tgz#779dffe6bcafec596a7172e983289a588647faaa"
+  integrity sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## Summary

- Enables `plugin:jest/recommended` in root `.eslintrc.js` to catch focused/skipped tests, empty expects, and duplicate test titles
- Adds `@commitlint/cli` + `@commitlint/config-conventional` with a `.husky/commit-msg` hook enforcing conventional commits (for semantic-release)
- Fixes pre-existing test lint violations surfaced by the new Jest rules (duplicate titles, deprecated matcher aliases, `done` callbacks, `fail()` usage, async promise tests)
- Documents commit message enforcement in `CONTRIBUTING.md`

Closes WEB-36

## Test plan

- [x] `yarn lint` passes across all 5 packages
- [x] `echo "random message" | yarn commitlint` is rejected
- [x] `echo "feat: add commitlint" | yarn commitlint` succeeds
- [x] Commit hooks verified on the commit itself (lint-staged + commitlint)


Made with [Cursor](https://cursor.com)