### PR TITLE
feat(experiment-browser): support injectable in-memory cache storage for web experiment

### DIFF
--- a/packages/experiment-browser/src/experimentClient.ts
+++ b/packages/experiment-browser/src/experimentClient.ts
@@ -196,7 +196,14 @@ export class ExperimentClient implements Client {
       ? `${this.config.instanceName}-${String(internalInstanceName)}`
       : this.config.instanceName;
     if (this.isWebExperiment) {
-      storage = new SessionStorage();
+      // Internal: experiment-tag injects an in-memory storage while cookie
+      // consent is not yet granted, so the amp-exp-* caches never touch
+      // sessionStorage pre-consent. Always fall back to SessionStorage when
+      // nothing is injected.
+      const internalCacheStorage = this.config?.['internalCacheStorage'] as
+        | Storage
+        | undefined;
+      storage = internalCacheStorage ?? new SessionStorage();
     } else {
       storage = new LocalStorage();
     }

--- a/packages/experiment-browser/src/index.ts
+++ b/packages/experiment-browser/src/index.ts
@@ -18,6 +18,7 @@ export {
 } from './factory';
 export { StubExperimentClient } from './stubClient';
 export { ExperimentClient } from './experimentClient';
+export { MemoryStorage } from './storage/memory-storage';
 export { Client, FetchOptions } from './types/client';
 export {
   ExperimentAnalyticsProvider,

--- a/packages/experiment-browser/src/storage/memory-storage.ts
+++ b/packages/experiment-browser/src/storage/memory-storage.ts
@@ -1,0 +1,25 @@
+import { Storage } from '../types/storage';
+
+/**
+ * In-memory {@link Storage} for the web experiment variant/flag caches
+ * (`amp-exp-*`), injected by experiment-tag while cookie consent has not been
+ * granted so the caches never touch sessionStorage pre-consent. The storage is
+ * chosen once at client construction: after a mid-session grant the cache
+ * stays in memory for the page lifetime and reverts to SessionStorage on the
+ * next load — acceptable because it is a cache that repopulates on fetch.
+ */
+export class MemoryStorage implements Storage {
+  private readonly store = new Map<string, string>();
+
+  get(key: string): string {
+    return this.store.get(key);
+  }
+
+  put(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+
+  delete(key: string): void {
+    this.store.delete(key);
+  }
+}

--- a/packages/experiment-browser/test/memoryStorage.test.ts
+++ b/packages/experiment-browser/test/memoryStorage.test.ts
@@ -1,0 +1,93 @@
+import { ExperimentClient } from '../src/experimentClient';
+import { MemoryStorage } from '../src/storage/memory-storage';
+import { Storage } from '../src/types/storage';
+
+const API_KEY = 'client-DvWljIjiiuqLbyjqdvBaLFfEBrAvGuA3';
+
+class SpyStorage implements Storage {
+  gets: string[] = [];
+  puts: Record<string, string> = {};
+  get(key: string): string {
+    this.gets.push(key);
+    return undefined;
+  }
+  put(key: string, value: string): void {
+    this.puts[key] = value;
+  }
+  delete(key: string): void {
+    delete this.puts[key];
+  }
+}
+
+describe('MemoryStorage', () => {
+  test('get returns what was put, delete removes', () => {
+    const storage = new MemoryStorage();
+    expect(storage.get('k')).toBeUndefined();
+    storage.put('k', 'v');
+    expect(storage.get('k')).toEqual('v');
+    storage.delete('k');
+    expect(storage.get('k')).toBeUndefined();
+  });
+
+  test('instances are isolated', () => {
+    const a = new MemoryStorage();
+    const b = new MemoryStorage();
+    a.put('k', 'v');
+    expect(b.get('k')).toBeUndefined();
+  });
+});
+
+describe('web experiment cache storage selection', () => {
+  let sessionGetItem: jest.SpyInstance;
+  let localGetItem: jest.SpyInstance;
+
+  beforeEach(() => {
+    sessionGetItem = jest.spyOn(
+      Object.getPrototypeOf(window.sessionStorage),
+      'getItem',
+    );
+    localGetItem = jest.spyOn(
+      Object.getPrototypeOf(window.localStorage),
+      'getItem',
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('injected internalCacheStorage is used for the amp-exp-* caches', () => {
+    const injected = new SpyStorage();
+    new ExperimentClient(API_KEY, {
+      internalInstanceNameSuffix: 'web',
+      internalCacheStorage: injected,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    // The constructor loads the variant/flag/options caches from the
+    // injected storage instead of sessionStorage.
+    expect(injected.gets.length).toBeGreaterThan(0);
+    expect(injected.gets.every((key) => key.startsWith('amp-exp-'))).toBe(true);
+    expect(sessionGetItem).not.toHaveBeenCalled();
+  });
+
+  test('falls back to SessionStorage when nothing is injected', () => {
+    new ExperimentClient(API_KEY, {
+      internalInstanceNameSuffix: 'web',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    expect(sessionGetItem).toHaveBeenCalled();
+    expect(
+      sessionGetItem.mock.calls.every(([key]) => key.startsWith('amp-exp-')),
+    ).toBe(true);
+  });
+
+  test('non-web clients keep LocalStorage even when a storage is injected', () => {
+    const injected = new SpyStorage();
+    new ExperimentClient(API_KEY, {
+      internalCacheStorage: injected,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    expect(injected.gets).toEqual([]);
+    expect(localGetItem).toHaveBeenCalled();
+  });
+});

--- a/packages/experiment-browser/test/memoryStorage.test.ts
+++ b/packages/experiment-browser/test/memoryStorage.test.ts
@@ -38,18 +38,30 @@ describe('MemoryStorage', () => {
 });
 
 describe('web experiment cache storage selection', () => {
-  let sessionGetItem: jest.SpyInstance;
-  let localGetItem: jest.SpyInstance;
+  let sessionGetItem: jest.Mock;
+  let localGetItem: jest.Mock;
 
   beforeEach(() => {
-    sessionGetItem = jest.spyOn(
-      Object.getPrototypeOf(window.sessionStorage),
-      'getItem',
-    );
-    localGetItem = jest.spyOn(
-      Object.getPrototypeOf(window.localStorage),
-      'getItem',
-    );
+    // sessionStorage and localStorage share Storage.prototype, and jsdom
+    // ignores instance-level getItem assignment/spyOn. Spy the prototype
+    // once and route by `this` so the two remain distinguishable.
+    sessionGetItem = jest.fn();
+    localGetItem = jest.fn();
+    const proto = Object.getPrototypeOf(window.sessionStorage);
+    const originalGetItem: (
+      this: globalThis.Storage,
+      key: string,
+    ) => string | null = proto.getItem;
+    jest
+      .spyOn(proto, 'getItem')
+      .mockImplementation(function (this: globalThis.Storage, key: string) {
+        if (this === window.sessionStorage) {
+          sessionGetItem(key);
+        } else if (this === window.localStorage) {
+          localGetItem(key);
+        }
+        return originalGetItem.call(this, key);
+      });
   });
 
   afterEach(() => {
@@ -68,6 +80,7 @@ describe('web experiment cache storage selection', () => {
     expect(injected.gets.length).toBeGreaterThan(0);
     expect(injected.gets.every((key) => key.startsWith('amp-exp-'))).toBe(true);
     expect(sessionGetItem).not.toHaveBeenCalled();
+    expect(localGetItem).not.toHaveBeenCalled();
   });
 
   test('falls back to SessionStorage when nothing is injected', () => {
@@ -79,6 +92,7 @@ describe('web experiment cache storage selection', () => {
     expect(
       sessionGetItem.mock.calls.every(([key]) => key.startsWith('amp-exp-')),
     ).toBe(true);
+    expect(localGetItem).not.toHaveBeenCalled();
   });
 
   test('non-web clients keep LocalStorage even when a storage is injected', () => {
@@ -89,5 +103,6 @@ describe('web experiment cache storage selection', () => {
     } as any);
     expect(injected.gets).toEqual([]);
     expect(localGetItem).toHaveBeenCalled();
+    expect(sessionGetItem).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Lets the web experiment client take an injectable cache storage instead of always writing its `amp-exp-*` variant/flag/options caches to `sessionStorage`. This is the one `experiment-browser` piece needed for consent v1 (no-flicker in-memory `pending`), where experiments must evaluate before the end user has agreed to any storage.

**Ships dark.** Nothing injects it yet — the default path is unchanged, so this is a no-op for every current deployment. `experiment-tag` starts passing `MemoryStorage` when the consent-gated in-memory mode lands.

Tracked by [WEB-173](https://linear.app/amplitude/issue/WEB-173). Design: [Cookie Consent Control — Tech Spec](https://linear.app/amplitude/document/cookie-consent-control-tech-spec-1e85897e46f7) §6b.

## What changed

- **`storage/memory-storage.ts`** (new) — `MemoryStorage`, a `Map`-backed `Storage` mirroring `local-storage.ts` / `session-storage.ts`. Exported from `src/index.ts` so `experiment-tag` can construct it.
- **`experimentClient.ts`** — the web-experiment branch of the storage selection now reads an internal `internalCacheStorage` off the config and **always falls back to `SessionStorage`** when it's absent. Non-web clients are untouched and keep `LocalStorage`.
- **`test/memoryStorage.test.ts`** (new) — 5 tests.

## Risk

- **Fallback is unconditional.** The POC this derives from could leave `storage` undefined when nothing was injected (flagged by Bugbot); here the `?? new SessionStorage()` fallback is covered by a dedicated test, so the default path cannot regress to undefined storage.
- **Internal, not public config.** `internalCacheStorage` is read via index access like the existing `internalInstanceNameSuffix`, so it stays off the documented `ExperimentConfig` surface.
- **Storage is chosen once, at construction.** After a mid-session consent grant the cache stays in memory for the page lifetime and reverts to `sessionStorage` on the next load. Safe because it's a cache — it repopulates on the next fetch, and no flush is needed.
- **Non-web unaffected.** A test asserts an injected storage is ignored (and `LocalStorage` still used) when the client isn't the web instance.

## Test plan

- [x] `yarn test` in `experiment-browser` — 212 passing, incl. 5 new
- [x] `yarn lint` — clean
- [x] `yarn build` — emits `dist/types/src/storage/memory-storage.d.ts`; `MemoryStorage` present in all three bundles (needed before `experiment-tag` type-checks against it)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No

Made with [Cursor](https://cursor.com)

[WEB-173]: https://amplitude.atlassian.net/browse/WEB-173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
