### PR TITLE
chore(eslint): tighten no-unused-vars to error severity [WEB-38]

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,11 @@ module.exports = {
   rules: {
     'no-console': ['error', { allow: ['warn', 'error', 'debug'] }],
 
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      { vars: 'all', args: 'none', ignoreRestSiblings: true },
+    ],
+
     // eslint-plugin-import
     'import/no-extraneous-dependencies': [
       'error',

--- a/packages/experiment-browser/src/experimentClient.ts
+++ b/packages/experiment-browser/src/experimentClient.ts
@@ -38,7 +38,11 @@ import { SessionStorage } from './storage/session-storage';
 import { FetchHttpClient, WrapperClient } from './transport/http';
 import { exposureEvent } from './types/analytics';
 import { Client, FetchOptions } from './types/client';
-import { Exposure, ExposureTrackingProvider } from './types/exposure';
+import { Exposure } from './types/exposure';
+import {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  type ExposureTrackingProvider, // used for documentation
+} from './types/exposure';
 import { LogLevel } from './types/logger';
 import { ExperimentPlugin, IntegrationPlugin } from './types/plugin';
 import { ExperimentUserProvider } from './types/provider';

--- a/packages/experiment-tag/src/util/triggers/mutation-manager.ts
+++ b/packages/experiment-tag/src/util/triggers/mutation-manager.ts
@@ -4,14 +4,10 @@ function debounce<T extends (...args: any[]) => void>(
   options: { maxWait?: number } = {},
 ): T & { cancel: () => void } {
   let timeout: ReturnType<typeof setTimeout> | null = null;
-  let lastInvokeTime = 0;
   let maxTimeout: ReturnType<typeof setTimeout> | null = null;
 
   const debounced = function (...args: Parameters<T>) {
-    const now = Date.now();
-
     if (options.maxWait && !maxTimeout) {
-      lastInvokeTime = now;
       maxTimeout = setTimeout(() => {
         if (timeout) {
           clearTimeout(timeout);


### PR DESCRIPTION
## Summary

- Set `@typescript-eslint/no-unused-vars` to `error` with Amplitude-TypeScript config (`args: 'none'`, `ignoreRestSiblings: true`)
- Fix JSDoc-only `ExposureTrackingProvider` import via `import type` + eslint-disable (used for documentation)
- Remove dead `lastInvokeTime` / `now` assignments in `mutation-manager` debounce helper (write-only since #165)

Part of [ESLint config hardening](https://linear.app/amplitude/project/eslint-config-hardening-experiment-js-client-0cc46b6be4c7) — [WEB-38](https://linear.app/amplitude/issue/WEB-38/tighten-typescript-eslintno-unused-vars-to-error-severity).

## Test plan

- [x] `yarn lint` passes (0 errors across all packages)
- [ ] CI lint job green


Made with [Cursor](https://cursor.com)

[WEB-38]: https://amplitude.atlassian.net/browse/WEB-38?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ