### PR TITLE
ci(release): add recovery mode to republish already-tagged packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,9 @@ jobs:
       # Recovery: move to the tagged release commit so `lerna publish from-git` sees its tags
       - name: Checkout tagged release commit
         if: ${{ github.event.inputs.publishRef != '' }}
-        run: git checkout ${{ github.event.inputs.publishRef }}
+        env:
+          PUBLISH_REF: ${{ github.event.inputs.publishRef }}
+        run: git checkout "$PUBLISH_REF"
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
         description: 'Do a dry run to preview instead of a real release'
         required: true
         default: 'true'
+      publishRef:
+        description: 'Recovery: republish packages already tagged at this commit SHA (skips the version bump). Leave blank for a normal release; leave dryRun=true when using this.'
+        required: false
+        default: ''
 
 jobs:
   authorize:
@@ -34,6 +38,11 @@ jobs:
       # Needed for lerna version to determine last tag
       - name: Fetch
         run: git fetch --prune --unshallow --tags
+
+      # Recovery: move to the tagged release commit so `lerna publish from-git` sees its tags
+      - name: Checkout tagged release commit
+        if: ${{ github.event.inputs.publishRef != '' }}
+        run: git checkout ${{ github.event.inputs.publishRef }}
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -65,19 +74,26 @@ jobs:
           git config --global user.email amplitude-sdk-bot@users.noreply.github.com
 
       - name: Release (Dry Run)
-        if: ${{ github.event.inputs.dryRun == 'true'}}
+        if: ${{ github.event.inputs.dryRun == 'true' && github.event.inputs.publishRef == '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: yarn lerna version --no-push --no-git-tag-version --loglevel silly --yes
 
       - name: Release
-        if: ${{ github.event.inputs.dryRun == 'false'}}
+        if: ${{ github.event.inputs.dryRun == 'false' && github.event.inputs.publishRef == '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
         run: |
           yarn lerna version --yes
           yarn lerna publish from-git --yes --loglevel silly
+
+      # Recovery: publish the packages already tagged at publishRef (no version bump)
+      - name: Release (publish tagged)
+        if: ${{ github.event.inputs.publishRef != '' }}
+        env:
+          NPM_CONFIG_PROVENANCE: true
+        run: yarn lerna publish from-git --yes --loglevel silly
 
       # Check if experiment-tag was updated
       - name: Check if experiment-tag was updated

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,10 @@ on:
         required: true
         default: 'true'
       publishRef:
-        description: 'Recovery: republish packages already tagged at this commit SHA (skips the version bump). Leave blank for a normal release; leave dryRun=true when using this.'
+        description:
+          'Recovery: republish packages already tagged at this commit SHA (skips
+          the version bump). Leave blank for a normal release. Honors dryRun:
+          dryRun=true previews the tagged versions, dryRun=false publishes them.'
         required: false
         default: ''
 
@@ -76,13 +79,19 @@ jobs:
           git config --global user.email amplitude-sdk-bot@users.noreply.github.com
 
       - name: Release (Dry Run)
-        if: ${{ github.event.inputs.dryRun == 'true' && github.event.inputs.publishRef == '' }}
+        if:
+          ${{ github.event.inputs.dryRun == 'true' &&
+          github.event.inputs.publishRef == '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: yarn lerna version --no-push --no-git-tag-version --loglevel silly --yes
+        run:
+          yarn lerna version --no-push --no-git-tag-version --loglevel silly
+          --yes
 
       - name: Release
-        if: ${{ github.event.inputs.dryRun == 'false' && github.event.inputs.publishRef == '' }}
+        if:
+          ${{ github.event.inputs.dryRun == 'false' &&
+          github.event.inputs.publishRef == '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
@@ -90,9 +99,21 @@ jobs:
           yarn lerna version --yes
           yarn lerna publish from-git --yes --loglevel silly
 
+      # Recovery (dry run): preview the tagged versions that would be published
+      - name: Release (publish tagged, dry run)
+        if:
+          ${{ github.event.inputs.publishRef != '' && github.event.inputs.dryRun
+          == 'true' }}
+        run: |
+          echo "Dry run: the versions tagged at this commit would be published"
+          echo "(from-git skips any version already on npm):"
+          git tag --points-at HEAD
+
       # Recovery: publish the packages already tagged at publishRef (no version bump)
       - name: Release (publish tagged)
-        if: ${{ github.event.inputs.publishRef != '' }}
+        if:
+          ${{ github.event.inputs.publishRef != '' && github.event.inputs.dryRun
+          == 'false' }}
         env:
           NPM_CONFIG_PROVENANCE: true
         run: yarn lerna publish from-git --yes --loglevel silly
@@ -129,7 +150,9 @@ jobs:
 
       # Configure AWS credentials for S3 upload
       - name: Configure AWS Credentials
-        if: ${{ github.event.inputs.dryRun == 'false' && env.UPLOAD_PACKAGES != '' }}
+        if:
+          ${{ github.event.inputs.dryRun == 'false' && env.UPLOAD_PACKAGES != ''
+          }}
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
@@ -137,7 +160,9 @@ jobs:
 
       # Install dependencies and upload experiment packages to S3
       - name: Upload packages to S3
-        if: ${{ github.event.inputs.dryRun == 'false' && env.UPLOAD_PACKAGES != '' }}
+        if:
+          ${{ github.event.inputs.dryRun == 'false' && env.UPLOAD_PACKAGES != ''
+          }}
         env:
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
           PACKAGES: ${{ env.UPLOAD_PACKAGES }}


### PR DESCRIPTION
## Why

The last release (`chore(release): publish`, commit `a40490a`) bumped and **tagged** all packages and created the GitHub releases, but the npm publish step aborted on the first package (`@amplitude/analytics-connector@1.6.5`), so four packages were tagged but never published:

- `@amplitude/analytics-connector@1.6.5`
- `@amplitude/experiment-js-client@1.21.3`
- `@amplitude/experiment-tag@0.26.0`
- `@amplitude/experiment-plugin-segment@0.3.14`

`experiment-js-client` and `experiment-tag` both depend on `@amplitude/analytics-connector@^1.6.5`, which isn't on npm, so this must be finished by publishing the exact tagged versions — not by cutting a fresh release.

A standalone recovery workflow can't do this: npm trusted publishing binds the OIDC identity to this workflow file (`release.yml`), so the publish must run from here.

## What

Adds an optional `publishRef` input. When set, the job checks out that commit and runs only `lerna publish from-git` — no version bump. Normal release behavior is unchanged when `publishRef` is blank.

## How to run the recovery

Dispatch **Release** with `dryRun=true` (default) and `publishRef=a40490a366c9857c542492137dc7cda04d3be816`. `from-git` skips already-published versions (e.g. `experiment-core@0.13.3`) and publishes the four missing ones with provenance.

> Requires the npm trusted publisher for `@amplitude/analytics-connector` to be configured (repo `experiment-js-client`, workflow `release.yml`), matching the sibling packages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes npm publish paths in the trusted release workflow; mis-set `publishRef` or `dryRun` could publish or skip the wrong artifacts, though it remains manual dispatch-only.
> 
> **Overview**
> Adds an optional **`publishRef`** input to the manual **Release** workflow so operators can **republish packages already tagged at a specific commit** without running `lerna version` again.
> 
> When `publishRef` is set, the job **checks out that SHA** after fetch/tags, then either **lists tags at HEAD** (`dryRun=true`) or runs **`lerna publish from-git`** with npm provenance (`dryRun=false`). The existing **normal release** paths (dry-run `lerna version` and full `lerna version` + `from-git`) now run **only when `publishRef` is empty**, so default behavior is unchanged.
> 
> Recovery dry-run does not invoke Lerna publish preview—only `git tag --points-at HEAD`—while recovery publish skips the version bump entirely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fafa0800490229cd2aa2eec1ac11c0b213380893. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->