### PR TITLE
feat(experiment-tag): fix early returns in previewvariants

### DIFF
--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -734,11 +734,11 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       const variant = keyToVariant[key];
       const flag = this.flagVariantMap[key];
       if (!flag) {
-        return;
+        continue;
       }
       const variantObject = flag[variant];
       if (!variantObject) {
-        return;
+        continue;
       }
       if (this.isPreviewMode) {
         showPreviewModeModal({
@@ -750,7 +750,7 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
         if (this.isActionActiveOnPage(key, undefined)) {
           this.exposureWithDedupe(key, variantObject);
         }
-        return;
+        continue;
       }
       await this.handleVariantAction(key, variantObject);
     }


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary
fix early returns in previewvariants
It was originally a .forEach

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small control-flow fix in preview-only code; reduces risk of incomplete multi-flag previews with no change to normal variant application.
> 
> **Overview**
> **Fixes `previewVariants` stopping after the first bad entry** when previewing multiple flags at once.
> 
> In the `keyToVariant` loop, three paths that used `return` (unknown flag key, missing variant on the flag, variant with no array payload after optional exposure) now use **`continue`**, so later flags in the map still get reverted/applied. The PR notes this matches behavior from when the logic was a `.forEach`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7d48c2d999d8740440e688753f8e613a350a9f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->