### PR TITLE
fix(spa-router): allow interceptor to navigate to external URLs

### DIFF
--- a/packages/experiment-tag/src/util/spa-link-interceptor.ts
+++ b/packages/experiment-tag/src/util/spa-link-interceptor.ts
@@ -96,18 +96,13 @@ function navigateSpa(href: string): void {
     return;
   }
 
-  const url = new URL(href, window.location.href);
-  if (url.origin !== window.location.origin) {
+  const url = new URL(href, globalScope.location.href);
+  if (url.origin !== globalScope.location.origin) {
     // this external URL needs to do a full page reload anyways
-    window.location.href = url;
+    globalScope.location.href = url;
     return;
   }
 
-  // ignore if link is just changing the hash
-  const samePage =
-    url.href.split('#')[0] === window.location.href.split('#')[0];
-  const sameOrigin = url.origin === window.location.origin;
-  
   // special case for NextJS router
   if (globalScope.next?.router?.push) {
     globalScope.next.router.push(href);

--- a/packages/experiment-tag/src/util/spa-link-interceptor.ts
+++ b/packages/experiment-tag/src/util/spa-link-interceptor.ts
@@ -96,8 +96,13 @@ function navigateSpa(href: string): void {
     return;
   }
 
-  const url = new URL(href, globalScope.location.href);
-  if (url.origin !== globalScope.location.origin) {
+  let url: URL | undefined;
+  try {
+    url = new URL(href, globalScope.location.href);
+  } catch {
+    // ignore
+  }
+  if (url && url.origin !== globalScope.location.origin) {
     // this external URL needs to do a full page reload anyways
     globalScope.location.href = href;
     return;

--- a/packages/experiment-tag/src/util/spa-link-interceptor.ts
+++ b/packages/experiment-tag/src/util/spa-link-interceptor.ts
@@ -99,7 +99,7 @@ function navigateSpa(href: string): void {
   const url = new URL(href, globalScope.location.href);
   if (url.origin !== globalScope.location.origin) {
     // this external URL needs to do a full page reload anyways
-    globalScope.location.href = url;
+    globalScope.location.href = href;
     return;
   }
 

--- a/packages/experiment-tag/src/util/spa-link-interceptor.ts
+++ b/packages/experiment-tag/src/util/spa-link-interceptor.ts
@@ -14,17 +14,11 @@ declare global {
   }
 }
 
-// determine if click navigates to a different in-app page
-function isLocalNavigation(
+// determine if navigating within same window
+function isSameWindowNavigation(
   event: MouseEvent,
-  href: string,
   target: string | null,
 ): boolean {
-  const globalScope = getGlobalScope();
-  if (!globalScope?.location) {
-    return false;
-  }
-
   const isModified =
     (target && target !== '_self') ||
     event.metaKey ||
@@ -33,11 +27,7 @@ function isLocalNavigation(
     event.altKey ||
     event.button > 0;
 
-  const url = new URL(href, globalScope.location.href);
-
-  const sameOrigin = url.origin === globalScope.location.origin;
-
-  return !isModified && sameOrigin;
+  return !isModified;
 }
 
 function detectSpaRouting(anchor: HTMLAnchorElement) {
@@ -87,7 +77,7 @@ export function installSpaLinkInterceptor() {
     const target = anchor.getAttribute('target');
     if (
       !href ||
-      !isLocalNavigation(e, href, target) ||
+      !isSameWindowNavigation(e, target) ||
       !detectSpaRouting(anchor)
     ) {
       return;
@@ -106,6 +96,18 @@ function navigateSpa(href: string): void {
     return;
   }
 
+  const url = new URL(href, window.location.href);
+  if (url.origin !== window.location.origin) {
+    // this external URL needs to do a full page reload anyways
+    window.location.href = url;
+    return;
+  }
+
+  // ignore if link is just changing the hash
+  const samePage =
+    url.href.split('#')[0] === window.location.href.split('#')[0];
+  const sameOrigin = url.origin === window.location.origin;
+  
   // special case for NextJS router
   if (globalScope.next?.router?.push) {
     globalScope.next.router.push(href);


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary
allow interceptor to navigate to external URLs

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes real user navigation for intercepted experiment links on customer sites; mis-routing could break external or edge-case anchor behavior, though scope is limited to mutated hrefs on detected React router links.
> 
> **Overview**
> The SPA link click interceptor no longer requires the anchor `href` to be same-origin before it runs. **`isLocalNavigation`** is replaced with **`isSameWindowNavigation`**, which only skips modified clicks (new tab, modifier keys, non-primary button).
> 
> Origin is handled in **`navigateSpa`**: after resolving the URL, cross-origin targets assign **`location.href`** for a full navigation instead of **`pushState`** or the Next.js router.
> 
> Same-window in-app links with experiment-mutated `href` attributes still use the existing SPA paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f923d5042a9a69308df9a7939c996f3e3322b7e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->