### PR TITLE
ci(release): skip version bumps for non-shipped file changes

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,5 @@
 {
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
   "version": "independent",
   "npmClient": "yarn",
   "command": {
@@ -10,7 +8,26 @@
       "conventionalCommits": true,
       "createRelease": "github",
       "message": "chore(release): publish",
-      "preid": "beta"
+      "preid": "beta",
+      "ignoreChanges": [
+        "**/*.md",
+        "**/*.test.ts",
+        "**/*.spec.ts",
+        "**/test/**",
+        "**/tests/**",
+        "**/__tests__/**",
+        "**/__mocks__/**",
+        "**/*.snap",
+        "**/example/**",
+        "**/examples/**",
+        "**/.eslintrc*",
+        "**/eslint.config.*",
+        "**/.prettierrc*",
+        "**/.prettierignore",
+        "**/jest.config.*",
+        "**/jest.setup*",
+        "**/commitlint.config.*"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

Stops the release pipeline from cutting a version bump for a package whose only changes are non-shipped files (docs, tests, mocks, examples, snapshots, lint/format/commitlint config). This is the `chore-triggers-a-release` follow-up from the release recovery work.

## Root cause (why the obvious fix doesn't work)

I originally suggested a `changelogPreset` with release rules mapping `chore`/`docs`/`refactor` to "no bump". After reading the installed tooling, **that approach does not work on lerna 9**:

- `lerna@9.0.7` `recommendVersion` hardcodes `let releaseType = data.releaseType || "patch"` (`node_modules/lerna/dist/index.js:3852`). Any package it is asked to version is bumped **at least a patch**, no matter what the conventional-commit preset recommends.
- Which packages it versions is decided by `collectUpdates`, which detects changes by **git file diff, not commit type**.

So there is no preset-level "release rule" that can return no-release. The only supported lever is file-based change detection via `command.version.ignoreChanges`.

## What's in the box

- **`lerna.json`** — add `command.version.ignoreChanges` covering `**/*.md`, test/mocks/snapshot files, `example(s)/**`, and eslint/prettier/jest/commitlint config. A package whose commit only touches these globs is no longer treated as changed, so it is not versioned or published.

## Scope / limitation (please read)

This fixes the **common** cases: a package that changed only docs/tests/config no longer cuts a release. It does **not** catch a commit typed `chore` that edits real `src/**` (e.g. the `chore` that touched `analytics-connector/src/util/global.ts` in the incident) — lerna sees a shipped-source change and bumps a patch regardless of type, and lerna 9 offers no config to gate on commit type.

If you want strict commit-type gating (a `chore` never releases even when it edits source), that requires a workflow step that computes per-package releasable commits and passes computed `--ignore-changes "packages/<pkg>/**"` globs to `lerna version`. Happy to do that as a follow-up if you want the stricter behavior — it adds moving parts to the release job, so I kept this PR to the low-risk config change.

## Test plan

- [x] `lerna.json` parses as valid JSON (17 ignore globs)
- [x] prettier + commitlint pre-commit hooks pass
- [ ] On the next release, confirm a docs/test/config-only change to a package does not appear in the `lerna version` plan

Made with [Cursor](https://cursor.com)