### PR TITLE
chore(eslint): restrict globalThis/window/self and use getGlobalScope() [WEB-37]

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,5 +44,32 @@ module.exports = {
       },
     ],
     'jest/no-conditional-expect': 'off',
+
+    'no-restricted-globals': [
+      'error',
+      {
+        name: 'globalThis',
+        message:
+          'Unsafe access to `globalThis`. Use getGlobalScope() from @amplitude/experiment-core instead.',
+      },
+      {
+        name: 'window',
+        message:
+          'Unsafe access to `window`. Use getGlobalScope() from @amplitude/experiment-core instead.',
+      },
+      {
+        name: 'self',
+        message:
+          'Unsafe access to `self`. Use getGlobalScope() from @amplitude/experiment-core instead.',
+      },
+    ],
   },
+  overrides: [
+    {
+      files: ['**/*.test.ts', '**/*.spec.ts'],
+      rules: {
+        'no-restricted-globals': 'off',
+      },
+    },
+  ],
 };

--- a/packages/analytics-connector/src/util/global.ts
+++ b/packages/analytics-connector/src/util/global.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals -- standalone global shim; cannot depend on experiment-core */
 export const safeGlobal =
   typeof globalThis !== 'undefined'
     ? globalThis

--- a/packages/experiment-core/src/index.ts
+++ b/packages/experiment-core/src/index.ts
@@ -24,6 +24,7 @@ export { Poller } from './util/poller';
 export {
   safeGlobal,
   getGlobalScope,
+  type GlobalScope,
   isLocalStorageAvailable,
   getLocalStorage,
   getSessionStorage,

--- a/packages/experiment-core/src/util/global.ts
+++ b/packages/experiment-core/src/util/global.ts
@@ -1,4 +1,8 @@
-export const getGlobalScope = (): typeof globalThis | undefined => {
+// eslint-disable-next-line no-restricted-globals -- canonical type for the runtime global object
+export type GlobalScope = typeof globalThis;
+
+/* eslint-disable no-restricted-globals -- must probe globals to resolve the runtime scope */
+export const getGlobalScope = (): GlobalScope | undefined => {
   if (typeof globalThis !== 'undefined' && globalThis !== null) {
     return globalThis;
   }
@@ -13,8 +17,9 @@ export const getGlobalScope = (): typeof globalThis | undefined => {
   }
   return undefined;
 };
+/* eslint-enable no-restricted-globals */
 
-export const safeGlobal: typeof globalThis | undefined = getGlobalScope();
+export const safeGlobal: GlobalScope | undefined = getGlobalScope();
 
 export const isLocalStorageAvailable = (): boolean => {
   const globalScope = getGlobalScope();

--- a/packages/experiment-tag/src/behavioral-targeting/event-storage.ts
+++ b/packages/experiment-tag/src/behavioral-targeting/event-storage.ts
@@ -1,3 +1,5 @@
+import { getGlobalScope } from '@amplitude/experiment-core';
+
 import { RelayClient } from './relay-client';
 import { RelayEventStorage } from './relay-protocol';
 import { SessionManager } from './session-manager';
@@ -163,7 +165,10 @@ export class EventStorageManager {
     }
 
     try {
-      const origin = window.location.origin;
+      const origin = getGlobalScope()?.location?.origin;
+      if (!origin) {
+        return false;
+      }
       const migrated = await relay.checkMigrated(origin);
 
       // First-time origins migrate their local store in bulk (one RPC). The
@@ -357,8 +362,13 @@ export class EventStorageManager {
    * This prevents data loss on page close or backgrounding.
    */
   private setupFlushHandlers(): void {
+    const globalScope = getGlobalScope();
+    if (!globalScope) {
+      return;
+    }
+
     // Flush before page unload (close, refresh, navigation)
-    window.addEventListener('beforeunload', this.handleBeforeUnload);
+    globalScope.addEventListener('beforeunload', this.handleBeforeUnload);
 
     // Flush when tab becomes hidden (user switches tabs)
     document.addEventListener('visibilitychange', this.handleVisibilityChange);
@@ -396,7 +406,10 @@ export class EventStorageManager {
     }
 
     // Remove event listeners
-    window.removeEventListener('beforeunload', this.handleBeforeUnload);
+    getGlobalScope()?.removeEventListener(
+      'beforeunload',
+      this.handleBeforeUnload,
+    );
     document.removeEventListener(
       'visibilitychange',
       this.handleVisibilityChange,

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -5,6 +5,7 @@ import {
   EvaluationFlag,
   FlagEvaluationTrace,
   getGlobalScope,
+  type GlobalScope,
   isLocalStorageAvailable,
 } from '@amplitude/experiment-core';
 import {
@@ -108,7 +109,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
   private readonly apiKey: string;
   private readonly initialFlags: [];
   private readonly config: WebExperimentConfig;
-  private readonly globalScope: typeof globalThis;
+  private readonly globalScope: GlobalScope;
   private readonly experimentClient: ExperimentClient;
   private appliedInjections: Set<string> = new Set();
   appliedMutations: {

--- a/packages/experiment-tag/src/subscriptions/subscription-refactor.ts
+++ b/packages/experiment-tag/src/subscriptions/subscription-refactor.ts
@@ -1,4 +1,4 @@
-import { EvaluationEngine } from '@amplitude/experiment-core';
+import { EvaluationEngine, type GlobalScope } from '@amplitude/experiment-core';
 
 import { DefaultWebExperimentClient, INJECT_ACTION } from '../experiment';
 import { TriggerManager, TRIGGER_MANAGER_REGISTRY } from '../triggers';
@@ -29,7 +29,7 @@ export class SubscriptionManager {
     private messageBus: MessageBus,
     private pageObjects: PageObjects,
     private options: initOptions,
-    private readonly globalScope: typeof globalThis,
+    private readonly globalScope: GlobalScope,
   ) {
     this.initializeTriggerManagers();
   }

--- a/packages/experiment-tag/src/subscriptions/subscriptions.ts
+++ b/packages/experiment-tag/src/subscriptions/subscriptions.ts
@@ -1,4 +1,4 @@
-import { EvaluationEngine } from '@amplitude/experiment-core';
+import { EvaluationEngine, type GlobalScope } from '@amplitude/experiment-core';
 
 import { BehavioralTargetingManager } from '../behavioral-targeting';
 import { areBehaviorsEqual } from '../behavioral-targeting/util';
@@ -61,7 +61,7 @@ export class SubscriptionManager {
     | BehavioralTargetingManager
     | undefined;
   private options: initOptions;
-  private readonly globalScope: typeof globalThis;
+  private readonly globalScope: GlobalScope;
   private pageChangeSubscribers: Set<(event: PageChangeEvent) => void> =
     new Set();
   private lastNotifiedActivePages: PageObjects = {};
@@ -98,7 +98,7 @@ export class SubscriptionManager {
     return getCustomerDocument(this.globalScope);
   }
 
-  private get contentWindow(): typeof globalThis {
+  private get contentWindow(): GlobalScope {
     return getCustomerWindow(this.globalScope);
   }
 
@@ -108,7 +108,7 @@ export class SubscriptionManager {
     pageObjects: PageObjects,
     behavioralTargetingManager: BehavioralTargetingManager | undefined,
     options: initOptions,
-    globalScope: typeof globalThis,
+    globalScope: GlobalScope,
   ) {
     this.webExperimentClient = webExperimentClient;
     this.messageBus = messageBus;

--- a/packages/experiment-tag/src/triggers/base-trigger-manager.ts
+++ b/packages/experiment-tag/src/triggers/base-trigger-manager.ts
@@ -1,3 +1,5 @@
+import type { GlobalScope } from '@amplitude/experiment-core';
+
 import {
   MessageBus,
   MessagePayloads,
@@ -62,7 +64,7 @@ export abstract class BaseTriggerManager<TPayload = any>
   constructor(
     protected readonly pageObjects: PageObject[],
     protected readonly messageBus: MessageBus,
-    protected readonly globalScope: typeof globalThis,
+    protected readonly globalScope: GlobalScope,
     protected readonly options?: TriggerManagerOptions,
   ) {}
 

--- a/packages/experiment-tag/src/triggers/index.ts
+++ b/packages/experiment-tag/src/triggers/index.ts
@@ -1,3 +1,5 @@
+import type { GlobalScope } from '@amplitude/experiment-core';
+
 import { MessageBus, MessageType } from '../subscriptions/message-bus';
 import { PageObject } from '../types';
 
@@ -29,7 +31,7 @@ export const TRIGGER_MANAGER_REGISTRY: Partial<
     new (
       pageObjects: PageObject[],
       messageBus: MessageBus,
-      globalScope: typeof globalThis,
+      globalScope: GlobalScope,
       options?: TriggerManagerOptions,
     ) => TriggerManager
   >

--- a/packages/experiment-tag/src/util/debug-recorder.ts
+++ b/packages/experiment-tag/src/util/debug-recorder.ts
@@ -1,3 +1,5 @@
+import type { GlobalScope } from '@amplitude/experiment-core';
+
 import type {
   DebugEvent,
   DebugState,
@@ -27,7 +29,7 @@ export const DebugRecorder = {
    * Evaluate activation signals. Must be called before any other method.
    * Checks window.__AMP_DEBUG and localStorage('amp-ve-debug').
    */
-  init: (globalScope: typeof globalThis) => {
+  init: (globalScope: GlobalScope) => {
     if ((globalScope as Record<string, unknown>).__AMP_DEBUG === true) {
       active = true;
       return;

--- a/packages/experiment-tag/src/util/shell.ts
+++ b/packages/experiment-tag/src/util/shell.ts
@@ -1,3 +1,5 @@
+import type { GlobalScope } from '@amplitude/experiment-core';
+
 import { cspSafeStyleSheet } from './csp-safe-stylesheet';
 
 const MOBILE_MODE_SESSION_KEY = 'amp-visual-editor-mobile-mode';
@@ -30,7 +32,7 @@ export function getDeviceIframe(): HTMLIFrameElement | null {
  * customer site lives inside a same-origin iframe; otherwise it is the
  * top-level document.
  */
-export function getCustomerDocument(globalScope: typeof globalThis): Document {
+export function getCustomerDocument(globalScope: GlobalScope): Document {
   if (isMobileModeActive()) {
     return getDeviceIframe()?.contentDocument ?? globalScope.document;
   }
@@ -43,22 +45,22 @@ export function getCustomerDocument(globalScope: typeof globalThis): Document {
  * top-level window.
  */
 export const getCustomerWindow = (
-  globalScope: typeof globalThis,
-): Window & typeof globalThis => {
+  globalScope: GlobalScope,
+): Window & GlobalScope => {
   if (isMobileModeActive()) {
     return (
-      (getDeviceIframe()?.contentWindow as Window & typeof globalThis) ??
-      (globalScope as Window & typeof globalThis)
+      (getDeviceIframe()?.contentWindow as Window & GlobalScope) ??
+      (globalScope as Window & GlobalScope)
     );
   }
-  return globalScope as Window & typeof globalThis;
+  return globalScope as Window & GlobalScope;
 };
 
 /**
  * Syncs the iframe URL to the top-level URL bar. The wrapped replaceState
  * also triggers the SDK's url_change pipeline.
  */
-function syncIframeUrl(globalScope: typeof globalThis, iframeWindow: Window) {
+function syncIframeUrl(globalScope: GlobalScope, iframeWindow: Window) {
   const iframeHref = iframeWindow.location.href;
   if (iframeHref && iframeHref !== globalScope.location.href) {
     globalScope.history.replaceState(globalScope.history.state, '', iframeHref);
@@ -68,10 +70,7 @@ function syncIframeUrl(globalScope: typeof globalThis, iframeWindow: Window) {
 /**
  * Patches iframe history methods and popstate to mirror SPA navigations.
  */
-function observeIframeSpaNav(
-  globalScope: typeof globalThis,
-  iframeWindow: Window,
-) {
+function observeIframeSpaNav(globalScope: GlobalScope, iframeWindow: Window) {
   const iframeHistory = iframeWindow.history;
 
   const wrap = (original: typeof iframeHistory.pushState) =>
@@ -110,7 +109,7 @@ function observeIframeSpaNav(
  * guarantee it renders into the already-built shell rather than racing with
  * DOM restructuring.
  */
-export function buildShell(globalScope: typeof globalThis): Promise<void> {
+export function buildShell(globalScope: GlobalScope): Promise<void> {
   const doc = globalScope.document;
 
   const run = () => {

--- a/packages/experiment-tag/src/util/spa-link-interceptor.ts
+++ b/packages/experiment-tag/src/util/spa-link-interceptor.ts
@@ -1,3 +1,4 @@
+import { getGlobalScope } from '@amplitude/experiment-core';
 import type { ElementRecord } from 'dom-mutator/dist/types';
 
 declare global {
@@ -19,6 +20,11 @@ function isLocalNavigation(
   href: string,
   target: string | null,
 ): boolean {
+  const globalScope = getGlobalScope();
+  if (!globalScope?.location) {
+    return false;
+  }
+
   const isModified =
     (target && target !== '_self') ||
     event.metaKey ||
@@ -27,12 +33,12 @@ function isLocalNavigation(
     event.altKey ||
     event.button > 0;
 
-  const url = new URL(href, window.location.href);
+  const url = new URL(href, globalScope.location.href);
 
   // ignore if link is just changing the hash
   const samePage =
-    url.href.split('#')[0] === window.location.href.split('#')[0];
-  const sameOrigin = url.origin === window.location.origin;
+    url.href.split('#')[0] === globalScope.location.href.split('#')[0];
+  const sameOrigin = url.origin === globalScope.location.origin;
 
   return !isModified && sameOrigin && !samePage;
 }
@@ -55,10 +61,15 @@ function detectSpaRouting(anchor: HTMLAnchorElement) {
 const initFlag = Symbol.for('@amplitude/spa-link-interceptor-initiated');
 
 export function installSpaLinkInterceptor() {
-  if (window[initFlag]) {
+  const globalScope = getGlobalScope();
+  if (!globalScope) {
     return;
   }
-  window[initFlag] = true;
+
+  if (globalScope[initFlag]) {
+    return;
+  }
+  globalScope[initFlag] = true;
 
   const handler = (e: MouseEvent) => {
     const anchor = (e.target as Element).closest(
@@ -91,13 +102,20 @@ export function installSpaLinkInterceptor() {
 }
 
 function navigateSpa(href: string): void {
+  const globalScope = getGlobalScope();
+  if (!globalScope) {
+    return;
+  }
+
   // special case for NextJS router
-  if (window.next?.router?.push) {
-    window.next.router.push(href);
+  if (globalScope.next?.router?.push) {
+    globalScope.next.router.push(href);
     return;
   }
 
   // other routers use pushState
   history.pushState(null, '', href);
-  window.dispatchEvent(new PopStateEvent('popstate', { state: history.state }));
+  globalScope.dispatchEvent(
+    new PopStateEvent('popstate', { state: history.state }),
+  );
 }

--- a/packages/plugin-segment/src/global.ts
+++ b/packages/plugin-segment/src/global.ts
@@ -1,3 +1,3 @@
-import { getGlobalScope } from '@amplitude/experiment-core';
+import { getGlobalScope, type GlobalScope } from '@amplitude/experiment-core';
 
-export const safeGlobal = getGlobalScope() ?? ({} as typeof globalThis);
+export const safeGlobal = getGlobalScope() ?? ({} as GlobalScope);


### PR DESCRIPTION
## Summary

- Add ESLint `no-restricted-globals` for `globalThis`, `window`, and `self` (disabled in `*.test.ts` / `*.spec.ts`).
- Route runtime global access through `getGlobalScope()` from `@amplitude/experiment-core` in `event-storage`, `spa-link-interceptor`, and related call sites.
- Export `GlobalScope` type from experiment-core for type-only annotations; `analytics-connector` keeps a file-level eslint-disable (standalone shim, no experiment-core dep).

## Test plan

- [x] `yarn lint`
- [x] `packages/experiment-core` — `test/util/global.test.ts` (19 passed)
- [x] `packages/experiment-tag` — `test/behavioral-targeting/event-storage.test.ts` (36 passed)


Made with [Cursor](https://cursor.com)