### PR TITLE
chore(ci): run bundle-size check on pull requests only

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -2,9 +2,6 @@ name: Bundle size
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
 
 jobs:
   experiment-tag-bundle-size:


### PR DESCRIPTION
## Summary
- Remove `push: main` trigger from `bundle-size.yml`
- Bundle size checks continue to run on pull requests only

## Test plan
- [x] Open this PR and confirm the Bundle size workflow runs
- [ ] After merge, confirm no Bundle size workflow runs on push to `main`

Made with [Cursor](https://cursor.com)