### PR TITLE
ci: add TypeScript typecheck workflow [WEB-152]

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,40 @@
+name: Typecheck
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+
+      - name: Set up SSH for deploy key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DOM_MUTATOR_ACCESS_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+        continue-on-error: true # forked repos don't have access, and this is only for experiment-tag
+        shell: bash
+
+      - name: Clear yarn cache
+        run: yarn cache clean
+
+      - name: Install
+        run: yarn install --frozen-lockfile --force
+
+      - name: Build
+        run: yarn build
+
+      - name: Typecheck
+        run: yarn typecheck

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,9 @@ hooks:
 - **On push**: `yarn lint` runs across all packages. This is the same command CI
   runs, so if it passes locally it will pass in CI.
 
+Run `yarn build && yarn typecheck` to type-check each package's source
+`tsconfig.json` (the Typecheck CI workflow runs the same steps).
+
 If you need to bypass hooks in an emergency, use `git commit --no-verify` or
 `git push --no-verify`. CI will still enforce the check on the PR.
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "lerna run build --stream",
     "clean": "lerna run clean --stream && rimraf node_modules",
     "lint": "lerna run lint --stream",
+    "typecheck": "lerna exec \"tsc -p tsconfig.json --noEmit\"",
     "prepare": "husky",
     "test": "lerna run test --stream"
   },


### PR DESCRIPTION
## Summary
- Add root `yarn typecheck` — runs `tsc --noEmit` on each package's source `tsconfig.json` via lerna
- Add **Typecheck** CI workflow (install → build → typecheck) so workspace `dist/` types resolve before checking dependents
- Document local usage in CONTRIBUTING.md

## Context
WEB-151 audit: all 5 package `tsconfig.json` configs are clean after build. Test tsconfigs (notably `experiment-tag/tsconfig.test.json`) have 3 pre-existing errors — out of scope for this gate.

## Test plan
- [x] `yarn build && yarn typecheck` passes locally
- [x] Typecheck CI green on PR

Made with [Cursor](https://cursor.com)