### PR TITLE
feat(experiment-tag): run the client under pending consent

### DIFF
--- a/packages/experiment-browser/src/factory.ts
+++ b/packages/experiment-browser/src/factory.ts
@@ -76,7 +76,13 @@ const newExperimentClient = (
 ): ExperimentClient => {
   return new ExperimentClient(apiKey, {
     ...config,
-    userProvider: new DefaultUserProvider(config?.userProvider, apiKey),
+    userProvider: new DefaultUserProvider(
+      config?.userProvider,
+      apiKey,
+      // Internal option set by experiment-tag: suppresses this provider's
+      // web-storage reads/writes while cookie consent is withheld.
+      config?.['internalPersistenceAllowed'],
+    ),
   });
 };
 

--- a/packages/experiment-browser/src/integration/manager.ts
+++ b/packages/experiment-browser/src/integration/manager.ts
@@ -140,11 +140,9 @@ export class IntegrationManager {
 
 export class SessionDedupeCache {
   private readonly storageKey: string;
-  private readonly instanceName: string;
   // Lazy: the availability check writes a probe key, so it must not run
   // before the persistence guard allows storage access.
   private isSessionStorageAvailable?: boolean;
-  private legacyKeysRemoved = false;
   /** A clearCache() arrived while gated; drop the stored copy on reopen. */
   private clearStoredOnReopen = false;
   /** Entries were recorded while gated; merge them into the stored copy on reopen. */
@@ -156,24 +154,23 @@ export class SessionDedupeCache {
     instanceName: string,
     /**
      * When provided and returning false, deduplication runs purely in memory:
-     * no sessionStorage reads, writes, probes, or legacy-key cleanup. Used by
-     * experiment-tag while cookie consent is withheld.
+     * no sessionStorage reads, writes, or probes. Used by experiment-tag while
+     * cookie consent is withheld.
      */
     private readonly persistenceAllowed?: () => boolean,
   ) {
-    this.instanceName = instanceName;
     this.storageKey = `EXP_sent_v3_${instanceName}`;
+  }
+
+  private isGated(): boolean {
+    return this.persistenceAllowed !== undefined && !this.persistenceAllowed();
   }
 
   /**
    * The sessionStorage to use for this operation, or undefined while the
    * guard is closed or storage is unusable. First allowed call runs the
-   * availability probe and the one-time legacy-key cleanup.
+   * availability probe.
    */
-  private isGated(): boolean {
-    return this.persistenceAllowed !== undefined && !this.persistenceAllowed();
-  }
-
   private usableStorage(): Storage | undefined {
     if (this.isGated()) {
       return undefined;
@@ -184,11 +181,6 @@ export class SessionDedupeCache {
     const sessionStorage = getSessionStorage();
     if (!this.isSessionStorageAvailable || !sessionStorage) {
       return undefined;
-    }
-    if (!this.legacyKeysRemoved) {
-      this.legacyKeysRemoved = true;
-      sessionStorage.removeItem(`EXP_sent_${this.instanceName}`);
-      sessionStorage.removeItem(`EXP_sent_v2_${this.instanceName}`);
     }
     if (this.clearStoredOnReopen) {
       this.clearStoredOnReopen = false;
@@ -376,9 +368,8 @@ export class PersistentTrackingQueue {
   }
 
   private loadQueue(): void {
-    // While persistence is gated the device copy is not consulted (reading is
-    // access to device data too); events pushed in the meantime exist only in
-    // memory and remain the queue.
+    // While persistence is gated the device copy is not consulted (reads are
+    // gated too); events pushed in the meantime exist only in memory.
     const localStorage = this.usableStorage();
     if (localStorage) {
       const storedQueue = localStorage.getItem(this.storageKey);
@@ -400,11 +391,9 @@ export class PersistentTrackingQueue {
   private storeQueue(): void {
     const localStorage = this.usableStorage();
     if (localStorage) {
-      // An empty queue is represented by the key's absence rather than a
-      // stored `[]` — loadQueue treats both the same, and this keeps the queue
-      // from putting anything on the device when every event was handed to
-      // the tracker immediately (which also matters under consent gating,
-      // where the write itself is the problem).
+      // An empty queue is stored as key absence rather than `[]`, so nothing
+      // lands on the device when every event was handed to the tracker
+      // immediately.
       if (this.inMemoryQueue.length === 0) {
         localStorage.removeItem(this.storageKey);
         return;

--- a/packages/experiment-browser/src/integration/manager.ts
+++ b/packages/experiment-browser/src/integration/manager.ts
@@ -44,7 +44,10 @@ export class IntegrationManager {
       MAX_QUEUE_SIZE,
       config['internalPersistenceAllowed'],
     );
-    this.cache = new SessionDedupeCache(instanceName);
+    this.cache = new SessionDedupeCache(
+      instanceName,
+      config['internalPersistenceAllowed'],
+    );
   }
 
   /**
@@ -137,18 +140,61 @@ export class IntegrationManager {
 
 export class SessionDedupeCache {
   private readonly storageKey: string;
-  private readonly isSessionStorageAvailable = checkIsSessionStorageAvailable();
+  private readonly instanceName: string;
+  // Lazy: the availability check writes a probe key, so it must not run
+  // before the persistence guard allows storage access.
+  private isSessionStorageAvailable?: boolean;
+  private legacyKeysRemoved = false;
+  /** A clearCache() arrived while gated; drop the stored copy on reopen. */
+  private clearStoredOnReopen = false;
+  /** Entries were recorded while gated; merge them into the stored copy on reopen. */
+  private hasGatedEntries = false;
   private inMemoryCache: Record<string, string | null> = {};
   private identity: Identity = {};
 
-  constructor(instanceName: string) {
+  constructor(
+    instanceName: string,
+    /**
+     * When provided and returning false, deduplication runs purely in memory:
+     * no sessionStorage reads, writes, probes, or legacy-key cleanup. Used by
+     * experiment-tag while cookie consent is withheld.
+     */
+    private readonly persistenceAllowed?: () => boolean,
+  ) {
+    this.instanceName = instanceName;
     this.storageKey = `EXP_sent_v3_${instanceName}`;
-    // Remove previous versions of storage if they exist.
-    const sessionStorage = getSessionStorage();
-    if (this.isSessionStorageAvailable && sessionStorage) {
-      sessionStorage.removeItem(`EXP_sent_${instanceName}`);
-      sessionStorage.removeItem(`EXP_sent_v2_${instanceName}`);
+  }
+
+  /**
+   * The sessionStorage to use for this operation, or undefined while the
+   * guard is closed or storage is unusable. First allowed call runs the
+   * availability probe and the one-time legacy-key cleanup.
+   */
+  private isGated(): boolean {
+    return this.persistenceAllowed !== undefined && !this.persistenceAllowed();
+  }
+
+  private usableStorage(): Storage | undefined {
+    if (this.isGated()) {
+      return undefined;
     }
+    if (this.isSessionStorageAvailable === undefined) {
+      this.isSessionStorageAvailable = checkIsSessionStorageAvailable();
+    }
+    const sessionStorage = getSessionStorage();
+    if (!this.isSessionStorageAvailable || !sessionStorage) {
+      return undefined;
+    }
+    if (!this.legacyKeysRemoved) {
+      this.legacyKeysRemoved = true;
+      sessionStorage.removeItem(`EXP_sent_${this.instanceName}`);
+      sessionStorage.removeItem(`EXP_sent_v2_${this.instanceName}`);
+    }
+    if (this.clearStoredOnReopen) {
+      this.clearStoredOnReopen = false;
+      sessionStorage.removeItem(this.storageKey);
+    }
+    return sessionStorage;
   }
 
   shouldTrack(exposure: Exposure, user?: ExperimentUser): boolean {
@@ -178,6 +224,9 @@ export class SessionDedupeCache {
     if (!hasKey || normalizedCachedVariant !== normalizedExposureVariant) {
       shouldTrack = true;
       this.inMemoryCache[exposure.flag_key] = normalizedExposureVariant;
+      if (this.isGated()) {
+        this.hasGatedEntries = true;
+      }
     }
     this.storeCache();
     return shouldTrack;
@@ -185,9 +234,14 @@ export class SessionDedupeCache {
 
   private clearCache(): void {
     this.inMemoryCache = {};
-    const sessionStorage = getSessionStorage();
-    if (this.isSessionStorageAvailable && sessionStorage) {
+    this.hasGatedEntries = false;
+    const sessionStorage = this.usableStorage();
+    if (sessionStorage) {
       sessionStorage.removeItem(this.storageKey);
+    } else if (this.isGated()) {
+      // An identity change while gated must not let a pre-gate stored cache
+      // suppress the new identity's exposures once the guard reopens.
+      this.clearStoredOnReopen = true;
     }
   }
 
@@ -202,16 +256,26 @@ export class SessionDedupeCache {
   }
 
   private loadCache(): void {
-    const sessionStorage = getSessionStorage();
-    if (this.isSessionStorageAvailable && sessionStorage) {
+    const sessionStorage = this.usableStorage();
+    // While gated the in-memory cache is the only tier, so leaving it in
+    // place (rather than resetting to {}) is what keeps dedupe working.
+    if (sessionStorage) {
       const storedCache = sessionStorage.getItem(this.storageKey);
-      this.inMemoryCache = storedCache ? JSON.parse(storedCache) : {};
+      const stored = storedCache ? JSON.parse(storedCache) : {};
+      if (this.hasGatedEntries) {
+        // Entries recorded while the guard was closed exist only in memory;
+        // letting the stored copy replace them would re-track those exposures.
+        this.inMemoryCache = { ...stored, ...this.inMemoryCache };
+        this.hasGatedEntries = false;
+      } else {
+        this.inMemoryCache = stored;
+      }
     }
   }
 
   private storeCache(): void {
-    const sessionStorage = getSessionStorage();
-    if (this.isSessionStorageAvailable && sessionStorage) {
+    const sessionStorage = this.usableStorage();
+    if (sessionStorage) {
       try {
         sessionStorage.setItem(
           this.storageKey,
@@ -228,8 +292,12 @@ export class SessionDedupeCache {
 export class PersistentTrackingQueue {
   private readonly storageKey: string;
   private readonly maxQueueSize: number;
-  private readonly isLocalStorageAvailable = isLocalStorageAvailable();
+  // Lazy: the availability check writes a probe key, so it must not run
+  // before the persistence guard allows storage access.
+  private isLocalStorageAvailable?: boolean;
   private inMemoryQueue: ExperimentEvent[] = [];
+  /** Events were pushed while gated; merge them with the stored copy on reopen. */
+  private holdsGatedEvents = false;
   private poller: any | undefined;
   private tracker: ((event: ExperimentEvent) => boolean) | undefined;
 
@@ -251,6 +319,9 @@ export class PersistentTrackingQueue {
   push(event: ExperimentEvent): void {
     this.loadQueue();
     this.inMemoryQueue.push(event);
+    if (!this.canPersist()) {
+      this.holdsGatedEvents = true;
+    }
     this.flush();
     this.storeQueue();
   }
@@ -293,30 +364,42 @@ export class PersistentTrackingQueue {
     return this.persistenceAllowed ? this.persistenceAllowed() : true;
   }
 
+  private usableStorage(): Storage | undefined {
+    if (!this.canPersist()) return undefined;
+    if (this.isLocalStorageAvailable === undefined) {
+      this.isLocalStorageAvailable = isLocalStorageAvailable();
+    }
+    const localStorage = getLocalStorage();
+    return this.isLocalStorageAvailable && localStorage
+      ? localStorage
+      : undefined;
+  }
+
   private loadQueue(): void {
     // While persistence is gated the device copy is not consulted (reading is
     // access to device data too); events pushed in the meantime exist only in
     // memory and remain the queue.
-    if (!this.canPersist()) return;
-    const localStorage = getLocalStorage();
-    if (this.isLocalStorageAvailable && localStorage) {
+    const localStorage = this.usableStorage();
+    if (localStorage) {
       const storedQueue = localStorage.getItem(this.storageKey);
       const stored: ExperimentEvent[] = storedQueue
         ? JSON.parse(storedQueue)
         : [];
-      // A non-empty memory with nothing stored only happens when events were
-      // pushed while persistence was gated (ungated flows store on every
-      // push); replacing them with the empty device copy would drop them.
-      if (stored.length > 0 || this.inMemoryQueue.length === 0) {
+      if (this.holdsGatedEvents) {
+        // Events pushed while the guard was closed exist only in memory;
+        // append them after the (older) stored ones rather than letting
+        // either copy clobber the other.
+        this.inMemoryQueue = [...stored, ...this.inMemoryQueue];
+        this.holdsGatedEvents = false;
+      } else {
         this.inMemoryQueue = stored;
       }
     }
   }
 
   private storeQueue(): void {
-    if (!this.canPersist()) return;
-    const localStorage = getLocalStorage();
-    if (this.isLocalStorageAvailable && localStorage) {
+    const localStorage = this.usableStorage();
+    if (localStorage) {
       // An empty queue is represented by the key's absence rather than a
       // stored `[]` — loadQueue treats both the same, and this keeps the queue
       // from putting anything on the device when every event was handed to

--- a/packages/experiment-browser/src/integration/manager.ts
+++ b/packages/experiment-browser/src/integration/manager.ts
@@ -39,7 +39,11 @@ export class IntegrationManager {
     this.config = config;
     this.client = client;
     const instanceName = config.instanceName ?? Defaults.instanceName;
-    this.queue = new PersistentTrackingQueue(instanceName);
+    this.queue = new PersistentTrackingQueue(
+      instanceName,
+      MAX_QUEUE_SIZE,
+      config['internalPersistenceAllowed'],
+    );
     this.cache = new SessionDedupeCache(instanceName);
   }
 
@@ -229,7 +233,17 @@ export class PersistentTrackingQueue {
   private poller: any | undefined;
   private tracker: ((event: ExperimentEvent) => boolean) | undefined;
 
-  constructor(instanceName: string, maxQueueSize: number = MAX_QUEUE_SIZE) {
+  constructor(
+    instanceName: string,
+    maxQueueSize: number = MAX_QUEUE_SIZE,
+    /**
+     * When provided and returning false, the queue neither reads nor writes
+     * localStorage — events live only in memory. Used by experiment-tag while
+     * cookie consent is withheld, so an unsent event can't be parked on the
+     * device before the visitor has agreed to storage.
+     */
+    private readonly persistenceAllowed?: () => boolean,
+  ) {
     this.storageKey = `EXP_unsent_${instanceName}`;
     this.maxQueueSize = maxQueueSize;
   }
@@ -275,17 +289,43 @@ export class PersistentTrackingQueue {
     }
   }
 
+  private canPersist(): boolean {
+    return this.persistenceAllowed ? this.persistenceAllowed() : true;
+  }
+
   private loadQueue(): void {
+    // While persistence is gated the device copy is not consulted (reading is
+    // access to device data too); events pushed in the meantime exist only in
+    // memory and remain the queue.
+    if (!this.canPersist()) return;
     const localStorage = getLocalStorage();
     if (this.isLocalStorageAvailable && localStorage) {
       const storedQueue = localStorage.getItem(this.storageKey);
-      this.inMemoryQueue = storedQueue ? JSON.parse(storedQueue) : [];
+      const stored: ExperimentEvent[] = storedQueue
+        ? JSON.parse(storedQueue)
+        : [];
+      // A non-empty memory with nothing stored only happens when events were
+      // pushed while persistence was gated (ungated flows store on every
+      // push); replacing them with the empty device copy would drop them.
+      if (stored.length > 0 || this.inMemoryQueue.length === 0) {
+        this.inMemoryQueue = stored;
+      }
     }
   }
 
   private storeQueue(): void {
+    if (!this.canPersist()) return;
     const localStorage = getLocalStorage();
     if (this.isLocalStorageAvailable && localStorage) {
+      // An empty queue is represented by the key's absence rather than a
+      // stored `[]` — loadQueue treats both the same, and this keeps the queue
+      // from putting anything on the device when every event was handed to
+      // the tracker immediately (which also matters under consent gating,
+      // where the write itself is the problem).
+      if (this.inMemoryQueue.length === 0) {
+        localStorage.removeItem(this.storageKey);
+        return;
+      }
       // Trim the queue if it is too large.
       if (this.inMemoryQueue.length > this.maxQueueSize) {
         this.inMemoryQueue = this.inMemoryQueue.slice(

--- a/packages/experiment-browser/src/providers/default.ts
+++ b/packages/experiment-browser/src/providers/default.ts
@@ -27,6 +27,13 @@ export class DefaultUserProvider implements ExperimentUserProvider {
    * merge), so nothing is lost by not persisting here.
    */
   private readonly persistenceAllowed?: () => boolean;
+  /**
+   * The first URL seen while persistence was gated. Without it, an SPA
+   * navigation before consent resolves would shift the reported landing page
+   * per call, and a grant after that navigation would persist the page at
+   * grant time rather than where the visitor actually landed.
+   */
+  private gatedLandingUrl?: string;
 
   constructor(
     userProvider?: ExperimentUserProvider,
@@ -103,25 +110,30 @@ export class DefaultUserProvider implements ExperimentUserProvider {
 
   private getLandingUrl(): string | undefined {
     if (!this.canPersist()) {
-      // Storage is gated (reads included): report this page as the landing
-      // page without consulting or extending the per-session record.
-      return this.globalScope?.location?.href.replace(/\/$/, '');
+      // Storage is gated (reads included): report the first URL of this
+      // page's life as the landing page without consulting or extending the
+      // per-session record.
+      this.gatedLandingUrl ??= this.getCurrentUrl();
+      return this.gatedLandingUrl;
     }
     try {
       const sessionUser = JSON.parse(
         this.sessionStorage.get(this.storageKey) || '{}',
       );
       if (!sessionUser.landing_url) {
-        sessionUser.landing_url = this.globalScope?.location?.href.replace(
-          /\/$/,
-          '',
-        );
+        // Prefer the URL remembered from the gated window, so a grant after
+        // an SPA navigation persists where the visitor actually landed.
+        sessionUser.landing_url = this.gatedLandingUrl ?? this.getCurrentUrl();
         this.sessionStorage.put(this.storageKey, JSON.stringify(sessionUser));
       }
       return sessionUser.landing_url;
     } catch {
       return undefined;
     }
+  }
+
+  private getCurrentUrl(): string | undefined {
+    return this.globalScope?.location?.href.replace(/\/$/, '');
   }
 
   private getFirstSeen(): string | undefined {

--- a/packages/experiment-browser/src/providers/default.ts
+++ b/packages/experiment-browser/src/providers/default.ts
@@ -100,6 +100,12 @@ export class DefaultUserProvider implements ExperimentUserProvider {
   }
 
   private getCookie(): Record<string, string> {
+    // Reads are gated with writes: while consent is withheld, cookies an
+    // earlier consented visit left behind (experiment identity, analytics
+    // device ids) must not enter the evaluation context.
+    if (!this.canPersist()) {
+      return undefined;
+    }
     if (!this.globalScope?.document?.cookie) {
       return undefined;
     }

--- a/packages/experiment-browser/src/providers/default.ts
+++ b/packages/experiment-browser/src/providers/default.ts
@@ -19,11 +19,28 @@ export class DefaultUserProvider implements ExperimentUserProvider {
 
   public readonly userProvider: ExperimentUserProvider | undefined;
   private readonly apiKey?: string;
+  /**
+   * When provided and returning false, `landing_url` and `first_seen` are
+   * computed for the current call without reading or writing web storage.
+   * Used by experiment-tag while cookie consent is withheld — it supplies its
+   * own consent-managed `first_seen` via the user object (which wins the
+   * merge), so nothing is lost by not persisting here.
+   */
+  private readonly persistenceAllowed?: () => boolean;
 
-  constructor(userProvider?: ExperimentUserProvider, apiKey?: string) {
+  constructor(
+    userProvider?: ExperimentUserProvider,
+    apiKey?: string,
+    persistenceAllowed?: () => boolean,
+  ) {
     this.userProvider = userProvider;
     this.apiKey = apiKey;
+    this.persistenceAllowed = persistenceAllowed;
     this.storageKey = `EXP_${this.apiKey?.slice(0, 10)}_DEFAULT_USER_PROVIDER`;
+  }
+
+  private canPersist(): boolean {
+    return this.persistenceAllowed ? this.persistenceAllowed() : true;
   }
 
   getUser(): ExperimentUser {
@@ -85,6 +102,11 @@ export class DefaultUserProvider implements ExperimentUserProvider {
   }
 
   private getLandingUrl(): string | undefined {
+    if (!this.canPersist()) {
+      // Storage is gated (reads included): report this page as the landing
+      // page without consulting or extending the per-session record.
+      return this.globalScope?.location?.href.replace(/\/$/, '');
+    }
     try {
       const sessionUser = JSON.parse(
         this.sessionStorage.get(this.storageKey) || '{}',
@@ -103,6 +125,12 @@ export class DefaultUserProvider implements ExperimentUserProvider {
   }
 
   private getFirstSeen(): string | undefined {
+    if (!this.canPersist()) {
+      // Storage is gated: mint a per-call value rather than persist one. A
+      // caller that manages first_seen itself (experiment-tag does, behind
+      // its consent gate) overrides this via the user-object merge.
+      return (Date.now() / 1000).toString();
+    }
     try {
       const localUser = JSON.parse(
         this.localStorage.get(this.storageKey) || '{}',

--- a/packages/experiment-browser/src/providers/default.ts
+++ b/packages/experiment-browser/src/providers/default.ts
@@ -28,10 +28,9 @@ export class DefaultUserProvider implements ExperimentUserProvider {
    */
   private readonly persistenceAllowed?: () => boolean;
   /**
-   * The first URL seen while persistence was gated. Without it, an SPA
-   * navigation before consent resolves would shift the reported landing page
-   * per call, and a grant after that navigation would persist the page at
-   * grant time rather than where the visitor actually landed.
+   * The first URL seen while persistence was gated, so an SPA navigation
+   * before consent resolves doesn't shift the reported (or later persisted)
+   * landing page.
    */
   private gatedLandingUrl?: string;
 
@@ -117,8 +116,7 @@ export class DefaultUserProvider implements ExperimentUserProvider {
   private getLandingUrl(): string | undefined {
     if (!this.canPersist()) {
       // Storage is gated (reads included): report the first URL of this
-      // page's life as the landing page without consulting or extending the
-      // per-session record.
+      // page's life without touching the per-session record.
       this.gatedLandingUrl ??= this.getCurrentUrl();
       return this.gatedLandingUrl;
     }
@@ -144,9 +142,9 @@ export class DefaultUserProvider implements ExperimentUserProvider {
 
   private getFirstSeen(): string | undefined {
     if (!this.canPersist()) {
-      // Storage is gated: mint a per-call value rather than persist one. A
-      // caller that manages first_seen itself (experiment-tag does, behind
-      // its consent gate) overrides this via the user-object merge.
+      // Storage is gated: mint a per-call value rather than persist one.
+      // experiment-tag manages first_seen itself and overrides this via the
+      // user-object merge.
       return (Date.now() / 1000).toString();
     }
     try {

--- a/packages/experiment-browser/test/defaultUserProvider.test.ts
+++ b/packages/experiment-browser/test/defaultUserProvider.test.ts
@@ -205,6 +205,22 @@ describe('DefaultUserProvider', () => {
       });
     });
 
+    test('gated: cookies are not read into the user context', async () => {
+      let allowed = false;
+      const defaultUserProvider = mockProvider(
+        new DefaultUserProvider(undefined, 'apikey', () => allowed),
+      );
+      // Cookies an earlier consented visit left behind must not enter the
+      // evaluation context while the guard is closed.
+      expect(defaultUserProvider.getUser().cookie).toBeUndefined();
+
+      allowed = true;
+      expect(defaultUserProvider.getUser().cookie).toEqual({
+        c1: 'v1',
+        c2: 'v2',
+      });
+    });
+
     test('guard reopening resumes normal persistence', async () => {
       let allowed = false;
       const defaultUserProvider = mockProvider(

--- a/packages/experiment-browser/test/defaultUserProvider.test.ts
+++ b/packages/experiment-browser/test/defaultUserProvider.test.ts
@@ -149,6 +149,61 @@ describe('DefaultUserProvider', () => {
     };
     expect(actualUser).toEqual(expectedUser);
   });
+
+  describe('persistenceAllowed guard', () => {
+    test('gated: user fields populated, nothing read or written', async () => {
+      mockLocalStorage['EXP_apikey_DEFAULT_USER_PROVIDER'] =
+        '{"first_seen": 99}';
+      mockSessionStorage['EXP_apikey_DEFAULT_USER_PROVIDER'] =
+        '{"landing_url": "http://testtest.com"}';
+
+      const defaultUserProvider = mockProvider(
+        new DefaultUserProvider(undefined, 'apikey', () => false),
+      );
+      const actualUser = defaultUserProvider.getUser();
+      // Stored values are ignored; both fields come from the current page/time.
+      expect(actualUser.first_seen).toEqual('1000');
+      expect(actualUser.landing_url).toEqual(mockGlobal.location.href);
+      // Stored values are left exactly as they were.
+      expect(mockLocalStorage).toEqual({
+        EXP_apikey_DEFAULT_USER_PROVIDER: '{"first_seen": 99}',
+      });
+      expect(mockSessionStorage).toEqual({
+        EXP_apikey_DEFAULT_USER_PROVIDER:
+          '{"landing_url": "http://testtest.com"}',
+      });
+    });
+
+    test('gated with empty storage: no keys are created', async () => {
+      const defaultUserProvider = mockProvider(
+        new DefaultUserProvider(undefined, 'apikey', () => false),
+      );
+      const actualUser = defaultUserProvider.getUser();
+      expect(actualUser.first_seen).toEqual('1000');
+      expect(actualUser.landing_url).toEqual(mockGlobal.location.href);
+      expect(mockLocalStorage).toEqual({});
+      expect(mockSessionStorage).toEqual({});
+    });
+
+    test('guard reopening resumes normal persistence', async () => {
+      let allowed = false;
+      const defaultUserProvider = mockProvider(
+        new DefaultUserProvider(undefined, 'apikey', () => allowed),
+      );
+      defaultUserProvider.getUser();
+      expect(mockLocalStorage).toEqual({});
+      expect(mockSessionStorage).toEqual({});
+
+      allowed = true;
+      defaultUserProvider.getUser();
+      expect(mockLocalStorage).toEqual({
+        EXP_apikey_DEFAULT_USER_PROVIDER: '{"first_seen":"1000"}',
+      });
+      expect(mockSessionStorage).toEqual({
+        EXP_apikey_DEFAULT_USER_PROVIDER: `{"landing_url":"${mockGlobal.location.href}"}`,
+      });
+    });
+  });
 });
 
 const mockProvider = (provider: DefaultUserProvider): DefaultUserProvider => {

--- a/packages/experiment-browser/test/defaultUserProvider.test.ts
+++ b/packages/experiment-browser/test/defaultUserProvider.test.ts
@@ -185,6 +185,26 @@ describe('DefaultUserProvider', () => {
       expect(mockSessionStorage).toEqual({});
     });
 
+    test('gated landing_url survives an SPA navigation and persists on grant', async () => {
+      const landingHref = mockGlobal.location.href;
+      let allowed = false;
+      const defaultUserProvider = mockProvider(
+        new DefaultUserProvider(undefined, 'apikey', () => allowed),
+      );
+      expect(defaultUserProvider.getUser().landing_url).toEqual(landingHref);
+
+      // SPA route change while consent is still undecided.
+      mockGlobal.location.href = 'http://test.com/spa-page';
+      expect(defaultUserProvider.getUser().landing_url).toEqual(landingHref);
+
+      // Grant after the navigation: the true landing page is what persists.
+      allowed = true;
+      expect(defaultUserProvider.getUser().landing_url).toEqual(landingHref);
+      expect(mockSessionStorage).toEqual({
+        EXP_apikey_DEFAULT_USER_PROVIDER: `{"landing_url":"${landingHref}"}`,
+      });
+    });
+
     test('guard reopening resumes normal persistence', async () => {
       let allowed = false;
       const defaultUserProvider = mockProvider(

--- a/packages/experiment-browser/test/integration/manager.test.ts
+++ b/packages/experiment-browser/test/integration/manager.test.ts
@@ -262,32 +262,6 @@ describe('SessionDedupeCache', () => {
   beforeEach(() => {
     safeGlobal.sessionStorage.clear();
   });
-  test('old v1 storage is cleared on first use', () => {
-    const instanceName = '$default_instance';
-    safeGlobal.sessionStorage.setItem(
-      'EXP_sent_$default_instance',
-      `{"flag-key":"variant"}`,
-    );
-    const cache = new SessionDedupeCache(instanceName);
-    // Cleanup is deferred to the first storage operation so a persistence
-    // guard can suppress it entirely.
-    cache.shouldTrack({ flag_key: 'flag-key', variant: 'on' });
-    expect(
-      safeGlobal.sessionStorage.getItem('EXP_sent_$default_instance'),
-    ).toBeNull();
-  });
-  test('old v2 storage is cleared on first use', () => {
-    const instanceName = '$default_instance';
-    safeGlobal.sessionStorage.setItem(
-      'EXP_sent_v2_$default_instance',
-      `{"flag-key":{"flag_key":"flag-key","variant":"on"}}`,
-    );
-    const cache = new SessionDedupeCache(instanceName);
-    cache.shouldTrack({ flag_key: 'flag-key', variant: 'on' });
-    expect(
-      safeGlobal.sessionStorage.getItem('EXP_sent_v2_$default_instance'),
-    ).toBeNull();
-  });
   test('storage key', () => {
     const instanceName = '$default_instance';
     const cache = new SessionDedupeCache(instanceName);
@@ -452,18 +426,11 @@ describe('SessionDedupeCache', () => {
     const v3Key = 'EXP_sent_v3_$default_instance';
 
     test('gated: dedupes in memory without touching sessionStorage', () => {
-      // A legacy key that ungated construction would have cleaned up.
-      safeGlobal.sessionStorage.setItem(
-        'EXP_sent_$default_instance',
-        '{"old":"v"}',
-      );
       const cache = new SessionDedupeCache('$default_instance', () => false);
       expect(cache.shouldTrack(exposure)).toEqual(true);
       expect(cache.shouldTrack(exposure)).toEqual(false);
       expect(safeGlobal.sessionStorage.getItem(v3Key)).toBeNull();
-      expect(
-        safeGlobal.sessionStorage.getItem('EXP_sent_$default_instance'),
-      ).toEqual('{"old":"v"}');
+      expect(safeGlobal.sessionStorage.length).toEqual(0);
     });
 
     test('entries recorded while gated survive the guard reopening', () => {

--- a/packages/experiment-browser/test/integration/manager.test.ts
+++ b/packages/experiment-browser/test/integration/manager.test.ts
@@ -652,16 +652,13 @@ describe('PersistentTrackingQueue', () => {
 
     queue.push(event);
     expect(queue['inMemoryQueue']).toEqual([]);
-    expect(safeGlobal.localStorage.getItem(queue['storageKey'])).toEqual(
-      JSON.stringify([]),
-    );
+    // A fully drained queue leaves no key behind rather than a stored `[]`.
+    expect(safeGlobal.localStorage.getItem(queue['storageKey'])).toBeNull();
     expect(trackedEvents).toEqual([event]);
 
     queue.push(event);
     expect(queue['inMemoryQueue']).toEqual([]);
-    expect(safeGlobal.localStorage.getItem(queue['storageKey'])).toEqual(
-      JSON.stringify([]),
-    );
+    expect(safeGlobal.localStorage.getItem(queue['storageKey'])).toBeNull();
     expect(trackedEvents).toEqual([event, event]);
   });
 
@@ -690,9 +687,7 @@ describe('PersistentTrackingQueue', () => {
 
     queue.push(event);
     expect(queue['inMemoryQueue']).toEqual([]);
-    expect(safeGlobal.localStorage.getItem(queue['storageKey'])).toEqual(
-      JSON.stringify([]),
-    );
+    expect(safeGlobal.localStorage.getItem(queue['storageKey'])).toBeNull();
     expect(trackedEvents).toEqual([event, event]);
   });
 
@@ -710,6 +705,90 @@ describe('PersistentTrackingQueue', () => {
       { eventType: '4' },
       { eventType: '5' },
     ]);
+  });
+
+  describe('persistenceAllowed guard', () => {
+    const storageKey = 'EXP_unsent_$default_instance';
+    const event: ExperimentEvent = {
+      eventType: '$exposure',
+      eventProperties: { flag_key: 'flag-key', variant: 'on' },
+    };
+
+    test('gated: events stay in memory and never touch localStorage', () => {
+      const queue = new PersistentTrackingQueue(
+        '$default_instance',
+        512,
+        () => false,
+      );
+      queue.push(event);
+      expect(queue['inMemoryQueue']).toEqual([event]);
+      expect(safeGlobal.localStorage.getItem(storageKey)).toBeNull();
+
+      const trackedEvents: ExperimentEvent[] = [];
+      queue.setTracker((e) => {
+        trackedEvents.push(e);
+        return true;
+      });
+      expect(trackedEvents).toEqual([event]);
+      expect(safeGlobal.localStorage.getItem(storageKey)).toBeNull();
+      queue['poller'] = undefined;
+    });
+
+    test('gated: a stored copy from an earlier session is not read', () => {
+      const stale = [{ eventType: 'stale' }];
+      safeGlobal.localStorage.setItem(storageKey, JSON.stringify(stale));
+      const queue = new PersistentTrackingQueue(
+        '$default_instance',
+        512,
+        () => false,
+      );
+      const trackedEvents: ExperimentEvent[] = [];
+      queue.setTracker((e) => {
+        trackedEvents.push(e);
+        return true;
+      });
+      expect(trackedEvents).toEqual([]);
+      // Untouched, not deleted: removal is cleanup's job, not the queue's.
+      expect(safeGlobal.localStorage.getItem(storageKey)).toEqual(
+        JSON.stringify(stale),
+      );
+      queue['poller'] = undefined;
+    });
+
+    test('events pushed while gated survive the guard reopening', () => {
+      let allowed = false;
+      const queue = new PersistentTrackingQueue(
+        '$default_instance',
+        512,
+        () => allowed,
+      );
+      queue.push(event);
+      expect(safeGlobal.localStorage.getItem(storageKey)).toBeNull();
+
+      allowed = true;
+      const trackedEvents: ExperimentEvent[] = [];
+      queue.setTracker((e) => {
+        trackedEvents.push(e);
+        return true;
+      });
+      // loadQueue must not let the (empty) device copy clobber the in-memory
+      // events that were held back while the guard was closed.
+      expect(trackedEvents).toEqual([event]);
+      expect(safeGlobal.localStorage.getItem(storageKey)).toBeNull();
+      queue['poller'] = undefined;
+    });
+
+    test('guard returning true behaves like no guard', () => {
+      const queue = new PersistentTrackingQueue(
+        '$default_instance',
+        512,
+        () => true,
+      );
+      queue.push(event);
+      expect(safeGlobal.localStorage.getItem(storageKey)).toEqual(
+        JSON.stringify([event]),
+      );
+    });
   });
 
   test('no duplicate for partial success', () => {

--- a/packages/experiment-browser/test/integration/manager.test.ts
+++ b/packages/experiment-browser/test/integration/manager.test.ts
@@ -262,24 +262,28 @@ describe('SessionDedupeCache', () => {
   beforeEach(() => {
     safeGlobal.sessionStorage.clear();
   });
-  test('old v1 storage is cleared', () => {
+  test('old v1 storage is cleared on first use', () => {
     const instanceName = '$default_instance';
     safeGlobal.sessionStorage.setItem(
       'EXP_sent_$default_instance',
       `{"flag-key":"variant"}`,
     );
-    new SessionDedupeCache(instanceName);
+    const cache = new SessionDedupeCache(instanceName);
+    // Cleanup is deferred to the first storage operation so a persistence
+    // guard can suppress it entirely.
+    cache.shouldTrack({ flag_key: 'flag-key', variant: 'on' });
     expect(
       safeGlobal.sessionStorage.getItem('EXP_sent_$default_instance'),
     ).toBeNull();
   });
-  test('old v2 storage is cleared', () => {
+  test('old v2 storage is cleared on first use', () => {
     const instanceName = '$default_instance';
     safeGlobal.sessionStorage.setItem(
       'EXP_sent_v2_$default_instance',
       `{"flag-key":{"flag_key":"flag-key","variant":"on"}}`,
     );
-    new SessionDedupeCache(instanceName);
+    const cache = new SessionDedupeCache(instanceName);
+    cache.shouldTrack({ flag_key: 'flag-key', variant: 'on' });
     expect(
       safeGlobal.sessionStorage.getItem('EXP_sent_v2_$default_instance'),
     ).toBeNull();
@@ -441,6 +445,62 @@ describe('SessionDedupeCache', () => {
     expect(cache.shouldTrack(exposure)).toEqual(false); // In-memory cache still works
     // Restore original setItem
     safeGlobal.sessionStorage.setItem = originalSetItem;
+  });
+
+  describe('persistenceAllowed guard', () => {
+    const exposure = { flag_key: 'flag-key', variant: 'on' };
+    const v3Key = 'EXP_sent_v3_$default_instance';
+
+    test('gated: dedupes in memory without touching sessionStorage', () => {
+      // A legacy key that ungated construction would have cleaned up.
+      safeGlobal.sessionStorage.setItem(
+        'EXP_sent_$default_instance',
+        '{"old":"v"}',
+      );
+      const cache = new SessionDedupeCache('$default_instance', () => false);
+      expect(cache.shouldTrack(exposure)).toEqual(true);
+      expect(cache.shouldTrack(exposure)).toEqual(false);
+      expect(safeGlobal.sessionStorage.getItem(v3Key)).toBeNull();
+      expect(
+        safeGlobal.sessionStorage.getItem('EXP_sent_$default_instance'),
+      ).toEqual('{"old":"v"}');
+    });
+
+    test('entries recorded while gated survive the guard reopening', () => {
+      let allowed = false;
+      const cache = new SessionDedupeCache('$default_instance', () => allowed);
+      expect(cache.shouldTrack(exposure)).toEqual(true);
+
+      allowed = true;
+      // Still deduped: the stored (empty) copy must not clobber the entry
+      // recorded in memory while the guard was closed.
+      expect(cache.shouldTrack(exposure)).toEqual(false);
+      expect(safeGlobal.sessionStorage.getItem(v3Key)).toEqual(
+        JSON.stringify({ 'flag-key': 'on' }),
+      );
+    });
+
+    test('an identity change while gated drops the pre-gate stored cache on reopen', () => {
+      safeGlobal.sessionStorage.setItem(
+        v3Key,
+        JSON.stringify({ 'other-flag': 'on' }),
+      );
+      let allowed = false;
+      const cache = new SessionDedupeCache('$default_instance', () => allowed);
+      // First call with a user is an identity change from {}, which clears
+      // the cache — while gated, the stored copy can't be removed yet.
+      cache.shouldTrack(exposure, { user_id: 'user-1' });
+
+      allowed = true;
+      // On reopen the stored pre-gate cache is dropped before being read, so
+      // it cannot suppress the new identity's exposures.
+      expect(
+        cache.shouldTrack(
+          { flag_key: 'other-flag', variant: 'on' },
+          { user_id: 'user-1' },
+        ),
+      ).toEqual(true);
+    });
   });
 
   // User-aware deduplication tests
@@ -752,6 +812,30 @@ describe('PersistentTrackingQueue', () => {
       expect(safeGlobal.localStorage.getItem(storageKey)).toEqual(
         JSON.stringify(stale),
       );
+      queue['poller'] = undefined;
+    });
+
+    test('gated events merge with a stale stored copy on reopen', () => {
+      const stale: ExperimentEvent = { eventType: 'stale' };
+      safeGlobal.localStorage.setItem(storageKey, JSON.stringify([stale]));
+      let allowed = false;
+      const queue = new PersistentTrackingQueue(
+        '$default_instance',
+        512,
+        () => allowed,
+      );
+      queue.push(event);
+
+      allowed = true;
+      const trackedEvents: ExperimentEvent[] = [];
+      queue.setTracker((e) => {
+        trackedEvents.push(e);
+        return true;
+      });
+      // Neither copy clobbers the other: stored (older) first, then the
+      // event held in memory while the guard was closed.
+      expect(trackedEvents).toEqual([stale, event]);
+      expect(safeGlobal.localStorage.getItem(storageKey)).toBeNull();
       queue['poller'] = undefined;
     });
 

--- a/packages/experiment-tag/src/behavioral-targeting/event-storage.ts
+++ b/packages/experiment-tag/src/behavioral-targeting/event-storage.ts
@@ -327,12 +327,9 @@ export class EventStorageManager {
   }
 
   /**
-   * Loads data from localStorage into memory on initialization.
-   *
-   * Storage access goes through the consent-gated helpers in `util/storage`:
-   * without consent this reads as absent (the cache starts empty rather than
-   * inheriting an earlier consented visit's events), and the uuid backfill
-   * below cannot write to a store the visitor has not agreed to.
+   * Loads data from localStorage into memory on initialization. Goes through
+   * the consent-gated helpers in `util/storage`: without consent this reads
+   * as absent, and the uuid backfill below cannot write to the device.
    */
   private loadFromLocalStorage(): EventStorage {
     const parsed = getStorageItem<EventStorage>(
@@ -387,11 +384,9 @@ export class EventStorageManager {
   }
 
   /**
-   * Immediately writes in-memory cache to localStorage.
-   *
-   * While consent is withheld nothing reaches the device: the events stay
-   * targetable in memory, and the listener armed at construction settles them
-   * on the consent decision — persisted on grant, dropped on refusal.
+   * Immediately writes in-memory cache to localStorage. While consent is
+   * withheld nothing reaches the device — the events stay targetable in
+   * memory and the consent listener settles them on the decision.
    */
   private flushToLocalStorage(): void {
     if (!this.hasPendingWrites) {
@@ -412,11 +407,9 @@ export class EventStorageManager {
 
   /**
    * Settles the pending window on the consent decision. The gated load at
-   * construction hid whatever an earlier consented visit stored, so a grant
-   * folds the device store back into memory (uuid-dedup via `mergeFromRelay`)
-   * and persists the union before any later write-through could replace it.
-   * Refusal drops the pending-window events so they cannot reach the device
-   * through a later re-grant.
+   * construction hid the device store, so a grant folds it back into memory
+   * (uuid-dedup via `mergeFromRelay`) and persists the union. Refusal drops
+   * the pending-window events.
    */
   private armConsentListener(): void {
     onConsentDecision((granted) => {

--- a/packages/experiment-tag/src/behavioral-targeting/session-manager.ts
+++ b/packages/experiment-tag/src/behavioral-targeting/session-manager.ts
@@ -1,3 +1,4 @@
+import { isConsentWithheld } from '../consent/consent-gate';
 import { getTopLevelDomainSync, SyncJsonCookie } from '../util/cookie';
 
 /**
@@ -140,12 +141,20 @@ export class SessionManager {
   }
 
   private domain(): string {
-    if (this.resolvedDomain === undefined) {
-      this.resolvedDomain =
-        typeof location !== 'undefined' && location.hostname
-          ? getTopLevelDomainSync(location.hostname)
-          : '';
+    if (this.resolvedDomain !== undefined) {
+      return this.resolvedDomain;
     }
-    return this.resolvedDomain;
+    const resolved =
+      typeof location !== 'undefined' && location.hostname
+        ? getTopLevelDomainSync(location.hostname)
+        : '';
+    // While consent is withheld the resolver returns an unprobed guess (a real
+    // probe writes a throwaway cookie). Don't pin the guess: leaving the cache
+    // empty lets the first post-grant write probe for real, instead of keeping
+    // a possibly-wrong domain for the rest of the page.
+    if (!isConsentWithheld()) {
+      this.resolvedDomain = resolved;
+    }
+    return resolved;
   }
 }

--- a/packages/experiment-tag/src/consent/clear-data.ts
+++ b/packages/experiment-tag/src/consent/clear-data.ts
@@ -95,9 +95,9 @@ const getPersistedDataGroups = (
     },
     {
       // In-flight redirect impressions; the cookie copy is the cross-subdomain
-      // transport.
+      // transport. REDIRECT_MARKER is the stick-detector record from WEB-228.
       feature: 'redirect impressions',
-      sessionStorage: [`EXP_${slice}_REDIRECT`],
+      sessionStorage: [`EXP_${slice}_REDIRECT`, `EXP_${slice}_REDIRECT_MARKER`],
       cookies: [`EXP_${slice}_REDIRECT`],
     },
     {
@@ -116,7 +116,14 @@ const getPersistedDataGroups = (
       // the page.
       feature: 'exposure queue and dedupe',
       localStorage: [`EXP_unsent_${instanceName}`],
-      sessionStorage: [`EXP_sent_v3_${instanceName}`],
+      // v1/v2 keys: denial-at-load never constructs SessionDedupeCache, so
+      // leftover entries from a tab open across an SDK upgrade would otherwise
+      // survive a refusal.
+      sessionStorage: [
+        `EXP_sent_v3_${instanceName}`,
+        `EXP_sent_v2_${instanceName}`,
+        `EXP_sent_${instanceName}`,
+      ],
     },
   ];
 };

--- a/packages/experiment-tag/src/consent/clear-data.ts
+++ b/packages/experiment-tag/src/consent/clear-data.ts
@@ -95,9 +95,14 @@ const getPersistedDataGroups = (
     },
     {
       // In-flight redirect impressions; the cookie copy is the cross-subdomain
-      // transport. REDIRECT_MARKER is the stick-detector record from WEB-228.
+      // transport. MARKER / SUPPRESSED are the WEB-228 stick-detector records
+      // (written even while pending — see isConsentExemptStorageKey).
       feature: 'redirect impressions',
-      sessionStorage: [`EXP_${slice}_REDIRECT`, `EXP_${slice}_REDIRECT_MARKER`],
+      sessionStorage: [
+        `EXP_${slice}_REDIRECT`,
+        `EXP_${slice}_REDIRECT_MARKER`,
+        `EXP_${slice}_REDIRECT_SUPPRESSED`,
+      ],
       cookies: [`EXP_${slice}_REDIRECT`],
     },
     {

--- a/packages/experiment-tag/src/consent/clear-data.ts
+++ b/packages/experiment-tag/src/consent/clear-data.ts
@@ -37,8 +37,7 @@ const ERASURE_MARKER_MAX_AGE_SECONDS = 365 * 24 * 60 * 60;
 
 /**
  * One feature's persisted footprint: every key it writes, per store. The
- * `feature` label names the writer — the groups exist so that each key is
- * explained by what persists it, not to drive any logic.
+ * grouping is documentation only — it does not drive any logic.
  */
 interface PersistedDataGroup {
   feature: string;
@@ -114,17 +113,10 @@ const getPersistedDataGroups = (
       // Experiment SDK on the page under the same name. Deleting the queue
       // discards that instance's queued exposures too — accepted: a visitor
       // who denied consent shouldn't have queued exposures from any SDK on
-      // the page. Dedupe keys cover every version, not just the current one:
-      // SessionDedupeCache drops the older two when constructed, and a denial
-      // at load never constructs a client — so an entry from an earlier SDK
-      // version would outlive the denial for the tab.
+      // the page.
       feature: 'exposure queue and dedupe',
       localStorage: [`EXP_unsent_${instanceName}`],
-      sessionStorage: [
-        `EXP_sent_v3_${instanceName}`,
-        `EXP_sent_v2_${instanceName}`,
-        `EXP_sent_${instanceName}`,
-      ],
+      sessionStorage: [`EXP_sent_v3_${instanceName}`],
     },
   ];
 };
@@ -147,24 +139,16 @@ export const getPersistedDataKeys = (
 
 /**
  * Deletes everything experiment-tag has persisted for `apiKey`. Runs when
- * consent is denied at load — where the data belongs to an earlier session, or
- * predates the customer enabling consent gating — and on mid-session
- * revocation.
+ * consent is denied at load and on mid-session revocation.
  *
- * This clears what earlier sessions left behind; it does not stop the current
- * one. A running client is unaware of consent — nothing outside `index.ts` reads
- * the status — so after a revocation it can re-persist some of these keys before
- * the page is reloaded.
- *
- * Cookies are deleted at the host scope and at every candidate root domain: the
- * writers pick between them via a writability probe whose result can differ from
- * the one that applied at write time, and deleting an unused domain is a no-op.
- * This path makes no probe of its own, so cleanup never sets a cookie while
- * consent is denied.
+ * Cookies are deleted at the host scope and at every candidate root domain:
+ * the writability probe that picked the domain at write time can resolve
+ * differently now, and deleting an unused domain is a no-op. No probe is made
+ * here, so cleanup never sets a cookie while consent is denied.
  *
  * Known gap: the relay iframe's CDN-origin localStorage can't be reached from
- * the parent page. The relay is only injected after a grant, so that data exists
- * only for consented visitors.
+ * the parent page. The relay is only injected after a grant, so that data
+ * exists only for consented visitors.
  */
 export const clearAllPersistedData = (
   apiKey: string,
@@ -191,16 +175,11 @@ export const clearAllPersistedData = (
 
 /**
  * Records that the shared identity was erased, so a sibling subdomain cannot
- * respawn it. The sweep reaches only this origin's localStorage, and identity
- * resolution seeds from the per-origin `EXP_<slice>` record once the shared cookie
- * is gone — so without this marker, whichever origin the visitor next opts in on
- * decides whether the refusal held.
- *
- * Written *after* a refusal, so the payload is `1`: no timestamp, no identifier,
- * justified only by making that refusal effective. It goes to the first root
- * domain that accepts it, verified by `writeRawCookie`'s read-back rather than a
- * probe cookie, which would be a second write. Hosts with no writable root domain
- * (single-label, IPs) share nothing across origins, so none is written.
+ * respawn it: the sweep reaches only this origin's localStorage, and without
+ * the marker another origin's local `EXP_<slice>` seed would re-establish the
+ * erased identity. The payload is just `1` — no timestamp or identifier — and
+ * goes to the first root domain that accepts it (verified by read-back, not a
+ * probe cookie, which would be a second write).
  */
 export const markIdentityErased = (apiKey: string): void => {
   const hostname = getGlobalScope()?.location?.hostname ?? '';
@@ -216,20 +195,15 @@ export const markIdentityErased = (apiKey: string): void => {
 };
 
 /**
- * Carries an erasure across to this origin — see {@link markIdentityErased}. Must
- * run before its caller reads any persisted state: variant/flag caches and
- * behavioral events hydrate into memory at construction, and copies already
- * loaded survive this sweep and can be written back under the fresh identity.
+ * Carries an erasure across to this origin — see {@link markIdentityErased}.
+ * Must run before the caller reads any persisted state, since caches hydrate
+ * into memory at construction and would survive the sweep.
  *
- * Both conditions matter. No marker means nothing to carry over; a shared identity
- * cookie means an identity established since the erasure is already in use and
- * wins over every local seed. Marker set with the cookie gone is exactly the
- * respawn case, and there the local records are worthless anyway — this origin is
- * about to mint a fresh identity regardless.
- *
- * Whether consent gating is still switched on is not consulted: the marker only
- * exists because a visitor refused, and that refusal has to outlive a customer
- * turning the feature off.
+ * Sweeps only when the marker is set AND the shared identity cookie is gone —
+ * the respawn case. A present cookie means an identity established since the
+ * erasure is in use and wins over local seeds. Runs regardless of whether
+ * gating is still enabled: a refusal has to outlive the customer turning the
+ * feature off.
  */
 export const clearIfErasedElsewhere = (
   apiKey: string,
@@ -242,16 +216,11 @@ export const clearIfErasedElsewhere = (
 
 /**
  * Arms the denial cleanup against the current manager, once. Called from
- * `initialize` because the sweep needs the apiKey that call supplies.
+ * `initialize` because the sweep needs its apiKey. Lives here rather than in
+ * `consent-gate.ts` to avoid a circular import with the storage utilities.
  *
- * Lives here rather than in `consent-gate.ts` so that module stays a leaf the
- * storage utilities can import — this file depends on those utilities, and
- * routing the sweep through the gate module would close the loop.
- *
- * Ordering matters: the immediate sweep covers a denial that resolved before
- * this point (config value, or a setConsentStatus call against the pre-init
- * stub), and the listener registered after it covers every later revocation.
- * Registering second keeps a single sweep per denial rather than double-firing
+ * The immediate sweep covers a denial that resolved before this point; the
+ * listener registered after it covers later revocations without double-firing
  * on the transition that just happened.
  */
 export const armDenialCleanup = (

--- a/packages/experiment-tag/src/consent/consent-cookie-storage.ts
+++ b/packages/experiment-tag/src/consent/consent-cookie-storage.ts
@@ -41,8 +41,26 @@ export class ConsentAwareCookieStorage<T> implements AsyncCookieStore<T> {
    */
   private flush: Promise<void> | null = null;
   private flushArmed = false;
+  private resolvedDelegate: Promise<AsyncCookieStore<T>> | null = null;
 
-  constructor(private readonly delegate: AsyncCookieStore<T>) {}
+  /**
+   * A factory delegate is resolved lazily, on the first access that actually
+   * reaches real storage. That lets construction-time inputs that cannot be
+   * probed while consent is withheld — the cross-subdomain cookie domain —
+   * be resolved for real once consent is granted, instead of freezing the
+   * unprobed guess a pending-time construction would capture.
+   */
+  constructor(
+    private readonly delegate:
+      | AsyncCookieStore<T>
+      | (() => Promise<AsyncCookieStore<T>> | AsyncCookieStore<T>),
+  ) {}
+
+  private getDelegate(): Promise<AsyncCookieStore<T>> {
+    return (this.resolvedDelegate ??= Promise.resolve(
+      typeof this.delegate === 'function' ? this.delegate() : this.delegate,
+    ));
+  }
 
   async get(key: string): Promise<T | undefined> {
     if (isConsentWithheld()) {
@@ -52,7 +70,7 @@ export class ConsentAwareCookieStorage<T> implements AsyncCookieStore<T> {
       return value === undefined ? undefined : snapshotValue(value);
     }
     await this.flush;
-    return this.delegate.get(key);
+    return (await this.getDelegate()).get(key);
   }
 
   async set(key: string, value: T): Promise<void> {
@@ -64,7 +82,7 @@ export class ConsentAwareCookieStorage<T> implements AsyncCookieStore<T> {
       return;
     }
     await this.flush;
-    return this.delegate.set(key, value);
+    return (await this.getDelegate()).set(key, value);
   }
 
   async remove(key: string): Promise<void> {
@@ -76,7 +94,7 @@ export class ConsentAwareCookieStorage<T> implements AsyncCookieStore<T> {
       return;
     }
     await this.flush;
-    return this.delegate.remove(key);
+    return (await this.getDelegate()).remove(key);
   }
 
   private armFlush(): void {
@@ -91,12 +109,22 @@ export class ConsentAwareCookieStorage<T> implements AsyncCookieStore<T> {
         return;
       }
       this.flush = (async () => {
+        // Resolved here, after the grant, so a factory delegate probes the
+        // real cookie domain rather than reusing a pending-time guess.
+        let delegate: AsyncCookieStore<T>;
+        try {
+          delegate = await this.getDelegate();
+        } catch {
+          // A failed delegate drops the buffer, like blocked cookie I/O; the
+          // flush itself must not reject or every later access would too.
+          return;
+        }
         for (const [key, value] of entries) {
           if (consentGate.manager.getStatus() !== 'granted') {
             return;
           }
           try {
-            const existing = await this.delegate.get(key);
+            const existing = await delegate.get(key);
             const merged =
               typeof value === 'string'
                 ? (mergeIdentityCookieJson(
@@ -104,7 +132,7 @@ export class ConsentAwareCookieStorage<T> implements AsyncCookieStore<T> {
                     value,
                   ) as T)
                 : value;
-            await this.delegate.set(key, merged);
+            await delegate.set(key, merged);
           } catch {
             // Blocked cookie I/O degrades silently, as the raw paths do.
           }
@@ -114,11 +142,24 @@ export class ConsentAwareCookieStorage<T> implements AsyncCookieStore<T> {
   }
 }
 
+type CookieStorageOptions = ConstructorParameters<typeof CookieStorage>[0];
+
 /**
  * Builds the cookie storage every experiment-tag call site should use, so a new
  * one cannot silently bypass the consent gate.
+ *
+ * Pass a function when an option can only be resolved with a device probe —
+ * the cross-subdomain `domain` — so it is evaluated on the first access that
+ * reaches real storage (post-grant for a visitor who started out pending)
+ * rather than frozen at construction while consent is withheld.
  */
 export const createCookieStorage = <T>(
-  options?: ConstructorParameters<typeof CookieStorage>[0],
+  options?:
+    | CookieStorageOptions
+    | (() => Promise<CookieStorageOptions> | CookieStorageOptions),
 ): AsyncCookieStore<T> =>
-  new ConsentAwareCookieStorage<T>(new CookieStorage<T>(options));
+  new ConsentAwareCookieStorage<T>(
+    typeof options === 'function'
+      ? async () => new CookieStorage<T>(await options())
+      : new CookieStorage<T>(options),
+  );

--- a/packages/experiment-tag/src/consent/consent-cookie-storage.ts
+++ b/packages/experiment-tag/src/consent/consent-cookie-storage.ts
@@ -44,11 +44,10 @@ export class ConsentAwareCookieStorage<T> implements AsyncCookieStore<T> {
   private resolvedDelegate: Promise<AsyncCookieStore<T>> | null = null;
 
   /**
-   * A factory delegate is resolved lazily, on the first access that actually
-   * reaches real storage. That lets construction-time inputs that cannot be
-   * probed while consent is withheld — the cross-subdomain cookie domain —
-   * be resolved for real once consent is granted, instead of freezing the
-   * unprobed guess a pending-time construction would capture.
+   * A factory delegate is resolved lazily, on the first access that reaches
+   * real storage. This lets the cross-subdomain cookie domain — unprobeable
+   * while consent is withheld — be resolved for real post-grant instead of
+   * freezing a pending-time guess.
    */
   constructor(
     private readonly delegate:
@@ -86,9 +85,8 @@ export class ConsentAwareCookieStorage<T> implements AsyncCookieStore<T> {
   }
 
   async remove(key: string): Promise<void> {
-    // Refusal falls through so denial cleanup can erase a cookie from a
-    // consented visit; only a still-undecided visitor stops at the buffer, since
-    // expiring a cookie is itself a write.
+    // Pending stops at the buffer (expiring a cookie is itself a write);
+    // refusal falls through so denial cleanup can erase real cookies.
     if (isConsentPending()) {
       this.buffered.delete(key);
       return;
@@ -109,14 +107,14 @@ export class ConsentAwareCookieStorage<T> implements AsyncCookieStore<T> {
         return;
       }
       this.flush = (async () => {
-        // Resolved here, after the grant, so a factory delegate probes the
-        // real cookie domain rather than reusing a pending-time guess.
+        // Resolved post-grant so a factory delegate probes the real cookie
+        // domain rather than reusing a pending-time guess.
         let delegate: AsyncCookieStore<T>;
         try {
           delegate = await this.getDelegate();
         } catch {
-          // A failed delegate drops the buffer, like blocked cookie I/O; the
-          // flush itself must not reject or every later access would too.
+          // Drop the buffer; the flush must not reject or every later access
+          // (which awaits it) would too.
           return;
         }
         for (const [key, value] of entries) {
@@ -145,13 +143,11 @@ export class ConsentAwareCookieStorage<T> implements AsyncCookieStore<T> {
 type CookieStorageOptions = ConstructorParameters<typeof CookieStorage>[0];
 
 /**
- * Builds the cookie storage every experiment-tag call site should use, so a new
- * one cannot silently bypass the consent gate.
- *
- * Pass a function when an option can only be resolved with a device probe —
- * the cross-subdomain `domain` — so it is evaluated on the first access that
- * reaches real storage (post-grant for a visitor who started out pending)
- * rather than frozen at construction while consent is withheld.
+ * Builds the cookie storage every experiment-tag call site should use, so a
+ * new one cannot silently bypass the consent gate. Pass a function when an
+ * option needs a device probe (the cross-subdomain `domain`); it is evaluated
+ * on the first access that reaches real storage rather than frozen at
+ * construction while consent is withheld.
  */
 export const createCookieStorage = <T>(
   options?:

--- a/packages/experiment-tag/src/consent/consent-gate.ts
+++ b/packages/experiment-tag/src/consent/consent-gate.ts
@@ -21,13 +21,11 @@ interface ConsentGate {
   /** Tri-state status owner; `index.ts` reads and transitions through it. */
   manager: ConsentManager;
   /**
-   * Whether the customer asked for consent gating at all. The manager starts at
-   * 'pending' for everyone, so this is what separates a visitor who has yet to
-   * decide from the overwhelming majority of pages that never enabled the
-   * feature — persistence gates must consult {@link isConsentPending}, never the
-   * status alone. Set by `initialize` before the client is constructed, and
-   * sticky once true so a later `initialize` resolving `consentRequired: false`
-   * cannot reopen storage a prior one closed.
+   * Whether the customer enabled consent gating. The manager starts at
+   * 'pending' for everyone, so gates must check this (via
+   * {@link isConsentPending}), never the status alone. Sticky once true, so a
+   * later `initialize` resolving `consentRequired: false` cannot reopen
+   * storage a prior one closed.
    */
   required: boolean;
   /** Args stashed by `initialize` while consent is not yet granted. */
@@ -35,12 +33,10 @@ interface ConsentGate {
   /** Whether the client has been (or is being) started. */
   started: boolean;
   /**
-   * The manager the denial-cleanup listener is attached to, or null before the
-   * first gated `initialize` — the listener needs the apiKey that call
-   * supplies (see `armDenialCleanup` in `clear-data.ts`). The test-only
-   * `reset()` replaces the manager, stranding listeners on the old instance
-   * (its status never changes again). Comparing instances rather than tracking
-   * a boolean makes the next initialize re-arm against the live manager.
+   * The manager the denial-cleanup listener is attached to (see
+   * `armDenialCleanup` in `clear-data.ts`). The test-only `reset()` replaces
+   * the manager, stranding listeners on the old instance; comparing instances
+   * lets the next initialize re-arm against the live one.
    */
   cleanupArmedManager: ConsentManager | null;
   /** Test-only reset; kept off the public `index` entry point. */
@@ -59,9 +55,6 @@ export const consentGate: ConsentGate = {
   started: false,
   cleanupArmedManager: null,
   reset() {
-    // Replacing the manager detaches its listeners with it; the armed-manager
-    // comparison in `armDenialCleanup` re-arms against the replacement on its
-    // own, so the null here is fresh state, not a correctness requirement.
     this.manager = new ConsentManager();
     this.required = false;
     this.deferredStart = null;
@@ -71,11 +64,9 @@ export const consentGate: ConsentGate = {
 };
 
 /**
- * Read-only snapshot of the gate for `getDebugState()` — the consent state is
- * module-scoped (it exists before any client does), so this is how it surfaces
- * on the single debug object at `window.webExperiment.getDebugState()`.
- * `impressionBuffers` is composed in by the recorder: the buffer module
- * imports this one, so the dependency cannot point the other way.
+ * Read-only snapshot of the gate for `getDebugState()`. `impressionBuffers`
+ * is composed in by the recorder — the buffer module imports this one, so the
+ * dependency cannot point the other way.
  */
 export const getConsentDebugState = (): Omit<
   ConsentDebugInfo,
@@ -88,12 +79,10 @@ export const getConsentDebugState = (): Omit<
 });
 
 /**
- * Runs `handler` on the first status transition of the current manager and
- * unsubscribes. Pending only ever resolves one way or the other, so a buffer
- * armed while consent is undecided is settled by that single transition:
- * flushed on grant, dropped on refusal. Spending the subscription there is also
- * what stops data gathered before a refusal from being written out later,
- * should the visitor return to the banner and opt in.
+ * Runs `handler` on the first status transition and unsubscribes. A buffer
+ * armed while pending is settled by that one transition: flushed on grant,
+ * dropped on refusal. The one-shot also stops data gathered before a refusal
+ * from being written out by a later same-page re-opt-in.
  */
 export const onConsentDecision = (
   handler: (granted: boolean) => void,
@@ -105,23 +94,18 @@ export const onConsentDecision = (
 };
 
 /**
- * True while the visitor has yet to decide and gating is active — the condition
- * under which persistence is held in memory instead of written out. False when
- * the feature is off, so every gate built on it is inert for pages that never
- * enabled consent.
+ * True while gating is active and the visitor has yet to decide — the
+ * condition under which writes are buffered in memory (consent may still
+ * arrive). Always false when the feature is off.
  */
 export const isConsentPending = (): boolean =>
   consentGate.required && consentGate.manager.getStatus() === 'pending';
 
 /**
- * True whenever gating is active and consent is not in hand — either not yet
- * given or refused. This is the condition for keeping data off the device;
- * {@link isConsentPending} narrows it to the case where the data is still worth
- * holding on to, because consent may yet arrive.
- *
- * Refusal has to suppress persistence and not merely trigger cleanup: a visitor
- * who withdraws consent mid-visit leaves a client already running, and erasing
- * its data while it carries on writing would put the data straight back.
+ * True while gating is active and consent is not in hand (pending or denied) —
+ * the condition for keeping data off the device. Denial must suppress
+ * persistence, not just trigger cleanup: a client already running after a
+ * mid-session revocation would otherwise write the data straight back.
  */
 export const isConsentWithheld = (): boolean =>
   consentGate.required && consentGate.manager.getStatus() !== 'granted';

--- a/packages/experiment-tag/src/consent/consent-impression-buffer.ts
+++ b/packages/experiment-tag/src/consent/consent-impression-buffer.ts
@@ -26,10 +26,8 @@ const WRAPPED_KEY = '__ampConsentGatedTrack';
 /**
  * The integration's original `track`, captured before the buffer replaces it.
  * The boolean is `IntegrationPlugin.track`'s contract: whether the downstream
- * integration accepted the event — the analytics SDK it forwards to may not
- * have a receiver attached yet. `flush` relies on it: a `false` (or a throw)
- * stops the replay, keeps the remainder buffered, and hands off to the retry
- * poller.
+ * integration accepted the event. `flush` relies on it — a `false` (or a
+ * throw) stops the replay and hands off to the retry poller.
  */
 type Tracker = (event: ExperimentEvent) => boolean;
 
@@ -151,16 +149,12 @@ class ImpressionBuffer {
 }
 
 /**
- * Records when the impression happened. The analytics SDK timestamps an event
- * as it receives it, which for a replay is the moment of the grant — long after
- * the variant was shown for a visitor who leaves the banner up.
- *
- * The `time` key is a cross-SDK contract, not a label: the analytics SDK's
- * event-bridge receiver destructures `time` out of `eventProperties` and
- * promotes it to the canonical event timestamp (`setEventReceiver` in
- * Amplitude-TypeScript's browser-client). The client already stamps it on web
- * experiment exposures, so this is a fallback for events that arrive without
- * one.
+ * Records when the impression happened — a replayed event would otherwise be
+ * timestamped at the moment of the grant, long after the variant was shown.
+ * The `time` key is a cross-SDK contract: the analytics SDK's event-bridge
+ * receiver promotes it from `eventProperties` to the canonical event
+ * timestamp. The client already stamps web experiment exposures, so this is a
+ * fallback for events that arrive without one.
  */
 function stampTime(event: ExperimentEvent): ExperimentEvent {
   if (event.eventProperties?.time !== undefined) {

--- a/packages/experiment-tag/src/consent/consent-manager.ts
+++ b/packages/experiment-tag/src/consent/consent-manager.ts
@@ -77,10 +77,8 @@ export class ConsentManager {
     const previous = this.currentStatus;
     this.currentStatus = status;
     // Snapshot before notifying: a listener can arm another listener while
-    // this loop runs (the relay teardown is armed inside the pending-grant
-    // deferral), and live Set iteration would visit — and, for a one-shot,
-    // spend — the new listener on the very transition it was armed during,
-    // instead of the next one.
+    // this loop runs, and live Set iteration would fire (and spend, for a
+    // one-shot) the new listener on the very transition it was armed during.
     for (const listener of [...this.listeners]) {
       try {
         listener(status, previous);

--- a/packages/experiment-tag/src/consent/consent-manager.ts
+++ b/packages/experiment-tag/src/consent/consent-manager.ts
@@ -76,7 +76,12 @@ export class ConsentManager {
     }
     const previous = this.currentStatus;
     this.currentStatus = status;
-    for (const listener of this.listeners) {
+    // Snapshot before notifying: a listener can arm another listener while
+    // this loop runs (the relay teardown is armed inside the pending-grant
+    // deferral), and live Set iteration would visit — and, for a one-shot,
+    // spend — the new listener on the very transition it was armed during,
+    // instead of the next one.
+    for (const listener of [...this.listeners]) {
       try {
         listener(status, previous);
       } catch (error) {

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -329,6 +329,13 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     string,
     StoredRedirectImpression
   > | null = null;
+  /**
+   * Settles once the post-grant identity refresh has finished (or right away on
+   * refusal). Armed only by a pending start(), whose gated reads may have
+   * minted an ephemeral identity; the deferred relay sync awaits it so the
+   * relay binds to the durable identity the grant flush restored.
+   */
+  private identityRefreshOnGrant: Promise<void> | null = null;
 
   constructor(
     apiKey: string,
@@ -664,6 +671,70 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       );
     }
     user.first_seen = identity.first_seen;
+
+    // Under pending, the gated reads above hid any durable identity an earlier
+    // consented visit stored, so the ids resolved here may be an ephemeral
+    // mint. The grant flush restores the durable identity on disk
+    // (grant-flush-merge), but this running client would otherwise keep the
+    // ephemeral one for the rest of the page — fragmenting sticky bucketing
+    // and cross-subdomain behavioral data across the grant boundary. Re-read
+    // the reconciled identity after the flush and move the client onto it, so
+    // post-grant evaluation and the deferred relay sync bind to the identity
+    // every later page load will use. Variants already painted stay as
+    // applied; a mid-page repaint at the moment of grant would be worse than
+    // one page of drift on the exposures already queued.
+    if (isConsentPending()) {
+      this.identityRefreshOnGrant = new Promise<void>((resolve) => {
+        onConsentDecision((granted) => {
+          if (!granted) {
+            resolve();
+            return;
+          }
+          void (async () => {
+            try {
+              // The localStorage gate flushed synchronously when this listener's
+              // predecessors ran (they were armed earlier, on the buffered
+              // writes); the cookie read below joins the cookie gate's flush.
+              const durableUser =
+                getStorageItem<WebExperimentUser>(
+                  'localStorage',
+                  experimentStorageName,
+                ) || {};
+              const refreshed = await resolveCrossSubdomainObject(
+                crossSubdomainCookieStorage,
+                identityCookieKey(this.apiKey),
+                {
+                  web_exp_id_v2:
+                    durableUser.web_exp_id_v2 ?? user.web_exp_id_v2,
+                  first_seen: user.first_seen,
+                },
+                {
+                  web_exp_id_v2: UUID,
+                  first_seen: () => (Date.now() / 1000).toString(),
+                },
+              );
+              user.web_exp_id = durableUser.web_exp_id ?? user.web_exp_id;
+              user.web_exp_id_v2 = refreshed.web_exp_id_v2;
+              user.first_seen = refreshed.first_seen;
+              const refreshedUser: WebExperimentUser = {
+                ...((this.experimentClient.getUser() ??
+                  {}) as WebExperimentUser),
+                web_exp_id: user.web_exp_id,
+                web_exp_id_v2: user.web_exp_id_v2,
+                first_seen: user.first_seen,
+              };
+              this.experimentClient.setUser(refreshedUser);
+            } catch {
+              // A failed refresh keeps the ephemeral identity — the same state
+              // the page was already in; the next load reads the durable one.
+            } finally {
+              resolve();
+            }
+          })();
+        });
+      });
+    }
+
     this.experimentClient.setUser(user);
 
     // evaluate variants for page targeting
@@ -1034,9 +1105,12 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
 
     // Third-party surface: the relay iframe stores events in the CDN origin's
     // localStorage, so it must not exist before consent. Deferred rather than
-    // skipped — a grant re-runs this with the same user, and by then the
-    // storage-gate flush listeners (armed earlier, on the buffered writes)
-    // have already run, so the merge reads a complete local event store. A
+    // skipped — a grant re-runs this, and by then the storage-gate flush
+    // listeners (armed earlier, on the buffered writes) have already run, so
+    // the merge reads a complete local event store. The re-entry awaits the
+    // identity refresh (also armed earlier in start(), so its listener fires
+    // first) and re-reads the client's user, so the relay binds to the
+    // durable identity the grant restored rather than a pending-time mint. A
     // refusal spends the one-shot subscription without injecting and the
     // relay stays out for the rest of the page — a later re-opt-in gets it on
     // the next load. A refusal that already landed (a denial racing start())
@@ -1047,7 +1121,13 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       if (isConsentPending()) {
         onConsentDecision((granted) => {
           if (granted) {
-            this.scheduleRelaySync(user);
+            void (async () => {
+              await this.identityRefreshOnGrant;
+              this.scheduleRelaySync({
+                ...user,
+                ...(this.experimentClient.getUser() as WebExperimentUser),
+              });
+            })();
           }
         });
       }

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -327,6 +327,11 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
   // Cross-subdomain cookie domain (leading-dot form or ''); resolved once, early
   // in start(), and reused by every EXP_ cookie path (identity + RTBT session).
   private rootDomain = '';
+  /** Redirect impressions parsed from AMP_REDIRECT before the first url_change. */
+  private preloadedUrlRedirectImpressions: Record<
+    string,
+    StoredRedirectImpression
+  > | null = null;
 
   constructor(
     apiKey: string,
@@ -570,6 +575,8 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       flushEventBuffer(this);
       return;
     }
+
+    this.consumeRedirectParamFromUrl(urlParams);
 
     // fire url_change upon landing on page, set updateActivePagesOnly to not trigger variant actions
     this.subscriptionManager.markUrlAsPublished(this.globalScope.location.href);
@@ -1962,6 +1969,29 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     }
   }
 
+  private consumeRedirectParamFromUrl(urlParams: Record<string, string>): void {
+    const encoded = urlParams[REDIRECT_IMPRESSION_PARAM];
+    if (!encoded) {
+      return;
+    }
+    if (
+      !this.config.redirectConfig?.encodeRedirectInUrl &&
+      !consentGate.required
+    ) {
+      return;
+    }
+    try {
+      this.preloadedUrlRedirectImpressions = JSON.parse(atob(encoded));
+    } catch {
+      this.preloadedUrlRedirectImpressions = {};
+    }
+    const cleanedUrl = removeQueryParams(this.globalScope.location.href, [
+      REDIRECT_IMPRESSION_PARAM,
+    ]);
+    this.subscriptionManager?.markUrlAsPublished(cleanedUrl);
+    this.globalScope.history.replaceState({}, '', cleanedUrl);
+  }
+
   private async fireStoredRedirectImpressions() {
     const storageKey = `EXP_${this.apiKey.slice(0, 10)}_REDIRECT`;
 
@@ -1970,11 +2000,14 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     // handleRedirect), so a gated destination must consume the param — and
     // clean the URL — even when the customer never opted into
     // encodeRedirectInUrl, including when consent has been granted by the
-    // time this page loads.
-    let urlImpressions: Record<string, StoredRedirectImpression> = {};
+    // time this page loads. When start() already consumed the param for page
+    // targeting, use that snapshot here.
+    let urlImpressions: Record<string, StoredRedirectImpression> =
+      this.preloadedUrlRedirectImpressions ?? {};
+    this.preloadedUrlRedirectImpressions = null;
     if (
-      this.config.redirectConfig?.encodeRedirectInUrl ||
-      consentGate.required
+      Object.keys(urlImpressions).length === 0 &&
+      (this.config.redirectConfig?.encodeRedirectInUrl || consentGate.required)
     ) {
       const urlParams = getUrlParams();
       const encoded = urlParams[REDIRECT_IMPRESSION_PARAM];

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -684,6 +684,13 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     // applied; a mid-page repaint at the moment of grant would be worse than
     // one page of drift on the exposures already queued.
     if (isConsentPending()) {
+      // The pending-time resolution, snapshotted before the grant handler
+      // mutates `user`: any post-flush cookie field still equal to one of
+      // these can only be this page's own buffered write (gated reads saw no
+      // cookie, so these values were minted or subdomain-local), and a
+      // durable value that survived elsewhere on disk should win over it.
+      const pendingWebExpIdV2 = user.web_exp_id_v2;
+      const pendingFirstSeen = user.first_seen;
       this.identityRefreshOnGrant = new Promise<void>((resolve) => {
         onConsentDecision((granted) => {
           if (!granted) {
@@ -700,22 +707,62 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
                   'localStorage',
                   experimentStorageName,
                 ) || {};
+              const durableProvider =
+                getStorageItem<{ first_seen?: string }>(
+                  'localStorage',
+                  defaultUserProviderStorageKey,
+                ) || {};
               const refreshed = await resolveCrossSubdomainObject(
                 crossSubdomainCookieStorage,
                 identityCookieKey(this.apiKey),
                 {
                   web_exp_id_v2:
                     durableUser.web_exp_id_v2 ?? user.web_exp_id_v2,
-                  first_seen: user.first_seen,
+                  first_seen: durableProvider.first_seen ?? user.first_seen,
                 },
                 {
                   web_exp_id_v2: UUID,
                   first_seen: () => (Date.now() / 1000).toString(),
                 },
               );
+              // When no durable cookie existed the flush merge wrote the
+              // pending-time values into it, so the re-read above returns this
+              // page's own mint. An ungated start() would have seeded the
+              // cookie from the durable localStorage values instead — converge
+              // to that: restore them over any field still at its pending-time
+              // value and rewrite the cookie, so the mint does not become the
+              // visitor's permanent identity.
+              const restored = { ...refreshed };
+              if (
+                durableUser.web_exp_id_v2 &&
+                refreshed.web_exp_id_v2 === pendingWebExpIdV2 &&
+                durableUser.web_exp_id_v2 !== pendingWebExpIdV2
+              ) {
+                restored.web_exp_id_v2 = durableUser.web_exp_id_v2;
+              }
+              if (
+                durableProvider.first_seen &&
+                refreshed.first_seen === pendingFirstSeen &&
+                durableProvider.first_seen !== pendingFirstSeen
+              ) {
+                restored.first_seen = durableProvider.first_seen;
+              }
+              if (
+                restored.web_exp_id_v2 !== refreshed.web_exp_id_v2 ||
+                restored.first_seen !== refreshed.first_seen
+              ) {
+                try {
+                  await crossSubdomainCookieStorage.set(
+                    identityCookieKey(this.apiKey),
+                    JSON.stringify(restored),
+                  );
+                } catch {
+                  /* write blocked: carry the restored values in memory only */
+                }
+              }
               user.web_exp_id = durableUser.web_exp_id ?? user.web_exp_id;
-              user.web_exp_id_v2 = refreshed.web_exp_id_v2;
-              user.first_seen = refreshed.first_seen;
+              user.web_exp_id_v2 = restored.web_exp_id_v2;
+              user.first_seen = restored.first_seen;
               const refreshedUser: WebExperimentUser = {
                 ...((this.experimentClient.getUser() ??
                   {}) as WebExperimentUser),

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -407,6 +407,14 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       internalInstanceNameSuffix: 'web',
+      // The SDK's own direct-to-device writers — DefaultUserProvider
+      // (landing_url/first_seen) and the unsent-exposure queue — sit below
+      // this tag's gated storage helpers, so they get the gate as a callback.
+      // Checked per call: a mid-session grant reopens persistence
+      // immediately, and when gating was never enabled this always allows.
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      internalPersistenceAllowed: () => !isConsentWithheld(),
       initialFlags: initialFlagsString,
       // timeout for fetching remote flags
       fetchTimeoutMillis: 1000,

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -324,9 +324,6 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
   // Preview mode is set by url params, postMessage or session storage, not chrome extension
   isPreviewMode = false;
   previewFlags: Record<string, string> = {};
-  // Cross-subdomain cookie domain (leading-dot form or ''); resolved once, early
-  // in start(), and reused by every EXP_ cookie path (identity + RTBT session).
-  private rootDomain = '';
   /** Redirect impressions parsed from AMP_REDIRECT before the first url_change. */
   private preloadedUrlRedirectImpressions: Record<
     string,
@@ -586,15 +583,14 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     this.subscriptionManager.markUrlAsPublished(this.globalScope.location.href);
     this.messageBus.publish('url_change', { updateActivePages: true });
 
-    // Resolve the cross-subdomain cookie domain as early as possible — but after
-    // the synchronous url_change above, whose subscribers apply anti-flicker
-    // variants/redirects before this first await. Every EXP_ cookie needs it:
-    // identity just below, and the RTBT session (behavioral-targeting plugin)
-    // whose sync writes resolve it via getTopLevelDomainSync(). The
-    // writability probe is async, so it must complete before any cookie write.
-    this.rootDomain = await getTopLevelDomain(
-      this.globalScope.location.hostname,
-    );
+    // Warm the cross-subdomain cookie-domain cache as early as possible — but
+    // after the synchronous url_change above, whose subscribers apply
+    // anti-flicker variants/redirects before this first await. Under withheld
+    // consent this returns an uncached guess (probing writes a cookie), so
+    // every consumer resolves the domain lazily at write time instead of
+    // capturing this result: the identity storage below via its options
+    // factory, the RTBT session via getTopLevelDomainSync().
+    await getTopLevelDomain(this.globalScope.location.hostname);
 
     const experimentStorageName = `EXP_${this.apiKey.slice(0, 10)}`;
     const user =
@@ -619,12 +615,21 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     // Resolve web_exp_id_v2 and first_seen as a single root-domain cookie for
     // cross-subdomain identity before getVariants() so anti-flicker and local
     // evaluation use the shared first_seen, not a subdomain-local mint. The
-    // domain was resolved early in start() (this.rootDomain).
-    const crossSubdomainCookieStorage = createCookieStorage<string>({
-      ...(this.rootDomain && { domain: this.rootDomain }),
-      sameSite: 'Lax',
-      expirationDays: 365,
-    });
+    // domain is resolved when the storage first reaches real cookies — for a
+    // pending start that is the grant flush, when a real writability probe is
+    // allowed, so the cookie is not pinned to an unprobed pending-time guess.
+    const crossSubdomainCookieStorage = createCookieStorage<string>(
+      async () => {
+        const domain = await getTopLevelDomain(
+          this.globalScope.location.hostname,
+        );
+        return {
+          ...(domain && { domain }),
+          sameSite: 'Lax',
+          expirationDays: 365,
+        };
+      },
+    );
 
     const defaultUserProviderStorageKey = `${experimentStorageName}_DEFAULT_USER_PROVIDER`;
     const defaultUserProviderData =
@@ -1948,15 +1953,17 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       this.config.redirectConfig?.encodeRedirectInCookie &&
       isCrossSubdomain
     ) {
-      const domain = await getTopLevelDomain(
-        this.globalScope.location.hostname,
-      );
       const storage = createCookieStorage<
         Record<string, StoredRedirectImpression>
-      >({
-        ...(domain && { domain }),
-        sameSite: 'Lax',
-        expirationDays: 1 / 1440, // 1 minute
+      >(async () => {
+        const domain = await getTopLevelDomain(
+          this.globalScope.location.hostname,
+        );
+        return {
+          ...(domain && { domain }),
+          sameSite: 'Lax',
+          expirationDays: 1 / 1440, // 1 minute
+        };
       });
 
       try {
@@ -2043,14 +2050,16 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       | AsyncCookieStore<Record<string, StoredRedirectImpression>>
       | undefined;
     if (this.config.redirectConfig?.encodeRedirectInCookie) {
-      const domain = await getTopLevelDomain(
-        this.globalScope.location.hostname,
-      );
       cookieStorage = createCookieStorage<
         Record<string, StoredRedirectImpression>
-      >({
-        ...(domain && { domain }),
-        sameSite: 'Lax',
+      >(async () => {
+        const domain = await getTopLevelDomain(
+          this.globalScope.location.hostname,
+        );
+        return {
+          ...(domain && { domain }),
+          sameSite: 'Lax',
+        };
       });
       try {
         cookieImpressions = (await cookieStorage.get(storageKey)) || {};

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -1015,13 +1015,18 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     // have already run, so the merge reads a complete local event store. A
     // refusal spends the one-shot subscription without injecting and the
     // relay stays out for the rest of the page — a later re-opt-in gets it on
-    // the next load.
+    // the next load. A refusal that already landed (a denial racing start())
+    // arms nothing for the same reason: the decision for this page is made,
+    // and an armed one-shot would let a same-page re-opt-in inject what the
+    // spent-subscription path holds until the next load.
     if (isConsentWithheld()) {
-      onConsentDecision((granted) => {
-        if (granted) {
-          this.scheduleRelaySync(user);
-        }
-      });
+      if (isConsentPending()) {
+        onConsentDecision((granted) => {
+          if (granted) {
+            this.scheduleRelaySync(user);
+          }
+        });
+      }
       return;
     }
 

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -339,7 +339,11 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     config: WebExperimentConfig = {},
   ) {
     const globalScope = getGlobalScope();
-    if (!globalScope || !isLocalStorageAvailable()) {
+    // While consent is withheld nothing may touch localStorage — including the
+    // availability probe, which writes a throwaway key. Storage is gated to
+    // memory until a grant, and every post-grant path degrades on failure, so
+    // deferring the probe to an unlucky consented construction loses nothing.
+    if (!globalScope || (!isConsentWithheld() && !isLocalStorageAvailable())) {
       throw new Error(
         'Amplitude Web Experiment Client could not be initialized.',
       );

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -12,6 +12,7 @@ import {
   Variant,
   AmplitudeIntegrationPlugin,
   ExperimentClient,
+  MemoryStorage,
   Variants,
 } from '@amplitude/experiment-js-client';
 import mutate from 'dom-mutator';
@@ -28,7 +29,12 @@ import {
   type AsyncCookieStore,
   createCookieStorage,
 } from './consent/consent-cookie-storage';
-import { consentGate } from './consent/consent-gate';
+import {
+  consentGate,
+  isConsentPending,
+  isConsentWithheld,
+  onConsentDecision,
+} from './consent/consent-gate';
 import { wrapIntegrationTrack } from './consent/consent-impression-buffer';
 import { showPreviewModeModal } from './preview/preview';
 import { MessageBus } from './subscriptions/message-bus';
@@ -408,6 +414,14 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       fetchOnStart: false,
       automaticExposureTracking: false,
       ...this.config,
+      // While consent is withheld, keep the amp-exp-* variant/flag caches in
+      // memory instead of sessionStorage. Chosen once, here: after a
+      // mid-session grant the cache stays in memory for this page and reverts
+      // to sessionStorage on the next load — fine for a cache that
+      // repopulates on every fetch.
+      ...(isConsentWithheld() && {
+        internalCacheStorage: new MemoryStorage(),
+      }),
     });
     // Get all the locally available flag keys from the SDK.
     // Exclude flags promoted to remoteFlagKeys via the dependency loop above —
@@ -994,9 +1008,27 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       return;
     }
 
+    // Third-party surface: the relay iframe stores events in the CDN origin's
+    // localStorage, so it must not exist before consent. Deferred rather than
+    // skipped — a grant re-runs this with the same user, and by then the
+    // storage-gate flush listeners (armed earlier, on the buffered writes)
+    // have already run, so the merge reads a complete local event store. A
+    // refusal spends the one-shot subscription without injecting and the
+    // relay stays out for the rest of the page — a later re-opt-in gets it on
+    // the next load.
+    if (isConsentWithheld()) {
+      onConsentDecision((granted) => {
+        if (granted) {
+          this.scheduleRelaySync(user);
+        }
+      });
+      return;
+    }
+
     // Single-shot: scheduleRelaySync runs exactly once per start() (the two
-    // call sites are mutually exclusive and start() is re-entry guarded). If a
-    // future identity-change re-sync needs to re-run this, add ownership
+    // call sites are mutually exclusive and start() is re-entry guarded; the
+    // consent deferral above re-enters at most once). If a future
+    // identity-change re-sync needs to re-run this, add ownership
     // tracking that also covers reapplyVariantsAfterRelaySync's awaits — a
     // guard checked only here would leave the re-apply fetch/apply tail
     // unguarded.
@@ -1006,6 +1038,20 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       getRelayUrl(this.apiKey, this.config.serverZone, this.config.relayUrl),
     );
     this.relayClient = relayClient;
+
+    if (consentGate.required) {
+      // Withdrawal must stop requests to the third-party CDN origin, not just
+      // ignore its responses: destroy the iframe and detach the dual-write so
+      // no further events are posted to the relay after a revocation. Armed
+      // here because this is the only place a relay comes into being, and it
+      // only does so while consent is granted — the next applied transition
+      // can only be a revocation.
+      onConsentDecision((granted) => {
+        if (!granted) {
+          this.teardownRelay(relayClient);
+        }
+      });
+    }
 
     void this.behavioralTargetingManager
       .beginRelaySync(relayClient)
@@ -1383,7 +1429,17 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       isCrossSubdomain,
     );
 
-    if (this.config.redirectConfig?.encodeRedirectInUrl && isCrossSubdomain) {
+    // While consent is pending the sessionStorage/cookie copies written above
+    // are buffered in memory and die with this page, so the URL param is the
+    // only transport that survives the navigation. Forced on for any redirect
+    // (same-subdomain too, and regardless of the encodeRedirectInUrl opt-in) —
+    // it stores nothing on the device. Deliberately pending-only: a redirect
+    // after a mid-session revocation drops its impression, like every other
+    // post-denial event.
+    if (
+      (this.config.redirectConfig?.encodeRedirectInUrl && isCrossSubdomain) ||
+      isConsentPending()
+    ) {
       // Embed impression data in redirect URL for cross-domain and
       // cookie-blocked environments. Merge with any existing param in case
       // multiple redirect experiments fire in sequence.
@@ -1896,9 +1952,17 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
   private async fireStoredRedirectImpressions() {
     const storageKey = `EXP_${this.apiKey.slice(0, 10)}_REDIRECT`;
 
-    // Read URL param impressions (highest priority)
+    // Read URL param impressions (highest priority). A consent-gated source
+    // page forces the URL transport while consent is pending (see
+    // handleRedirect), so a gated destination must consume the param — and
+    // clean the URL — even when the customer never opted into
+    // encodeRedirectInUrl, including when consent has been granted by the
+    // time this page loads.
     let urlImpressions: Record<string, StoredRedirectImpression> = {};
-    if (this.config.redirectConfig?.encodeRedirectInUrl) {
+    if (
+      this.config.redirectConfig?.encodeRedirectInUrl ||
+      consentGate.required
+    ) {
       const urlParams = getUrlParams();
       const encoded = urlParams[REDIRECT_IMPRESSION_PARAM];
       if (encoded) {

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -115,7 +115,7 @@ const REDIRECT_ACTION = 'redirect';
 export const PREVIEW_MODE_PARAM = 'PREVIEW';
 export { PREVIEW_MODE_SESSION_KEY };
 const VISUAL_EDITOR_PARAM = 'VISUAL_EDITOR';
-const REDIRECT_IMPRESSION_PARAM = 'AMP_REDIRECT';
+export const REDIRECT_IMPRESSION_PARAM = 'AMP_REDIRECT';
 // User actions that mark the interaction boundary for the redirect stick-detector.
 // A user cannot call replaceState; anything they do to leave a page passes through
 // one of these, so their presence between a redirect and the next attempt means a

--- a/packages/experiment-tag/src/experiment.ts
+++ b/packages/experiment-tag/src/experiment.ts
@@ -330,10 +330,9 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     StoredRedirectImpression
   > | null = null;
   /**
-   * Settles once the post-grant identity refresh has finished (or right away on
-   * refusal). Armed only by a pending start(), whose gated reads may have
-   * minted an ephemeral identity; the deferred relay sync awaits it so the
-   * relay binds to the durable identity the grant flush restored.
+   * Settles once the post-grant identity refresh finishes (immediately on
+   * refusal). Armed only by a pending start(); the deferred relay sync awaits
+   * it so the relay binds to the durable identity, not an ephemeral mint.
    */
   private identityRefreshOnGrant: Promise<void> | null = null;
 
@@ -343,10 +342,9 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     config: WebExperimentConfig = {},
   ) {
     const globalScope = getGlobalScope();
-    // While consent is withheld nothing may touch localStorage — including the
-    // availability probe, which writes a throwaway key. Storage is gated to
-    // memory until a grant, and every post-grant path degrades on failure, so
-    // deferring the probe to an unlucky consented construction loses nothing.
+    // While consent is withheld, skip the localStorage availability probe —
+    // it writes a throwaway key. Storage is gated to memory until a grant, and
+    // every post-grant path degrades gracefully if storage turns out unusable.
     if (!globalScope || (!isConsentWithheld() && !isLocalStorageAvailable())) {
       throw new Error(
         'Amplitude Web Experiment Client could not be initialized.',
@@ -590,13 +588,11 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     this.subscriptionManager.markUrlAsPublished(this.globalScope.location.href);
     this.messageBus.publish('url_change', { updateActivePages: true });
 
-    // Warm the cross-subdomain cookie-domain cache as early as possible — but
-    // after the synchronous url_change above, whose subscribers apply
-    // anti-flicker variants/redirects before this first await. Under withheld
-    // consent this returns an uncached guess (probing writes a cookie), so
-    // every consumer resolves the domain lazily at write time instead of
-    // capturing this result: the identity storage below via its options
-    // factory, the RTBT session via getTopLevelDomainSync().
+    // Warm the cross-subdomain cookie-domain cache. Must run after the
+    // synchronous url_change above, whose subscribers apply anti-flicker
+    // variants/redirects before this first await. While consent is withheld
+    // this returns an uncached guess (probing writes a cookie), so consumers
+    // resolve the domain lazily at write time instead of capturing this result.
     await getTopLevelDomain(this.globalScope.location.hostname);
 
     const experimentStorageName = `EXP_${this.apiKey.slice(0, 10)}`;
@@ -619,12 +615,11 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       setStorageItem('localStorage', experimentStorageName, user);
     }
 
-    // Resolve web_exp_id_v2 and first_seen as a single root-domain cookie for
-    // cross-subdomain identity before getVariants() so anti-flicker and local
-    // evaluation use the shared first_seen, not a subdomain-local mint. The
-    // domain is resolved when the storage first reaches real cookies — for a
-    // pending start that is the grant flush, when a real writability probe is
-    // allowed, so the cookie is not pinned to an unprobed pending-time guess.
+    // Resolve web_exp_id_v2 and first_seen from the shared root-domain cookie
+    // before getVariants(), so local evaluation uses the cross-subdomain
+    // first_seen rather than a subdomain-local mint. The cookie domain is
+    // resolved when the storage first reaches real cookies (post-grant for a
+    // pending start), so it is never pinned to an unprobed guess.
     const crossSubdomainCookieStorage = createCookieStorage<string>(
       async () => {
         const domain = await getTopLevelDomain(
@@ -672,23 +667,17 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     }
     user.first_seen = identity.first_seen;
 
-    // Under pending, the gated reads above hid any durable identity an earlier
-    // consented visit stored, so the ids resolved here may be an ephemeral
-    // mint. The grant flush restores the durable identity on disk
-    // (grant-flush-merge), but this running client would otherwise keep the
-    // ephemeral one for the rest of the page — fragmenting sticky bucketing
-    // and cross-subdomain behavioral data across the grant boundary. Re-read
-    // the reconciled identity after the flush and move the client onto it, so
-    // post-grant evaluation and the deferred relay sync bind to the identity
-    // every later page load will use. Variants already painted stay as
-    // applied; a mid-page repaint at the moment of grant would be worse than
-    // one page of drift on the exposures already queued.
+    // Under pending, the gated reads above hid any durable identity already on
+    // disk, so the ids resolved here may be an ephemeral mint. The grant flush
+    // reconciles the disk state; on grant, re-read it and move the running
+    // client onto the durable identity — otherwise this page would keep the
+    // ephemeral ids, fragmenting bucketing and behavioral data across the
+    // grant boundary. Variants already painted stay as applied; no mid-page
+    // repaint.
     if (isConsentPending()) {
-      // The pending-time resolution, snapshotted before the grant handler
-      // mutates `user`: any post-flush cookie field still equal to one of
-      // these can only be this page's own buffered write (gated reads saw no
-      // cookie, so these values were minted or subdomain-local), and a
-      // durable value that survived elsewhere on disk should win over it.
+      // Snapshot the pending-time values. After the flush, a cookie field
+      // still equal to one of these is this page's own buffered write, and a
+      // durable value from disk should win over it.
       const pendingWebExpIdV2 = user.web_exp_id_v2;
       const pendingFirstSeen = user.first_seen;
       this.identityRefreshOnGrant = new Promise<void>((resolve) => {
@@ -699,9 +688,8 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
           }
           void (async () => {
             try {
-              // The localStorage gate flushed synchronously when this listener's
-              // predecessors ran (they were armed earlier, on the buffered
-              // writes); the cookie read below joins the cookie gate's flush.
+              // The localStorage gate has already flushed (its listener was
+              // armed first); the cookie read below joins the cookie flush.
               const durableUser =
                 getStorageItem<WebExperimentUser>(
                   'localStorage',
@@ -725,13 +713,10 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
                   first_seen: () => (Date.now() / 1000).toString(),
                 },
               );
-              // When no durable cookie existed the flush merge wrote the
-              // pending-time values into it, so the re-read above returns this
-              // page's own mint. An ungated start() would have seeded the
-              // cookie from the durable localStorage values instead — converge
-              // to that: restore them over any field still at its pending-time
-              // value and rewrite the cookie, so the mint does not become the
-              // visitor's permanent identity.
+              // If no durable cookie existed, the flush wrote this page's mint
+              // into it. Restore durable localStorage values over any field
+              // still at its pending-time value and rewrite the cookie — the
+              // same outcome an ungated start() would have produced.
               const restored = { ...refreshed };
               if (
                 durableUser.web_exp_id_v2 &&
@@ -1150,20 +1135,14 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
       return;
     }
 
-    // Third-party surface: the relay iframe stores events in the CDN origin's
-    // localStorage, so it must not exist before consent. Deferred rather than
-    // skipped — a grant re-runs this, and by then the storage-gate flush
-    // listeners (armed earlier, on the buffered writes) have already run, so
-    // the merge reads a complete local event store. The re-entry awaits the
-    // identity refresh (also armed earlier in start(), so its listener fires
-    // first) and re-reads the client's user, so the relay binds to the
-    // durable identity the grant restored rather than a pending-time mint. A
-    // refusal spends the one-shot subscription without injecting and the
-    // relay stays out for the rest of the page — a later re-opt-in gets it on
-    // the next load. A refusal that already landed (a denial racing start())
-    // arms nothing for the same reason: the decision for this page is made,
-    // and an armed one-shot would let a same-page re-opt-in inject what the
-    // spent-subscription path holds until the next load.
+    // The relay iframe stores events in the CDN origin's localStorage, so it
+    // must not exist before consent. Deferred rather than skipped: a grant
+    // re-runs this after the storage flush and identity refresh (their
+    // listeners were armed earlier, so they fire first), and re-reads the
+    // client's user so the relay binds to the durable identity rather than a
+    // pending-time mint. On refusal — including one that already landed —
+    // nothing is armed and the relay stays out for the rest of the page; a
+    // later re-opt-in gets it on the next load.
     if (isConsentWithheld()) {
       if (isConsentPending()) {
         onConsentDecision((granted) => {
@@ -1182,12 +1161,9 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     }
 
     // Single-shot: scheduleRelaySync runs exactly once per start() (the two
-    // call sites are mutually exclusive and start() is re-entry guarded; the
-    // consent deferral above re-enters at most once). If a future
-    // identity-change re-sync needs to re-run this, add ownership
-    // tracking that also covers reapplyVariantsAfterRelaySync's awaits — a
-    // guard checked only here would leave the re-apply fetch/apply tail
-    // unguarded.
+    // call sites are mutually exclusive; the consent deferral above re-enters
+    // at most once). If a future change needs to re-run this, add ownership
+    // tracking that also covers reapplyVariantsAfterRelaySync's awaits.
     const relayClient = new RelayClient(
       this.apiKey,
       webExpIdV2,
@@ -1196,12 +1172,10 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
     this.relayClient = relayClient;
 
     if (consentGate.required) {
-      // Withdrawal must stop requests to the third-party CDN origin, not just
-      // ignore its responses: destroy the iframe and detach the dual-write so
-      // no further events are posted to the relay after a revocation. Armed
-      // here because this is the only place a relay comes into being, and it
-      // only does so while consent is granted — the next applied transition
-      // can only be a revocation.
+      // Revocation must stop requests to the third-party CDN origin, not just
+      // ignore responses: destroy the iframe and detach the dual-write. Armed
+      // here because a relay only comes into being while consent is granted,
+      // so the next transition can only be a revocation.
       onConsentDecision((granted) => {
         if (!granted) {
           this.teardownRelay(relayClient);
@@ -1587,11 +1561,9 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
 
     // While consent is pending the sessionStorage/cookie copies written above
     // are buffered in memory and die with this page, so the URL param is the
-    // only transport that survives the navigation. Forced on for any redirect
-    // (same-subdomain too, and regardless of the encodeRedirectInUrl opt-in) —
-    // it stores nothing on the device. Deliberately pending-only: a redirect
-    // after a mid-session revocation drops its impression, like every other
-    // post-denial event.
+    // only transport that survives the navigation (and it stores nothing on
+    // the device). Pending-only: after a mid-session revocation the redirect
+    // impression is dropped, like every other post-denial event.
     if (
       (this.config.redirectConfig?.encodeRedirectInUrl && isCrossSubdomain) ||
       isConsentPending()
@@ -2133,13 +2105,11 @@ export class DefaultWebExperimentClient implements WebExperimentClient {
   private async fireStoredRedirectImpressions() {
     const storageKey = `EXP_${this.apiKey.slice(0, 10)}_REDIRECT`;
 
-    // Read URL param impressions (highest priority). A consent-gated source
-    // page forces the URL transport while consent is pending (see
-    // handleRedirect), so a gated destination must consume the param — and
-    // clean the URL — even when the customer never opted into
-    // encodeRedirectInUrl, including when consent has been granted by the
-    // time this page loads. When start() already consumed the param for page
-    // targeting, use that snapshot here.
+    // Read URL param impressions (highest priority). A pending source page
+    // forces the URL transport (see handleRedirect), so a consent-gated
+    // destination must consume the param — and clean the URL — even when the
+    // customer never opted into encodeRedirectInUrl. When start() already
+    // consumed the param for page targeting, use that snapshot here.
     let urlImpressions: Record<string, StoredRedirectImpression> =
       this.preloadedUrlRedirectImpressions ?? {};
     this.preloadedUrlRedirectImpressions = null;

--- a/packages/experiment-tag/src/index.ts
+++ b/packages/experiment-tag/src/index.ts
@@ -35,11 +35,13 @@ const bufferAnalyticsEvent = (event: {
 /**
  * Updates cookie-consent status. Exposed on `window.webExperiment` (incl. the
  * pre-init stub) so a CMP callback can call it before the client exists.
- * `granted` starts a deferred client once — including after an earlier
- * `denied` (the preference-center re-opt-in flow). Transitions to `pending`
- * are ignored: pending is only meaningful as an initial state. Unknown values
- * warn and are ignored. A grant recorded before `initialize()` runs is
- * honored on init.
+ * `granted` starts a deferred client once — the client only defers when
+ * consent was denied at load (the preference-center re-opt-in flow). With a
+ * client already running under pending, `granted` instead resolves the gates
+ * armed below it: buffered storage flushes, buffered impressions replay, and
+ * the relay iframe is injected. Transitions to `pending` are ignored: pending
+ * is only meaningful as an initial state. Unknown values warn and are
+ * ignored. A grant recorded before `initialize()` runs is honored on init.
  */
 export const setConsentStatus = (status: ConsentStatus): void => {
   const parsed = parseConsentStatus(status);
@@ -94,12 +96,15 @@ export const initialize = (
     return;
   }
 
-  // Consent gate: while consent is required and not granted, stash the args and
-  // return without constructing the client (no storage/eval/tracking/relay).
-  // An already-pending deferral keeps the gate closed even if this call resolves
+  // Consent gate: only a denial defers the start. Under pending the client
+  // runs normally — everything it would persist or send is held back by the
+  // layers below (storage and cookies buffer in memory, impressions buffer,
+  // the relay iframe stays out), so experiments apply without flicker while
+  // nothing lands on the device or leaves for a third-party origin.
+  // An already-denied deferral keeps the gate closed even if this call resolves
   // consentRequired=false, so a later initialize can't bypass a start that a
-  // prior one parked on consent. Denied also stashes — a later grant
-  // (preference-center re-opt-in) starts the client in-session with fresh state.
+  // prior one parked on consent. A later grant (preference-center re-opt-in)
+  // starts the deferred client in-session with fresh state.
   const effectiveConfig = mergeWithWindowConfig(config, globalScope);
   const consent = effectiveConfig.consentOptions;
   const gated = consent.consentRequired || consentGate.deferredStart !== null;
@@ -125,11 +130,11 @@ export const initialize = (
       consentGate.manager.seedFromConfig(configStatus ?? 'pending');
     }
     armDenialCleanup(apiKey, effectiveConfig.instanceName);
-    if (consentGate.manager.getStatus() !== 'granted') {
+    if (consentGate.manager.getStatus() === 'denied') {
       consentGate.deferredStart = { apiKey, initConfigs, config };
-      // The one point where pre-grant events are dropped: this clears anything
+      // The one point where denied-era events are dropped: this clears anything
       // buffered before the deferral began, and the plugin's execute() refuses
-      // to buffer while it lasts — so nothing tracked pre-grant ever replays.
+      // to buffer while it lasts — so nothing tracked while denied ever replays.
       eventBuffer.length = 0;
       return;
     }
@@ -238,7 +243,9 @@ export const createPlugin = (): Plugin => ({
         context.event_properties as Record<string, unknown>,
       );
     } else if (isConsentDeferred()) {
-      // Consent withheld: do not buffer — pre-grant events are not replayed.
+      // Start deferred on denied consent: do not buffer — events tracked
+      // while denied are never replayed. (A pending client runs; its events
+      // flow through and are gated at the storage layer instead.)
     } else {
       bufferAnalyticsEvent({
         event_type: context.event_type,

--- a/packages/experiment-tag/src/index.ts
+++ b/packages/experiment-tag/src/index.ts
@@ -9,7 +9,7 @@ import { SdkPreviewApi } from './preview/preview-api';
 import { ConsentStatus, InitConfigs, WebExperimentConfig } from './types';
 import { applyAntiFlickerCss, removeAntiFlickerCss } from './util/anti-flicker';
 import { mergeWithWindowConfig } from './util/config';
-import { isPreviewMode } from './util/url';
+import { discardRedirectImpressionParam, isPreviewMode } from './util/url';
 
 const eventBuffer: Array<{
   event_type: string;
@@ -136,6 +136,11 @@ export const initialize = (
       // buffered before the deferral began, and the plugin's execute() refuses
       // to buffer while it lasts — so nothing tracked while denied ever replays.
       eventBuffer.length = 0;
+      // Same for a redirect impression a pending source page put on this URL:
+      // the client that would consume it never constructs, so strip the param
+      // here or the assignment payload outlives the page in the address bar
+      // and replays through the deferred start on a later re-grant.
+      discardRedirectImpressionParam();
       return;
     }
     consentGate.deferredStart = null;

--- a/packages/experiment-tag/src/index.ts
+++ b/packages/experiment-tag/src/index.ts
@@ -33,15 +33,12 @@ const bufferAnalyticsEvent = (event: {
 };
 
 /**
- * Updates cookie-consent status. Exposed on `window.webExperiment` (incl. the
- * pre-init stub) so a CMP callback can call it before the client exists.
- * `granted` starts a deferred client once — the client only defers when
- * consent was denied at load (the preference-center re-opt-in flow). With a
- * client already running under pending, `granted` instead resolves the gates
- * armed below it: buffered storage flushes, buffered impressions replay, and
- * the relay iframe is injected. Transitions to `pending` are ignored: pending
- * is only meaningful as an initial state. Unknown values warn and are
- * ignored. A grant recorded before `initialize()` runs is honored on init.
+ * Updates cookie-consent status. Exposed on `window.webExperiment` (including
+ * the pre-init stub) so a CMP callback can call it before the client exists.
+ * `granted` starts a client deferred by an at-load denial, or — for a client
+ * already running under pending — flushes buffered storage, replays buffered
+ * impressions, and injects the relay iframe. Transitions to `pending` and
+ * unknown values are ignored.
  */
 export const setConsentStatus = (status: ConsentStatus): void => {
   const parsed = parseConsentStatus(status);
@@ -97,14 +94,11 @@ export const initialize = (
   }
 
   // Consent gate: only a denial defers the start. Under pending the client
-  // runs normally — everything it would persist or send is held back by the
-  // layers below (storage and cookies buffer in memory, impressions buffer,
-  // the relay iframe stays out), so experiments apply without flicker while
-  // nothing lands on the device or leaves for a third-party origin.
-  // An already-denied deferral keeps the gate closed even if this call resolves
-  // consentRequired=false, so a later initialize can't bypass a start that a
-  // prior one parked on consent. A later grant (preference-center re-opt-in)
-  // starts the deferred client in-session with fresh state.
+  // runs normally — the storage/cookie/impression/relay layers below hold
+  // everything in memory, so experiments apply without flicker while nothing
+  // lands on the device or leaves for a third-party origin. An existing
+  // denied deferral keeps the gate closed even if this call resolves
+  // consentRequired=false; a later grant starts the deferred client.
   const effectiveConfig = mergeWithWindowConfig(config, globalScope);
   const consent = effectiveConfig.consentOptions;
   const gated = consent.consentRequired || consentGate.deferredStart !== null;
@@ -113,11 +107,9 @@ export const initialize = (
   // second initialize can't reopen storage that a first one closed.
   consentGate.required = consentGate.required || gated;
   if (gated) {
-    // A runtime status (setConsentStatus) wins over the declarative config;
-    // seedFromConfig enforces that, and the guard here keeps a config-validity
-    // warning from firing about a value that can no longer take effect.
-    // setConsentStatus warns and ignores unknown values; an unrecognized
-    // config value warns and falls back to 'pending' (fail closed).
+    // A runtime status (setConsentStatus) wins over the declarative config.
+    // An unrecognized config value warns and falls back to 'pending' (fail
+    // closed).
     if (!consentGate.manager.hasExplicitStatus()) {
       const configStatus = parseConsentStatus(consent.consentStatus);
       if (consent.consentStatus !== undefined && configStatus === null) {
@@ -132,14 +124,11 @@ export const initialize = (
     armDenialCleanup(apiKey, effectiveConfig.instanceName);
     if (consentGate.manager.getStatus() === 'denied') {
       consentGate.deferredStart = { apiKey, initConfigs, config };
-      // The one point where denied-era events are dropped: this clears anything
-      // buffered before the deferral began, and the plugin's execute() refuses
-      // to buffer while it lasts — so nothing tracked while denied ever replays.
+      // Drop denied-era events: clear anything already buffered (the plugin's
+      // execute() refuses to buffer while the deferral lasts).
       eventBuffer.length = 0;
-      // Same for a redirect impression a pending source page put on this URL:
-      // the client that would consume it never constructs, so strip the param
-      // here or the assignment payload outlives the page in the address bar
-      // and replays through the deferred start on a later re-grant.
+      // Also strip a redirect-impression URL param a pending source page put
+      // on this URL, so it can't replay through the deferred start later.
       discardRedirectImpressionParam();
       return;
     }

--- a/packages/experiment-tag/src/types.ts
+++ b/packages/experiment-tag/src/types.ts
@@ -133,8 +133,9 @@ export interface ConsentOptions {
   consentRequired?: boolean;
   /**
    * Initial consent status, set before the script loads. Defaults to
-   * 'pending' when consentRequired is true. Values follow Google Consent
-   * Mode: 'granted' | 'denied' | 'pending'.
+   * 'pending' when consentRequired is true. 'granted' and 'denied' match
+   * Google Consent Mode naming; 'pending' is this script's own undecided
+   * initial state (Consent Mode has no such value).
    *
    * A runtime status set via `setConsentStatus` always wins over this
    * config value. 'denied' at load defers the client start entirely; a later

--- a/packages/experiment-tag/src/types.ts
+++ b/packages/experiment-tag/src/types.ts
@@ -125,8 +125,10 @@ export type ConsentStatus = 'granted' | 'pending' | 'denied';
 
 export interface ConsentOptions {
   /**
-   * When true, the script does not start until consent status is 'granted'.
-   * Default false — the consent feature is fully off and behavior is unchanged.
+   * When true, device persistence and third-party side effects are gated on
+   * consent: under 'pending' the client runs entirely in memory, and only a
+   * 'granted' status lets data reach the device. Default false — the consent
+   * feature is fully off and behavior is unchanged.
    */
   consentRequired?: boolean;
   /**
@@ -134,8 +136,9 @@ export interface ConsentOptions {
    * 'pending' when consentRequired is true. Values follow Google Consent
    * Mode: 'granted' | 'denied' | 'pending'.
    *
-   * A later 'granted' at runtime (via `setConsentStatus`) starts the script —
-   * including after 'denied' (the preference-center re-opt-in flow).
+   * A runtime status set via `setConsentStatus` always wins over this
+   * config value. 'denied' at load defers the client start entirely; a later
+   * 'granted' (the preference-center re-opt-in flow) starts it fresh.
    */
   consentStatus?: ConsentStatus;
 }
@@ -165,17 +168,22 @@ export interface WebExperimentConfig extends ExperimentConfig {
   relayUrl?: string;
   /**
    * Cookie-consent gating for the web experiment script. When
-   * `consentRequired` is true, the script does not start (no storage access,
-   * evaluation, variant application, tracking, or relay) until the status is
-   * 'granted'. Update status at runtime with
+   * `consentRequired` is true, the client still runs under 'pending' consent —
+   * experiments evaluate and variants apply without flicker — but nothing
+   * lands on the device or leaves for a third-party origin: storage writes are
+   * held in memory, impressions buffer, and the relay iframe is not injected.
+   * Update status at runtime with
    * `window.webExperiment.setConsentStatus(status)`.
    *
-   * `pending` and `denied` defer the start. `granted` starts the client,
-   * including after `denied` (preference-center re-opt-in). Transitions to
-   * `pending` are ignored — it is only meaningful as an initial state.
-   * Analytics events that arrive while the start is deferred are not kept for
-   * replay after grant. After the client has started, a later `denied` does
-   * not tear down an in-flight start; reload the page to reset.
+   * `granted` resolves the gates: buffered storage flushes, buffered
+   * impressions replay once, and the relay is injected. `denied` at load
+   * defers the client start entirely and erases data persisted by earlier
+   * sessions; a later `granted` (preference-center re-opt-in) starts it
+   * fresh. `denied` at runtime erases all persisted experiment data, writes a
+   * refusal marker, and discards buffered impressions — a subsequent grant
+   * does not replay them. Transitions to `pending` are ignored — it is only
+   * meaningful as an initial state — and unrecognized values warn and leave
+   * the current status in place.
    */
   consentOptions?: ConsentOptions;
 }

--- a/packages/experiment-tag/src/types.ts
+++ b/packages/experiment-tag/src/types.ts
@@ -133,9 +133,7 @@ export interface ConsentOptions {
   consentRequired?: boolean;
   /**
    * Initial consent status, set before the script loads. Defaults to
-   * 'pending' when consentRequired is true. 'granted' and 'denied' match
-   * Google Consent Mode naming; 'pending' is this script's own undecided
-   * initial state (Consent Mode has no such value).
+   * 'pending' when consentRequired is true.
    *
    * A runtime status set via `setConsentStatus` always wins over this
    * config value. 'denied' at load defers the client start entirely; a later

--- a/packages/experiment-tag/src/util/cookie.ts
+++ b/packages/experiment-tag/src/util/cookie.ts
@@ -174,11 +174,27 @@ export function getCookieDomainLevels(hostname: string): string[] {
 }
 
 /**
+ * The registrable-domain guess used while consent is withheld: probing
+ * writability writes a throwaway cookie, which is itself a device write. The
+ * guess is what the probe would confirm on any host whose public suffix is in
+ * {@link KNOWN_2LDS} (or is a plain TLD); on the rare host where it is wrong,
+ * writes carrying it fail closed — read-back-verified writers degrade to
+ * memory. Not cached, so the first post-grant caller probes for real.
+ */
+function unprobedDomainGuess(hostname: string): string {
+  const levels = getCookieDomainLevels(hostname);
+  return levels.length > 0 ? '.' + levels[0] : '';
+}
+
+/**
  * Synchronous variant of {@link getTopLevelDomain} for cross-subdomain cookies:
  * the first {@link getCookieDomainLevels} entry that accepts one, as a
  * leading-dot domain (e.g. `.example.com`), or `''` when none does.
  */
 export function getTopLevelDomainSync(hostname: string): string {
+  if (isConsentWithheld()) {
+    return unprobedDomainGuess(hostname);
+  }
   for (const domain of getCookieDomainLevels(hostname)) {
     if (isDomainWritableSync(domain)) {
       return '.' + domain;
@@ -189,6 +205,9 @@ export function getTopLevelDomainSync(hostname: string): string {
 
 export async function getTopLevelDomain(hostname: string): Promise<string> {
   if (cachedDomain !== undefined) return cachedDomain;
+  if (isConsentWithheld()) {
+    return unprobedDomainGuess(hostname);
+  }
   for (const domain of getCookieDomainLevels(hostname)) {
     if (await CookieStorage.isDomainWritable(domain)) {
       return (cachedDomain = '.' + domain);

--- a/packages/experiment-tag/src/util/cookie.ts
+++ b/packages/experiment-tag/src/util/cookie.ts
@@ -179,7 +179,10 @@ export function getCookieDomainLevels(hostname: string): string[] {
  * guess is what the probe would confirm on any host whose public suffix is in
  * {@link KNOWN_2LDS} (or is a plain TLD); on the rare host where it is wrong,
  * writes carrying it fail closed — read-back-verified writers degrade to
- * memory. Not cached, so the first post-grant caller probes for real.
+ * memory. Not cached, so the first post-grant caller probes for real. The one
+ * long-lived capture is `rootDomain` in `experiment.ts`, resolved once in
+ * start(): a wrong guess there keeps identity-cookie writes in memory for the
+ * rest of the page, and the next page load probes for real and recovers.
  */
 function unprobedDomainGuess(hostname: string): string {
   const levels = getCookieDomainLevels(hostname);

--- a/packages/experiment-tag/src/util/cookie.ts
+++ b/packages/experiment-tag/src/util/cookie.ts
@@ -174,16 +174,12 @@ export function getCookieDomainLevels(hostname: string): string[] {
 }
 
 /**
- * The registrable-domain guess used while consent is withheld: probing
- * writability writes a throwaway cookie, which is itself a device write. The
- * guess is what the probe would confirm on any host whose public suffix is in
- * {@link KNOWN_2LDS} (or is a plain TLD); on the rare host where it is wrong,
- * writes carrying it fail closed — read-back-verified writers degrade to
- * memory. Not cached, so the first post-grant caller probes for real. No
- * caller may capture this guess past the withheld window: cookie storages
- * resolve their domain through a lazy options factory (see
- * createCookieStorage) and the RTBT session re-resolves per write, so the
- * first post-grant write always sees a real probe.
+ * The registrable-domain guess used while consent is withheld — probing
+ * writability writes a throwaway cookie, which is itself a device write. On
+ * the rare host where the guess is wrong, writes carrying it fail closed
+ * (read-back-verified writers degrade to memory). Never cached, and callers
+ * must not capture it past the withheld window: cookie storages resolve their
+ * domain lazily, so the first post-grant write probes for real.
  */
 function unprobedDomainGuess(hostname: string): string {
   const levels = getCookieDomainLevels(hostname);
@@ -359,10 +355,9 @@ export class SyncJsonCookie<T> {
   write(value: T): void {
     this.memory = value;
     if (isConsentWithheld()) {
-      // The memory tier already holds the value, and this class degrades to it
-      // whenever the cookie is unavailable — so a withheld write needs no buffer
-      // of its own. Only a pending one is worth arming a flush for; after refusal
-      // the value simply stays in memory for the life of the page.
+      // The memory tier already holds the value, so no separate buffer is
+      // needed. Only pending arms a flush; after refusal the value just stays
+      // in memory for the life of the page.
       if (isConsentPending()) {
         this.armConsentFlush();
       }
@@ -380,18 +375,17 @@ export class SyncJsonCookie<T> {
   clear(): void {
     this.memory = undefined;
     if (isConsentPending()) {
-      // Nothing of ours is out there to delete, and issuing the expiry would be
-      // a cookie write in its own right. Refusal deliberately falls through, so
-      // denial cleanup can still erase a cookie from a consented visit.
+      // Issuing the expiry would itself be a cookie write. Refusal falls
+      // through so denial cleanup can erase a cookie from a consented visit.
       return;
     }
     deleteRawCookie(this.key, this.getDomain() || undefined);
   }
 
   /**
-   * Promotes the deferred value to a cookie on grant. Writing the same value
-   * rather than a fresh one is what keeps the session id the visitor already had
-   * while consent was pending, instead of rotating it at the moment of grant.
+   * Promotes the in-memory value to a cookie on grant. Writing the same value
+   * (not a fresh one) keeps the session id the visitor already had while
+   * pending, instead of rotating it at the moment of grant.
    */
   private armConsentFlush(): void {
     if (this.consentFlushArmed) {

--- a/packages/experiment-tag/src/util/cookie.ts
+++ b/packages/experiment-tag/src/util/cookie.ts
@@ -179,10 +179,11 @@ export function getCookieDomainLevels(hostname: string): string[] {
  * guess is what the probe would confirm on any host whose public suffix is in
  * {@link KNOWN_2LDS} (or is a plain TLD); on the rare host where it is wrong,
  * writes carrying it fail closed — read-back-verified writers degrade to
- * memory. Not cached, so the first post-grant caller probes for real. The one
- * long-lived capture is `rootDomain` in `experiment.ts`, resolved once in
- * start(): a wrong guess there keeps identity-cookie writes in memory for the
- * rest of the page, and the next page load probes for real and recovers.
+ * memory. Not cached, so the first post-grant caller probes for real. No
+ * caller may capture this guess past the withheld window: cookie storages
+ * resolve their domain through a lazy options factory (see
+ * createCookieStorage) and the RTBT session re-resolves per write, so the
+ * first post-grant write always sees a real probe.
  */
 function unprobedDomainGuess(hostname: string): string {
   const levels = getCookieDomainLevels(hostname);
@@ -415,10 +416,14 @@ export class SyncJsonCookie<T> {
 }
 
 export async function setMarketingCookie(apiKey: string, hostname: string) {
-  const domain = await getTopLevelDomain(hostname);
-  const storage = createCookieStorage<Campaign>({
-    sameSite: 'Lax',
-    ...(domain && { domain }),
+  // Domain resolved lazily so a pending-time guess is not baked in; see
+  // createCookieStorage.
+  const storage = createCookieStorage<Campaign>(async () => {
+    const domain = await getTopLevelDomain(hostname);
+    return {
+      sameSite: 'Lax',
+      ...(domain && { domain }),
+    };
   });
 
   const parser = new CampaignParser();

--- a/packages/experiment-tag/src/util/storage-keys.ts
+++ b/packages/experiment-tag/src/util/storage-keys.ts
@@ -18,14 +18,11 @@ export const PREVIEW_MODE_SESSION_KEY = 'amp-preview-mode';
 export const VISUAL_EDITOR_SESSION_KEY = 'visual-editor-state';
 
 /**
- * Keys that stay readable and writable while consent is pending.
- *
- * Both hold Amplitude's own tooling state, entered deliberately by the person
- * building the experiment through a `PREVIEW`/`VISUAL_EDITOR` URL parameter —
- * they say nothing about the visitor and are not what a consent banner is
- * asking about. Gating them would leave an editor that silently fails to open
- * on any site that has consent gating switched on, since the state has to
- * survive the redirect that strips those parameters from the URL.
+ * Keys that stay readable and writable while consent is pending. Both hold
+ * Amplitude's own tooling state (entered via a `PREVIEW`/`VISUAL_EDITOR` URL
+ * parameter), say nothing about the visitor, and must survive the redirect
+ * that strips those parameters — gating them would break preview mode and the
+ * visual editor on consent-gated sites.
  */
 export const CONSENT_EXEMPT_STORAGE_KEYS: ReadonlySet<string> = new Set([
   PREVIEW_MODE_SESSION_KEY,

--- a/packages/experiment-tag/src/util/storage-keys.ts
+++ b/packages/experiment-tag/src/util/storage-keys.ts
@@ -18,13 +18,25 @@ export const PREVIEW_MODE_SESSION_KEY = 'amp-preview-mode';
 export const VISUAL_EDITOR_SESSION_KEY = 'visual-editor-state';
 
 /**
- * Keys that stay readable and writable while consent is pending. Both hold
- * Amplitude's own tooling state (entered via a `PREVIEW`/`VISUAL_EDITOR` URL
- * parameter), say nothing about the visitor, and must survive the redirect
- * that strips those parameters — gating them would break preview mode and the
- * visual editor on consent-gated sites.
+ * Keys that stay readable and writable while consent is pending. Preview and
+ * visual-editor keys hold Amplitude tooling state (entered via a URL
+ * parameter) and must survive the redirect that strips those parameters.
+ * Stick-detector suffixes must hit real sessionStorage: a hard
+ * `location.replace` unloads the page, and a gated in-memory write dies
+ * before the destination can suppress a param-stripping loop. Pending is
+ * when anti-flicker redirects fire.
  */
 export const CONSENT_EXEMPT_STORAGE_KEYS: ReadonlySet<string> = new Set([
   PREVIEW_MODE_SESSION_KEY,
   VISUAL_EDITOR_SESSION_KEY,
 ]);
+
+const STICK_DETECTOR_SUFFIXES = [
+  '_REDIRECT_MARKER',
+  '_REDIRECT_SUPPRESSED',
+] as const;
+
+export const isConsentExemptStorageKey = (key: string): boolean =>
+  Boolean(key) &&
+  (CONSENT_EXEMPT_STORAGE_KEYS.has(key) ||
+    STICK_DETECTOR_SUFFIXES.some((suffix) => key.endsWith(suffix)));

--- a/packages/experiment-tag/src/util/storage.ts
+++ b/packages/experiment-tag/src/util/storage.ts
@@ -9,7 +9,7 @@ import {
 import type { ConsentManager } from '../consent/consent-manager';
 
 import { mergePendingJsonWithDevice } from './grant-flush-merge';
-import { CONSENT_EXEMPT_STORAGE_KEYS } from './storage-keys';
+import { isConsentExemptStorageKey } from './storage-keys';
 
 export type StorageType = 'localStorage' | 'sessionStorage';
 
@@ -62,10 +62,10 @@ const bufferKey = (storageType: StorageType, key: string): string =>
   `${storageType}:${key}`;
 
 /**
- * Amplitude's own tooling state is exempt from the gate — see
- * {@link CONSENT_EXEMPT_STORAGE_KEYS}.
+ * Amplitude tooling state and the redirect stick-detector — see
+ * {@link isConsentExemptStorageKey}.
  */
-const isExempt = (key: string): boolean => CONSENT_EXEMPT_STORAGE_KEYS.has(key);
+const isExempt = (key: string): boolean => isConsentExemptStorageKey(key);
 
 /** Whether a key is subject to the gate at all. */
 const isGated = (key: string): boolean => isConsentWithheld() && !isExempt(key);

--- a/packages/experiment-tag/src/util/storage.ts
+++ b/packages/experiment-tag/src/util/storage.ts
@@ -14,11 +14,9 @@ import { CONSENT_EXEMPT_STORAGE_KEYS } from './storage-keys';
 export type StorageType = 'localStorage' | 'sessionStorage';
 
 /**
- * Writes made while the visitor has yet to decide, held here instead of in
- * localStorage/sessionStorage. Entries carry the serialized form rather than the
- * live object so a buffered read parses a fresh copy exactly as a real read
- * would, and so a flush is a verbatim handover of what the caller asked to
- * store.
+ * Writes buffered while consent is pending, held here instead of in
+ * localStorage/sessionStorage. Entries hold the serialized form so buffered
+ * reads parse a fresh copy exactly as a real read would.
  */
 const pendingWrites = new Map<
   string,
@@ -27,11 +25,9 @@ const pendingWrites = new Map<
 
 /**
  * The manager this module's flush/drop listener is attached to. The test-only
- * `consentGate.reset()` replaces the manager with a fresh instance, which
- * silently strands any listener subscribed to the old one — its status never
- * changes again, so a stranded listener would never flush or drop the buffer.
- * Comparing instances (rather than tracking an "armed" boolean) makes the next
- * gated call notice the swap and re-subscribe to the live manager.
+ * `consentGate.reset()` replaces the manager, stranding listeners on the old
+ * instance; comparing instances makes the next gated call re-subscribe to the
+ * live one.
  */
 let armedManager: ConsentManager | null = null;
 
@@ -85,10 +81,9 @@ export const getStorageItem = <T>(
   key: string,
 ): T | null => {
   if (isGated(key)) {
-    // Reads are gated as well as writes — ePrivacy covers access to data already
-    // on the device, so a visitor without consent sees only what this page put in
-    // the buffer, never what an earlier consented session left behind. Once
-    // consent is refused the buffer is empty, so this reads as absent.
+    // Reads are gated too — ePrivacy covers access to data already on the
+    // device — so a visitor without consent sees only this page's buffer,
+    // never what an earlier consented session left behind.
     if (isConsentPending()) {
       armConsentListener();
     }
@@ -183,10 +178,8 @@ export const removeStorageItem = (
   storageType: StorageType,
   key: string,
 ): void => {
-  // Only pending holds removal back, and only to the buffer: issuing the delete
-  // would be a write to the device while the visitor is still deciding. Refusal
-  // deliberately falls through to real storage, because that is the path denial
-  // cleanup uses to erase what a previously consented visit left behind.
+  // Pending stops at the buffer (a delete is itself a device write); refusal
+  // falls through to real storage, which is how denial cleanup erases data.
   if (isConsentPending() && !isExempt(key)) {
     armConsentListener();
     pendingWrites.delete(bufferKey(storageType, key));

--- a/packages/experiment-tag/src/util/url.ts
+++ b/packages/experiment-tag/src/util/url.ts
@@ -1,6 +1,10 @@
 import { getGlobalScope } from '@amplitude/experiment-core';
 
-import { PREVIEW_MODE_PARAM, PREVIEW_MODE_SESSION_KEY } from '../experiment';
+import {
+  PREVIEW_MODE_PARAM,
+  PREVIEW_MODE_SESSION_KEY,
+  REDIRECT_IMPRESSION_PARAM,
+} from '../experiment';
 import { PreviewState } from '../types';
 
 import { getStorageItem } from './storage';
@@ -66,6 +70,27 @@ export const removeQueryParams = (
     urlObj.searchParams.delete(param);
   }
   return urlObj.toString();
+};
+
+/**
+ * Strips the redirect-impression transport param without consuming it. A
+ * pending-window redirect forces its impression payload onto the destination
+ * URL (see handleRedirect) because nothing else survives the navigation; when
+ * that destination loads denied, the impression is dropped like every other
+ * denied-era event, and the payload must not linger in the address bar,
+ * history, or referrers — or replay through the deferred start on a later
+ * re-grant.
+ */
+export const discardRedirectImpressionParam = (): void => {
+  const globalScope = getGlobalScope();
+  if (!globalScope || !getUrlParams()[REDIRECT_IMPRESSION_PARAM]) {
+    return;
+  }
+  globalScope.history.replaceState(
+    {},
+    '',
+    removeQueryParams(globalScope.location.href, [REDIRECT_IMPRESSION_PARAM]),
+  );
 };
 
 export const matchesUrl = (urlArray: string[], urlString: string): boolean => {

--- a/packages/experiment-tag/src/util/url.ts
+++ b/packages/experiment-tag/src/util/url.ts
@@ -73,13 +73,10 @@ export const removeQueryParams = (
 };
 
 /**
- * Strips the redirect-impression transport param without consuming it. A
- * pending-window redirect forces its impression payload onto the destination
- * URL (see handleRedirect) because nothing else survives the navigation; when
- * that destination loads denied, the impression is dropped like every other
- * denied-era event, and the payload must not linger in the address bar,
- * history, or referrers — or replay through the deferred start on a later
- * re-grant.
+ * Strips the redirect-impression transport param without consuming it. When a
+ * destination page loads denied, the impression is dropped like every other
+ * denied-era event, and the payload must not linger in the URL where it could
+ * replay through the deferred start on a later re-grant.
  */
 export const discardRedirectImpressionParam = (): void => {
   const globalScope = getGlobalScope();

--- a/packages/experiment-tag/test/behavioral-targeting/session-manager.test.ts
+++ b/packages/experiment-tag/test/behavioral-targeting/session-manager.test.ts
@@ -1,7 +1,11 @@
+import { activateConsent } from '../consent/consent-test-util';
+
 import {
   DEFAULT_SESSION_TIMEOUT_MS,
   SessionManager,
 } from 'src/behavioral-targeting/session-manager';
+import { consentGate } from 'src/consent/consent-gate';
+import * as cookieUtil from 'src/util/cookie';
 
 const testApiKey = 'test-api-key';
 const cookieKey = `EXP_${testApiKey.slice(0, 10)}_rtbt_session`;
@@ -248,6 +252,33 @@ describe('SessionManager', () => {
       const sessionId2 = sessionManager.getCurrentSessionId();
 
       expect(sessionId1).not.toBe(sessionId2);
+    });
+  });
+
+  describe('cookie domain resolution under consent gating', () => {
+    afterEach(() => {
+      consentGate.reset();
+      jest.restoreAllMocks();
+    });
+
+    test('does not pin the unprobed guess: first post-grant write probes for real', () => {
+      const spy = jest.spyOn(cookieUtil, 'getTopLevelDomainSync');
+      activateConsent('denied');
+      const manager = new SessionManager(testApiKey);
+      // Denial cleanup falls through to a cookie delete, which resolves the
+      // domain while consent is withheld — an unprobed guess.
+      manager.clearSession();
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      // The guess must not be pinned: the first post-grant write re-resolves
+      // with a real writability probe.
+      consentGate.manager.setStatus('granted');
+      manager.recordActivity();
+      expect(spy).toHaveBeenCalledTimes(2);
+
+      // The probed result is pinned; later writes reuse it.
+      manager.recordActivity();
+      expect(spy).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/experiment-tag/test/consent/clear-data.test.ts
+++ b/packages/experiment-tag/test/consent/clear-data.test.ts
@@ -38,8 +38,6 @@ describe('getPersistedDataKeys', () => {
         `${CACHE}-flags`,
         `${CACHE}-variants-options`,
         'EXP_sent_v3_$default_instance',
-        'EXP_sent_v2_$default_instance',
-        'EXP_sent_$default_instance',
       ],
       cookies: [
         `EXP_${SLICE}_identity`,
@@ -71,16 +69,6 @@ describe('getPersistedDataKeys', () => {
     );
     expect(cacheKey).toBe(CACHE);
     expect(cacheKey).not.toContain(SLICE);
-  });
-
-  it('clears every version of the dedupe cache key', () => {
-    // SessionDedupeCache retires the older keys when it is constructed, which a
-    // denial at load never does — so the sweep has to cover them itself.
-    const keys = getPersistedDataKeys(API_KEY, 'my-instance');
-
-    expect(keys.sessionStorage).toContain('EXP_sent_v3_my-instance');
-    expect(keys.sessionStorage).toContain('EXP_sent_v2_my-instance');
-    expect(keys.sessionStorage).toContain('EXP_sent_my-instance');
   });
 
   it('clears DEFAULT_USER_PROVIDER from both stores', () => {

--- a/packages/experiment-tag/test/consent/clear-data.test.ts
+++ b/packages/experiment-tag/test/consent/clear-data.test.ts
@@ -35,6 +35,7 @@ describe('getPersistedDataKeys', () => {
         `EXP_${SLICE}_DEFAULT_USER_PROVIDER`,
         `EXP_${SLICE}_REDIRECT`,
         `EXP_${SLICE}_REDIRECT_MARKER`,
+        `EXP_${SLICE}_REDIRECT_SUPPRESSED`,
         CACHE,
         `${CACHE}-flags`,
         `${CACHE}-variants-options`,

--- a/packages/experiment-tag/test/consent/clear-data.test.ts
+++ b/packages/experiment-tag/test/consent/clear-data.test.ts
@@ -34,10 +34,13 @@ describe('getPersistedDataKeys', () => {
       sessionStorage: [
         `EXP_${SLICE}_DEFAULT_USER_PROVIDER`,
         `EXP_${SLICE}_REDIRECT`,
+        `EXP_${SLICE}_REDIRECT_MARKER`,
         CACHE,
         `${CACHE}-flags`,
         `${CACHE}-variants-options`,
         'EXP_sent_v3_$default_instance',
+        'EXP_sent_v2_$default_instance',
+        'EXP_sent_$default_instance',
       ],
       cookies: [
         `EXP_${SLICE}_identity`,
@@ -69,6 +72,16 @@ describe('getPersistedDataKeys', () => {
     );
     expect(cacheKey).toBe(CACHE);
     expect(cacheKey).not.toContain(SLICE);
+  });
+
+  it('clears every version of the dedupe cache key', () => {
+    // Denial-at-load never constructs SessionDedupeCache, so the sweep has
+    // to cover the retired keys itself.
+    const keys = getPersistedDataKeys(API_KEY, 'my-instance');
+
+    expect(keys.sessionStorage).toContain('EXP_sent_v3_my-instance');
+    expect(keys.sessionStorage).toContain('EXP_sent_v2_my-instance');
+    expect(keys.sessionStorage).toContain('EXP_sent_my-instance');
   });
 
   it('clears DEFAULT_USER_PROVIDER from both stores', () => {

--- a/packages/experiment-tag/test/consent/consent-cookie-storage.test.ts
+++ b/packages/experiment-tag/test/consent/consent-cookie-storage.test.ts
@@ -152,6 +152,63 @@ describe('ConsentAwareCookieStorage', () => {
     });
   });
 
+  describe('lazy delegate', () => {
+    it('does not resolve the delegate while consent is withheld', async () => {
+      activateConsent('pending');
+      const factory = jest.fn(() => Promise.resolve(fakeStore()));
+      const storage = new ConsentAwareCookieStorage(factory);
+
+      await storage.set('ck', 'fresh');
+      expect(await storage.get('ck')).toEqual('fresh');
+
+      expect(factory).not.toHaveBeenCalled();
+    });
+
+    it('resolves the delegate at grant flush, so it captures post-grant state', async () => {
+      activateConsent('pending');
+      const delegate = fakeStore();
+      // Stands in for the cookie-domain probe: real only once granted.
+      const factory = jest.fn(() => {
+        expect(consentGate.manager.getStatus()).toEqual('granted');
+        return Promise.resolve(delegate);
+      });
+      const storage = new ConsentAwareCookieStorage(factory);
+      await storage.set('ck', 'fresh');
+
+      consentGate.manager.setStatus('granted');
+      expect(await storage.get('ck')).toEqual('fresh');
+
+      expect(factory).toHaveBeenCalledTimes(1);
+      expect(delegate.store).toEqual({ ck: 'fresh' });
+    });
+
+    it('never resolves the delegate when consent is denied', async () => {
+      activateConsent('pending');
+      const factory = jest.fn(() => Promise.resolve(fakeStore()));
+      const storage = new ConsentAwareCookieStorage(factory);
+      await storage.set('ck', 'fresh');
+
+      consentGate.manager.setStatus('denied');
+      expect(await storage.get('ck')).toBeUndefined();
+
+      expect(factory).not.toHaveBeenCalled();
+    });
+
+    it('drops the buffer without poisoning later access when the factory rejects', async () => {
+      activateConsent('pending');
+      const factory = (): Promise<AsyncCookieStore<string>> =>
+        Promise.reject(new Error('probe failed'));
+      const storage = new ConsentAwareCookieStorage(factory);
+      await storage.set('ck', 'fresh');
+
+      consentGate.manager.setStatus('granted');
+
+      // The flush swallows the failure; a later read surfaces it per-call
+      // like any other blocked delegate, without rejecting the flush chain.
+      await expect(storage.get('ck')).rejects.toThrow('probe failed');
+    });
+  });
+
   describe('denial', () => {
     it('discards buffered writes instead of flushing them', async () => {
       activateConsent('pending');

--- a/packages/experiment-tag/test/consent/consent-gate.test.ts
+++ b/packages/experiment-tag/test/consent/consent-gate.test.ts
@@ -430,8 +430,31 @@ describe('index.ts consent gate', () => {
       init({
         consentOptions: { consentRequired: true, consentStatus: 'pending' },
       });
+      // Pending runs the client gated (see 'starts under pending' above).
       expect(DebugRecorder.getDebugState().consent).toEqual({
         status: 'pending',
+        required: true,
+        started: true,
+        startDeferred: false,
+        impressionBuffers: [],
+      });
+
+      setConsentStatus('granted');
+      expect(DebugRecorder.getDebugState().consent).toEqual({
+        status: 'granted',
+        required: true,
+        started: true,
+        startDeferred: false,
+        impressionBuffers: [],
+      });
+    });
+
+    test('getDebugState().consent reports the parked start under denied-at-load', () => {
+      init({
+        consentOptions: { consentRequired: true, consentStatus: 'denied' },
+      });
+      expect(DebugRecorder.getDebugState().consent).toEqual({
+        status: 'denied',
         required: true,
         started: false,
         startDeferred: true,

--- a/packages/experiment-tag/test/consent/consent-gate.test.ts
+++ b/packages/experiment-tag/test/consent/consent-gate.test.ts
@@ -76,12 +76,24 @@ describe('index.ts consent gate', () => {
       'no status (defaults to pending)',
       { consentOptions: { consentRequired: true } },
     ],
-    [
-      'denied',
-      { consentOptions: { consentRequired: true, consentStatus: 'denied' } },
-    ],
-  ])('does not construct or start: required + %s', (_label, config) => {
-    init(config);
+  ])(
+    'starts under pending with the persistence gate armed: %s',
+    (_label, config) => {
+      init(config);
+      // The client runs (experiments apply, no flicker); everything it would
+      // persist or send is held back by the gated layers below.
+      expect(getInstance).toHaveBeenCalledTimes(1);
+      expect(start).toHaveBeenCalledTimes(1);
+      expect(consentGate.required).toBe(true);
+      expect(consentGate.manager.getStatus()).toBe('pending');
+      expect(consentGate.deferredStart).toBeNull();
+    },
+  );
+
+  test('does not construct or start: required + denied', () => {
+    init({
+      consentOptions: { consentRequired: true, consentStatus: 'denied' },
+    });
     expect(getInstance).not.toHaveBeenCalled();
   });
 
@@ -111,12 +123,20 @@ describe('index.ts consent gate', () => {
     },
   );
 
-  test('denied without a grant never starts', () => {
+  test('denial after a pending start does not stash a deferral or relaunch', () => {
     init({
       consentOptions: { consentRequired: true, consentStatus: 'pending' },
     });
+    expect(getInstance).toHaveBeenCalledTimes(1);
+
+    // Mid-session refusal: the running client stays up (gated layers drop its
+    // writes); nothing is parked for a later grant to release.
     setConsentStatus('denied');
-    expect(getInstance).not.toHaveBeenCalled();
+    expect(consentGate.deferredStart).toBeNull();
+
+    setConsentStatus('granted');
+    expect(getInstance).toHaveBeenCalledTimes(1);
+    expect(start).toHaveBeenCalledTimes(1);
   });
 
   test('transition to pending is ignored after grant (no-op)', () => {
@@ -139,9 +159,9 @@ describe('index.ts consent gate', () => {
 
   test('window.experimentConfig.consentOptions wins over the initialize arg', () => {
     globalScope.experimentConfig = {
-      consentOptions: { consentRequired: true, consentStatus: 'pending' },
+      consentOptions: { consentRequired: true, consentStatus: 'denied' },
     };
-    // initialize arg says granted, but window says pending -> should not start
+    // initialize arg says granted, but window says denied -> should not start
     init({
       consentOptions: { consentRequired: true, consentStatus: 'granted' },
     });
@@ -173,10 +193,10 @@ describe('index.ts consent gate', () => {
     },
   );
 
-  test('a second initialize with consentRequired=false cannot bypass a pending deferral', () => {
+  test('a second initialize with consentRequired=false cannot bypass a denied deferral', () => {
     // First init defers on consent.
     init({
-      consentOptions: { consentRequired: true, consentStatus: 'pending' },
+      consentOptions: { consentRequired: true, consentStatus: 'denied' },
     });
     expect(getInstance).not.toHaveBeenCalled();
 
@@ -211,7 +231,7 @@ describe('index.ts consent gate', () => {
 
   test('grant via a later initialize starts once and does not relaunch', () => {
     init({
-      consentOptions: { consentRequired: true, consentStatus: 'pending' },
+      consentOptions: { consentRequired: true, consentStatus: 'denied' },
     });
     expect(getInstance).not.toHaveBeenCalled();
 
@@ -230,13 +250,14 @@ describe('index.ts consent gate', () => {
     expect(start).toHaveBeenCalledTimes(1);
   });
 
-  test('grant via a later initialize drops events buffered while deferred', async () => {
+  test('grant via a later initialize drops events tracked while deferred on denial', async () => {
     const plugin = createPlugin();
     init({
-      consentOptions: { consentRequired: true, consentStatus: 'pending' },
+      consentOptions: { consentRequired: true, consentStatus: 'denied' },
     });
 
-    // Analytics during a consent deferral is not buffered (would be discarded on grant).
+    // Analytics during a denied deferral is not buffered (must not replay on
+    // a later re-opt-in).
     await plugin.execute?.({
       event_type: 'pre_grant',
       event_properties: {},
@@ -251,7 +272,7 @@ describe('index.ts consent gate', () => {
     expect(trackEvent).not.toHaveBeenCalled();
   });
 
-  test('invalid consentStatus in config defers like pending', () => {
+  test('invalid consentStatus in config warns and runs gated like pending', () => {
     const warn = jest
       .spyOn(console, 'warn')
       .mockImplementation(() => undefined);
@@ -264,7 +285,10 @@ describe('index.ts consent gate', () => {
     init({
       consentOptions: { consentRequired: true, consentStatus: 'granted' },
     });
-    expect(getInstance).not.toHaveBeenCalled();
+    // Fail closed: the unrecognized value falls back to pending, so the client
+    // runs with persistence gated rather than treating the typo as a grant.
+    expect(getInstance).toHaveBeenCalledTimes(1);
+    expect(consentGate.manager.getStatus()).toBe('pending');
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
   });
@@ -277,7 +301,9 @@ describe('index.ts consent gate', () => {
       consentOptions: { consentRequired: true, consentStatus: 'pending' },
     });
     setConsentStatus('grantd' as ConsentStatus);
-    expect(getInstance).not.toHaveBeenCalled();
+    // The pending start already ran once; the bad value must not change the
+    // status (which would flush the gated buffers) or relaunch anything.
+    expect(getInstance).toHaveBeenCalledTimes(1);
     expect(consentGate.manager.getStatus()).toBe('pending');
     expect(consentGate.manager.hasExplicitStatus()).toBe(false);
     expect(warn).toHaveBeenCalled();
@@ -300,19 +326,39 @@ describe('index.ts consent gate', () => {
     warn.mockRestore();
   });
 
-  test('setConsentStatus denied while deferred does not retain analytics buffer', async () => {
+  test('events during a denied deferral are not buffered or replayed on re-opt-in', async () => {
+    const plugin = createPlugin();
+    init({
+      consentOptions: { consentRequired: true, consentStatus: 'denied' },
+    });
+    await plugin.execute?.({
+      event_type: 'while_denied',
+      event_properties: {},
+    } as never);
+
+    // Re-opt-in launches the client; the denied-era event must not replay.
+    setConsentStatus('granted');
+    const trackEvent = jest.fn();
+    flushEventBuffer({ trackEvent } as never);
+    expect(trackEvent).not.toHaveBeenCalled();
+  });
+
+  test('a pending start keeps startup-buffered events (gated below, not dropped)', async () => {
     const plugin = createPlugin();
     init({
       consentOptions: { consentRequired: true, consentStatus: 'pending' },
     });
+    // The client is starting (not deferred), so a racing event buffers like
+    // the non-consent path; consent gating happens in the storage/impression
+    // layers it flows into, not here.
     await plugin.execute?.({
       event_type: 'while_pending',
       event_properties: {},
     } as never);
-    setConsentStatus('denied');
+
     const trackEvent = jest.fn();
     flushEventBuffer({ trackEvent } as never);
-    expect(trackEvent).not.toHaveBeenCalled();
+    expect(trackEvent).toHaveBeenCalledTimes(1);
   });
 
   test('grant from the start keeps startup-buffered events (no deferral window)', async () => {
@@ -352,7 +398,7 @@ describe('index.ts consent gate', () => {
 
     test('deferred grant goes through the preview path (anti-flicker + config fetch)', async () => {
       init({
-        consentOptions: { consentRequired: true, consentStatus: 'pending' },
+        consentOptions: { consentRequired: true, consentStatus: 'denied' },
       });
       expect(antiFlickerUtils.applyAntiFlickerCss).not.toHaveBeenCalled();
 

--- a/packages/experiment-tag/test/consent/consent-journeys.test.ts
+++ b/packages/experiment-tag/test/consent/consent-journeys.test.ts
@@ -150,6 +150,37 @@ describe('consent journeys', () => {
     expect(mockGlobal.localStorage.setItem).not.toHaveBeenCalled();
   });
 
+  test('denied at load: strips the AMP_REDIRECT param a pending source page added', async () => {
+    // A pending-window redirect on the source page forces its impression
+    // payload onto this URL. Denied here means the impression is dropped, so
+    // the payload must not stay in the address bar or replay on re-grant.
+    const encoded = btoa(
+      JSON.stringify({ 'flag-1': { redirectUrl: 'http://test.com/landing' } }),
+    );
+    mockGlobal.location.href = `http://test.com/landing?AMP_REDIRECT=${encoded}`;
+    mockGlobal.location.search = `?AMP_REDIRECT=${encoded}`;
+
+    initialize(API_KEY, INIT_CONFIGS, {
+      consentOptions: { consentRequired: true, consentStatus: 'denied' },
+    });
+    await flushAsync();
+
+    expect(mockGlobal.history.replaceState).toHaveBeenCalledWith(
+      {},
+      '',
+      'http://test.com/landing',
+    );
+  });
+
+  test('denied at load: leaves the URL alone when no redirect param is present', async () => {
+    initialize(API_KEY, INIT_CONFIGS, {
+      consentOptions: { consentRequired: true, consentStatus: 'denied' },
+    });
+    await flushAsync();
+
+    expect(mockGlobal.history.replaceState).not.toHaveBeenCalled();
+  });
+
   test('denied at load -> granted: re-opt-in starts the client and persists identity', async () => {
     initialize(API_KEY, INIT_CONFIGS, {
       consentOptions: { consentRequired: true, consentStatus: 'denied' },

--- a/packages/experiment-tag/test/consent/consent-journeys.test.ts
+++ b/packages/experiment-tag/test/consent/consent-journeys.test.ts
@@ -95,35 +95,59 @@ describe('consent journeys', () => {
     );
   });
 
-  test('pending: nothing is constructed and no storage is written', async () => {
+  test('pending: client runs, but nothing reaches storage', async () => {
     initialize(API_KEY, INIT_CONFIGS, {
       consentOptions: { consentRequired: true, consentStatus: 'pending' },
     });
     await flushAsync();
 
-    expect(mockGlobal.webExperiment.isStub).toBe(true);
+    // The client is real and running — experiments are live under pending —
+    // while every persistence surface stays untouched.
+    expect(mockGlobal.webExperiment.isStub).toBeFalsy();
+    expect(mockGlobal.webExperiment.isRunning).toBe(true);
     expect(mockGlobal.localStorage.setItem).not.toHaveBeenCalled();
     expect(mockGlobal.sessionStorage.setItem).not.toHaveBeenCalled();
     expect(Object.keys(cookieStore)).toHaveLength(0);
   });
 
-  test('pending -> granted: client starts and identity is persisted', async () => {
+  test('pending -> granted: the running client flushes identity to storage', async () => {
     initialize(API_KEY, INIT_CONFIGS, {
       consentOptions: { consentRequired: true, consentStatus: 'pending' },
     });
     await flushAsync();
+    expect(mockGlobal.webExperiment.isRunning).toBe(true);
     expect(mockGlobal.localStorage.setItem).not.toHaveBeenCalled();
 
-    // Customer CMP grants consent via the stub.
+    // Customer CMP grants consent on the already-running client: no relaunch,
+    // the buffered identity write flushes out.
     mockGlobal.webExperiment.setConsentStatus('granted');
     await flushAsync();
 
-    expect(mockGlobal.webExperiment.isStub).toBeFalsy();
     expect(mockGlobal.webExperiment.isRunning).toBe(true);
     expect(mockGlobal.localStorage.setItem).toHaveBeenCalledWith(
       IDENTITY_LS_KEY,
       expect.any(String),
     );
+  });
+
+  test('pending -> denied: nothing is written, and a later re-opt-in does not resurrect pre-denial data', async () => {
+    initialize(API_KEY, INIT_CONFIGS, {
+      consentOptions: { consentRequired: true, consentStatus: 'pending' },
+    });
+    await flushAsync();
+    expect(mockGlobal.webExperiment.isRunning).toBe(true);
+
+    mockGlobal.webExperiment.setConsentStatus('denied');
+    await flushAsync();
+    expect(mockGlobal.localStorage.setItem).not.toHaveBeenCalled();
+    expect(mockGlobal.sessionStorage.setItem).not.toHaveBeenCalled();
+    expect(Object.keys(cookieStore)).toHaveLength(0);
+
+    // The denial dropped the buffers and spent the one-shot flush listeners,
+    // so a preference-center re-opt-in must not write out pre-denial data.
+    mockGlobal.webExperiment.setConsentStatus('granted');
+    await flushAsync();
+    expect(mockGlobal.localStorage.setItem).not.toHaveBeenCalled();
   });
 
   test('denied at load -> granted: re-opt-in starts the client and persists identity', async () => {

--- a/packages/experiment-tag/test/consent/consent-manager.test.ts
+++ b/packages/experiment-tag/test/consent/consent-manager.test.ts
@@ -64,6 +64,26 @@ describe('ConsentManager', () => {
     expect(calls).toEqual(['first', 'second']);
   });
 
+  test('a listener armed during notification waits for the next transition', () => {
+    // Regression: the relay teardown is armed inside the pending-grant
+    // deferral callback. Iterating the live Set would visit the new listener
+    // on the in-flight transition, and a one-shot wrapper would spend itself
+    // there — leaving nothing armed for the actual revocation.
+    const manager = new ConsentManager();
+    const armed = jest.fn();
+    manager.onChange((status) => {
+      if (status === 'granted') {
+        manager.onChange(armed);
+      }
+    });
+
+    manager.setStatus('granted');
+    expect(armed).not.toHaveBeenCalled();
+
+    manager.setStatus('denied');
+    expect(armed).toHaveBeenCalledWith('denied', 'granted');
+  });
+
   test('unsubscribe stops notifications', () => {
     const manager = new ConsentManager();
     const listener = jest.fn();

--- a/packages/experiment-tag/test/consent/consent-pending-run.test.ts
+++ b/packages/experiment-tag/test/consent/consent-pending-run.test.ts
@@ -293,6 +293,20 @@ describe('pending-run wiring', () => {
     });
   });
 
+  describe('constructor localStorage probe', () => {
+    test('skipped while consent is withheld (the probe writes a throwaway key)', () => {
+      activateConsent('pending');
+      newBehavioralClient();
+      expect(experimentCore.isLocalStorageAvailable).not.toHaveBeenCalled();
+    });
+
+    test('runs as usual once consent is granted', () => {
+      activateConsent('granted');
+      newBehavioralClient();
+      expect(experimentCore.isLocalStorageAvailable).toHaveBeenCalled();
+    });
+  });
+
   describe('redirect impressions under pending', () => {
     test('forces the AMP_REDIRECT URL transport without the encodeRedirectInUrl opt-in', async () => {
       activateConsent('pending');

--- a/packages/experiment-tag/test/consent/consent-pending-run.test.ts
+++ b/packages/experiment-tag/test/consent/consent-pending-run.test.ts
@@ -245,6 +245,48 @@ describe('pending-run wiring', () => {
       expect(mockRelayDestroy).toHaveBeenCalled();
     });
 
+    test('grant moves the client onto the durable identity before the relay binds', async () => {
+      // Pending gated reads hide the identity an earlier consented visit
+      // stored, so start() mints an ephemeral one. The grant flush restores
+      // the durable identity on disk; the refresh must move the running
+      // client onto it and the deferred relay must bind to it — otherwise
+      // this page's behavioral data fragments under an id that never
+      // appears again.
+      activateConsent('pending');
+      const expKey = `EXP_${stringify(apiKey).slice(0, 10)}`;
+      mockGlobal.localStorage.setItem(
+        expKey,
+        JSON.stringify({
+          web_exp_id: 'durable-id',
+          web_exp_id_v2: 'durable-v2',
+        }),
+      );
+      cookieStore[`${expKey}_identity`] = JSON.stringify({
+        web_exp_id_v2: 'durable-v2',
+        first_seen: '100',
+      });
+
+      await newBehavioralClient().start();
+      await flushAsync();
+      expect(RelayClient).not.toHaveBeenCalled();
+
+      consentGate.manager.setStatus('granted');
+      await flushAsync();
+
+      expect(RelayClient).toHaveBeenCalledTimes(1);
+      expect((RelayClient as unknown as jest.Mock).mock.calls[0][1]).toEqual(
+        'durable-v2',
+      );
+      const setUserCalls = (ExperimentClient.prototype.setUser as jest.Mock)
+        .mock.calls;
+      expect(setUserCalls[setUserCalls.length - 1][0]).toEqual(
+        expect.objectContaining({
+          web_exp_id: 'durable-id',
+          web_exp_id_v2: 'durable-v2',
+        }),
+      );
+    });
+
     test('a denial racing start() keeps the relay out for the page, even across a re-opt-in', async () => {
       // Regression: when the denial lands before scheduleRelaySync runs, the
       // status is already 'denied' at the withheld check. Arming the deferral

--- a/packages/experiment-tag/test/consent/consent-pending-run.test.ts
+++ b/packages/experiment-tag/test/consent/consent-pending-run.test.ts
@@ -413,9 +413,15 @@ describe('pending-run wiring', () => {
       });
       await client.start();
 
-      // The gated sessionStorage write is held in memory (it would die with
-      // this page), so the impression must ride the URL instead.
-      expect(mockGlobal.sessionStorage.setItem).not.toHaveBeenCalled();
+      // Impression cookies/sessionStorage stay gated; the stick-detector
+      // marker is exempt so a hard nav can still suppress a strip loop.
+      const sessionKeys = mockGlobal.sessionStorage.setItem.mock.calls.map(
+        ([key]) => key,
+      );
+      expect(sessionKeys.every((key) => key.endsWith('_REDIRECT_MARKER'))).toBe(
+        true,
+      );
+      expect(sessionKeys.length).toBeGreaterThan(0);
       expect(mockGlobal.location.replace).toHaveBeenCalledTimes(1);
       const targetUrl = mockGlobal.location.replace.mock.calls[0][0] as string;
       const encoded = new URL(targetUrl).searchParams.get('AMP_REDIRECT');
@@ -423,6 +429,50 @@ describe('pending-run wiring', () => {
       expect(JSON.parse(atob(encoded as string))).toMatchObject({
         test: { redirectUrl: 'http://test.com/2', variantKey: 'treatment' },
       });
+    });
+
+    test('pending hard-nav marker survives so a server strip is suppressed', async () => {
+      activateConsent('pending');
+      const key = stringify(apiKey);
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {
+        // swallow expected loop warning
+      });
+      mockGlobal.sessionStorage.setItem(
+        `EXP_${key.slice(0, 10)}_REDIRECT_MARKER`,
+        JSON.stringify({
+          test: {
+            from: 'http://test.com',
+            target: 'http://test.com/2',
+            distinguishingParams: [],
+            landed: false,
+          },
+        }),
+      );
+      mockGetGlobalScope.mockReturnValue(
+        mockGlobal as unknown as typeof globalThis,
+      );
+
+      try {
+        await DefaultWebExperimentClient.getInstance(key, {
+          initialFlags: JSON.stringify([
+            createRedirectFlag(
+              'test',
+              'treatment',
+              'http://test.com/2',
+              undefined,
+              DEFAULT_REDIRECT_SCOPE,
+            ),
+          ]),
+          pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+        }).start();
+
+        expect(mockGlobal.location.replace).not.toHaveBeenCalled();
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('redirect loop detected'),
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
 
     test('a gated destination consumes the URL param and cleans the URL', async () => {

--- a/packages/experiment-tag/test/consent/consent-pending-run.test.ts
+++ b/packages/experiment-tag/test/consent/consent-pending-run.test.ts
@@ -287,6 +287,53 @@ describe('pending-run wiring', () => {
       );
     });
 
+    test('grant restores durable localStorage identity when no durable cookie existed', async () => {
+      // Cookie expired (or was cleared) but localStorage survived: the grant
+      // flush writes the pending-time mint into the cookie (no durable cookie
+      // wins the merge), so a plain re-read returns this page's own mint. An
+      // ungated start() would have seeded the cookie from localStorage — the
+      // refresh must converge to that, not let the mint become permanent.
+      activateConsent('pending');
+      const expKey = `EXP_${stringify(apiKey).slice(0, 10)}`;
+      mockGlobal.localStorage.setItem(
+        expKey,
+        JSON.stringify({
+          web_exp_id: 'durable-id',
+          web_exp_id_v2: 'durable-v2',
+        }),
+      );
+      mockGlobal.localStorage.setItem(
+        `${expKey}_DEFAULT_USER_PROVIDER`,
+        JSON.stringify({ first_seen: '1000' }),
+      );
+
+      await newBehavioralClient().start();
+      await flushAsync();
+
+      consentGate.manager.setStatus('granted');
+      await flushAsync();
+
+      expect(RelayClient).toHaveBeenCalledTimes(1);
+      expect((RelayClient as unknown as jest.Mock).mock.calls[0][1]).toEqual(
+        'durable-v2',
+      );
+      const setUserCalls = (ExperimentClient.prototype.setUser as jest.Mock)
+        .mock.calls;
+      expect(setUserCalls[setUserCalls.length - 1][0]).toEqual(
+        expect.objectContaining({
+          web_exp_id: 'durable-id',
+          web_exp_id_v2: 'durable-v2',
+          first_seen: '1000',
+        }),
+      );
+      // The cookie was rewritten with the durable values, so later loads
+      // resolve the same identity instead of the pending-time mint.
+      expect(JSON.parse(cookieStore[`${expKey}_identity`])).toEqual({
+        web_exp_id_v2: 'durable-v2',
+        first_seen: '1000',
+      });
+    });
+
     test('a denial racing start() keeps the relay out for the page, even across a re-opt-in', async () => {
       // Regression: when the denial lands before scheduleRelaySync runs, the
       // status is already 'denied' at the withheld check. Arming the deferral

--- a/packages/experiment-tag/test/consent/consent-pending-run.test.ts
+++ b/packages/experiment-tag/test/consent/consent-pending-run.test.ts
@@ -178,7 +178,7 @@ describe('pending-run wiring', () => {
       expect(mockRelayInit).toHaveBeenCalled();
     });
 
-    test('refusal never injects the relay, and a same-page re-opt-in gets it', async () => {
+    test('refusal never injects the relay, even after a same-page re-opt-in', async () => {
       activateConsent('pending');
       await newBehavioralClient().start();
       await flushAsync();
@@ -188,7 +188,8 @@ describe('pending-run wiring', () => {
       expect(RelayClient).not.toHaveBeenCalled();
 
       // The refusal spent the deferral's one-shot subscription without
-      // injecting; a later re-opt-in re-defers through the same gate.
+      // injecting, and nothing re-arms it — a re-opt-in gets the relay on
+      // the next page load, never this one.
       consentGate.manager.setStatus('granted');
       await flushAsync();
       expect(RelayClient).not.toHaveBeenCalled();

--- a/packages/experiment-tag/test/consent/consent-pending-run.test.ts
+++ b/packages/experiment-tag/test/consent/consent-pending-run.test.ts
@@ -1,0 +1,315 @@
+import * as experimentCore from '@amplitude/experiment-core';
+import { EvaluationOperator } from '@amplitude/experiment-core';
+import {
+  Experiment,
+  ExperimentClient,
+  MemoryStorage,
+} from '@amplitude/experiment-js-client';
+import { stringify } from 'ts-jest';
+
+import { createRedirectFlag } from '../util/create-flag';
+import { createPageObject } from '../util/create-page-object';
+import { createMockGlobal, setupGlobalObservers } from '../util/mocks';
+
+import { activateConsent } from './consent-test-util';
+
+import { RelayClient } from 'src/behavioral-targeting/relay-client';
+import { consentGate } from 'src/consent/consent-gate';
+import { DefaultWebExperimentClient } from 'src/experiment';
+
+// In-memory cookie store backing the mocked analytics-core CookieStorage.
+const cookieStore: Record<string, any> = {};
+const clearCookieStore = () =>
+  Object.keys(cookieStore).forEach((key) => delete cookieStore[key]);
+
+jest.mock('@amplitude/analytics-core', () => {
+  const actual = jest.requireActual('@amplitude/analytics-core');
+  const MockCookieStorage = jest.fn().mockImplementation(() => ({
+    get: jest.fn((key: string) => Promise.resolve(cookieStore[key])),
+    set: jest.fn((key: string, value: any) => {
+      cookieStore[key] = value;
+      return Promise.resolve();
+    }),
+    remove: jest.fn((key: string) => {
+      delete cookieStore[key];
+      return Promise.resolve();
+    }),
+    getRaw: jest.fn((key: string) =>
+      Promise.resolve(JSON.stringify(cookieStore[key])),
+    ),
+    isEnabled: jest.fn(() => Promise.resolve(true)),
+    reset: jest.fn(() => {
+      clearCookieStore();
+      return Promise.resolve();
+    }),
+  }));
+  (MockCookieStorage as any).isDomainWritable = jest
+    .fn()
+    .mockResolvedValue(false);
+  return { ...actual, CookieStorage: MockCookieStorage };
+});
+
+jest.mock('src/util/messenger', () => ({
+  WindowMessenger: { setup: jest.fn() },
+}));
+
+const mockRelayInit = jest.fn().mockResolvedValue(undefined);
+const mockRelayDestroy = jest.fn();
+const mockRelayWaitForAvailable = jest.fn().mockResolvedValue(false);
+const mockRelayCheckMigrated = jest.fn().mockResolvedValue(true);
+const mockRelayReadEvents = jest
+  .fn()
+  .mockResolvedValue({ events: [], nextId: 1 });
+// Mutable so individual tests can flip the relay to "available" (a successful
+// sync path) without re-mocking the module.
+const mockRelayState = { available: false };
+
+jest.mock('src/behavioral-targeting/relay-client', () => {
+  const actual = jest.requireActual('src/behavioral-targeting/relay-client');
+  return {
+    ...actual,
+    RelayClient: jest.fn().mockImplementation(() => ({
+      init: mockRelayInit,
+      destroy: mockRelayDestroy,
+      get relayAvailable() {
+        return mockRelayState.available;
+      },
+      waitForAvailable: mockRelayWaitForAvailable,
+      checkMigrated: mockRelayCheckMigrated,
+      readEvents: mockRelayReadEvents,
+      writeEvent: jest.fn(),
+      flush: jest.fn(),
+    })),
+  };
+});
+
+setupGlobalObservers();
+
+const BEHAVIORAL_TARGETING_RULES = {
+  flag_a: {
+    behavior_1: [
+      [
+        {
+          condition: {
+            type: 'behavior',
+            event_type: 'click',
+            op: EvaluationOperator.GREATER_THAN_EQUALS,
+            value: 1,
+            time_type: 'rolling',
+            time_value: 7,
+            interval: 'day',
+          },
+        },
+      ],
+    ],
+  },
+};
+
+const DEFAULT_PAGE_OBJECTS = {
+  test: createPageObject('A', 'url_change', undefined, 'http://test.com'),
+};
+const DEFAULT_REDIRECT_SCOPE = { treatment: ['A'], control: ['A'] };
+
+const flushAsync = async (): Promise<void> => {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve();
+  }
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+describe('pending-run wiring', () => {
+  let apiKey = 0;
+  const mockGetGlobalScope = jest.spyOn(experimentCore, 'getGlobalScope');
+  let mockGlobal: ReturnType<typeof createMockGlobal>;
+
+  const newBehavioralClient = () =>
+    DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+      initialFlags: JSON.stringify([]),
+      pageObjects: JSON.stringify({
+        flag_a: createPageObject(
+          'A',
+          'url_change',
+          undefined,
+          'http://test.com',
+        ),
+      }),
+      behavioralTargetingRules: JSON.stringify(BEHAVIORAL_TARGETING_RULES),
+    });
+
+  beforeEach(() => {
+    apiKey++;
+    jest.clearAllMocks();
+    consentGate.reset();
+    clearCookieStore();
+    mockRelayState.available = false;
+    jest.spyOn(experimentCore, 'isLocalStorageAvailable').mockReturnValue(true);
+    mockGlobal = createMockGlobal();
+    mockGetGlobalScope.mockReturnValue(
+      mockGlobal as unknown as typeof globalThis,
+    );
+    jest.spyOn(ExperimentClient.prototype, 'setUser').mockImplementation();
+    // `all` is left real so the redirect tests evaluate their local flag; the
+    // relay tests pass empty initialFlags, so it returns {} for them anyway.
+    jest
+      .spyOn(ExperimentClient.prototype, 'fetch')
+      .mockResolvedValue({} as never);
+  });
+
+  describe('relay iframe gating', () => {
+    test('not injected while consent is pending', async () => {
+      activateConsent('pending');
+      await newBehavioralClient().start();
+      await flushAsync();
+
+      expect(RelayClient).not.toHaveBeenCalled();
+      expect(mockRelayInit).not.toHaveBeenCalled();
+    });
+
+    test('grant injects the deferred relay', async () => {
+      activateConsent('pending');
+      await newBehavioralClient().start();
+      await flushAsync();
+      expect(RelayClient).not.toHaveBeenCalled();
+
+      consentGate.manager.setStatus('granted');
+      await flushAsync();
+
+      expect(RelayClient).toHaveBeenCalledTimes(1);
+      expect(mockRelayInit).toHaveBeenCalled();
+    });
+
+    test('refusal never injects the relay, and a same-page re-opt-in gets it', async () => {
+      activateConsent('pending');
+      await newBehavioralClient().start();
+      await flushAsync();
+
+      consentGate.manager.setStatus('denied');
+      await flushAsync();
+      expect(RelayClient).not.toHaveBeenCalled();
+
+      // The refusal spent the deferral's one-shot subscription without
+      // injecting; a later re-opt-in re-defers through the same gate.
+      consentGate.manager.setStatus('granted');
+      await flushAsync();
+      expect(RelayClient).not.toHaveBeenCalled();
+    });
+
+    test('revocation tears down a live relay (stops third-party requests)', async () => {
+      activateConsent('granted');
+      // Successful sync path: relay available, nothing to merge.
+      // syncFromRelay needs location.origin (absent from the default mock).
+      mockRelayState.available = true;
+      mockGlobal = createMockGlobal({
+        location: { origin: 'http://test.com' },
+      });
+      mockGetGlobalScope.mockReturnValue(
+        mockGlobal as unknown as typeof globalThis,
+      );
+
+      await newBehavioralClient().start();
+      await flushAsync();
+      expect(RelayClient).toHaveBeenCalledTimes(1);
+      expect(mockRelayDestroy).not.toHaveBeenCalled();
+
+      consentGate.manager.setStatus('denied');
+      await flushAsync();
+      expect(mockRelayDestroy).toHaveBeenCalled();
+    });
+  });
+
+  describe('memory-backed amp-exp-* caches', () => {
+    test('pending injects a MemoryStorage internal cache', () => {
+      const initSpy = jest.spyOn(Experiment, 'initialize');
+      activateConsent('pending');
+      DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+        initialFlags: JSON.stringify([]),
+        pageObjects: JSON.stringify({}),
+      });
+
+      expect(initSpy).toHaveBeenCalledWith(
+        stringify(apiKey),
+        expect.objectContaining({
+          internalCacheStorage: expect.any(MemoryStorage),
+        }),
+      );
+    });
+
+    test('without consent gating the cache storage is not overridden', () => {
+      const initSpy = jest.spyOn(Experiment, 'initialize');
+      DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+        initialFlags: JSON.stringify([]),
+        pageObjects: JSON.stringify({}),
+      });
+
+      const config = initSpy.mock.calls[0][1] as Record<string, unknown>;
+      expect(config.internalCacheStorage).toBeUndefined();
+    });
+  });
+
+  describe('redirect impressions under pending', () => {
+    test('forces the AMP_REDIRECT URL transport without the encodeRedirectInUrl opt-in', async () => {
+      activateConsent('pending');
+      const client = DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+        initialFlags: JSON.stringify([
+          createRedirectFlag(
+            'test',
+            'treatment',
+            'http://test.com/2',
+            undefined,
+            DEFAULT_REDIRECT_SCOPE,
+          ),
+        ]),
+        pageObjects: JSON.stringify(DEFAULT_PAGE_OBJECTS),
+      });
+      await client.start();
+
+      // The gated sessionStorage write is held in memory (it would die with
+      // this page), so the impression must ride the URL instead.
+      expect(mockGlobal.sessionStorage.setItem).not.toHaveBeenCalled();
+      expect(mockGlobal.location.replace).toHaveBeenCalledTimes(1);
+      const targetUrl = mockGlobal.location.replace.mock.calls[0][0] as string;
+      const encoded = new URL(targetUrl).searchParams.get('AMP_REDIRECT');
+      expect(encoded).not.toBeNull();
+      expect(JSON.parse(atob(encoded as string))).toMatchObject({
+        test: { redirectUrl: 'http://test.com/2', variantKey: 'treatment' },
+      });
+    });
+
+    test('a gated destination consumes the URL param and cleans the URL', async () => {
+      activateConsent('pending');
+      const encoded = btoa(
+        JSON.stringify({
+          test: { redirectUrl: 'http://test.com/2', variantKey: 'treatment' },
+        }),
+      );
+      mockGlobal = createMockGlobal({
+        location: {
+          href: `http://test.com/2?AMP_REDIRECT=${encodeURIComponent(encoded)}`,
+          search: `?AMP_REDIRECT=${encodeURIComponent(encoded)}`,
+        },
+      });
+      mockGetGlobalScope.mockReturnValue(
+        mockGlobal as unknown as typeof globalThis,
+      );
+      const mockExposureInternal = jest.spyOn(
+        ExperimentClient.prototype as any,
+        'exposureInternal',
+      );
+
+      const client = DefaultWebExperimentClient.getInstance(stringify(apiKey), {
+        initialFlags: JSON.stringify([]),
+        pageObjects: JSON.stringify({}),
+      });
+      await client.start();
+      await flushAsync();
+
+      expect(mockExposureInternal).toHaveBeenCalledTimes(1);
+      expect(mockExposureInternal.mock.calls[0][0]).toBe('test');
+      expect(mockGlobal.history.replaceState).toHaveBeenCalledWith(
+        {},
+        '',
+        'http://test.com/2',
+      );
+    });
+  });
+});

--- a/packages/experiment-tag/test/consent/consent-pending-run.test.ts
+++ b/packages/experiment-tag/test/consent/consent-pending-run.test.ts
@@ -446,6 +446,7 @@ describe('pending-run wiring', () => {
         'exposureInternal',
       );
 
+      const replaceStateSpy = mockGlobal.history.replaceState;
       const client = DefaultWebExperimentClient.getInstance(stringify(apiKey), {
         initialFlags: JSON.stringify([]),
         pageObjects: JSON.stringify({}),
@@ -455,11 +456,7 @@ describe('pending-run wiring', () => {
 
       expect(mockExposureInternal).toHaveBeenCalledTimes(1);
       expect(mockExposureInternal.mock.calls[0][0]).toBe('test');
-      expect(mockGlobal.history.replaceState).toHaveBeenCalledWith(
-        {},
-        '',
-        'http://test.com/2',
-      );
+      expect(replaceStateSpy).toHaveBeenCalledWith({}, '', 'http://test.com/2');
     });
   });
 });

--- a/packages/experiment-tag/test/consent/consent-pending-run.test.ts
+++ b/packages/experiment-tag/test/consent/consent-pending-run.test.ts
@@ -215,6 +215,52 @@ describe('pending-run wiring', () => {
       await flushAsync();
       expect(mockRelayDestroy).toHaveBeenCalled();
     });
+
+    test('revocation tears down a relay that was injected by a grant', async () => {
+      // Regression: the teardown listener is armed inside the pending-grant
+      // deferral callback, i.e. while the manager is still notifying grant
+      // listeners. Live-Set iteration would spend the one-shot on the grant
+      // itself, leaving the relay alive through the revocation.
+      activateConsent('pending');
+      mockRelayState.available = true;
+      mockGlobal = createMockGlobal({
+        location: { origin: 'http://test.com' },
+      });
+      mockGetGlobalScope.mockReturnValue(
+        mockGlobal as unknown as typeof globalThis,
+      );
+
+      await newBehavioralClient().start();
+      await flushAsync();
+      expect(RelayClient).not.toHaveBeenCalled();
+
+      consentGate.manager.setStatus('granted');
+      await flushAsync();
+      expect(RelayClient).toHaveBeenCalledTimes(1);
+      expect(mockRelayDestroy).not.toHaveBeenCalled();
+
+      consentGate.manager.setStatus('denied');
+      await flushAsync();
+      expect(mockRelayDestroy).toHaveBeenCalled();
+    });
+
+    test('a denial racing start() keeps the relay out for the page, even across a re-opt-in', async () => {
+      // Regression: when the denial lands before scheduleRelaySync runs, the
+      // status is already 'denied' at the withheld check. Arming the deferral
+      // there would hand the relay to a same-page re-opt-in — unlike the
+      // pending path, where the refusal spends the subscription and the relay
+      // waits for the next load.
+      activateConsent('pending');
+      const startPromise = newBehavioralClient().start();
+      consentGate.manager.setStatus('denied');
+      await startPromise;
+      await flushAsync();
+      expect(RelayClient).not.toHaveBeenCalled();
+
+      consentGate.manager.setStatus('granted');
+      await flushAsync();
+      expect(RelayClient).not.toHaveBeenCalled();
+    });
   });
 
   describe('memory-backed amp-exp-* caches', () => {

--- a/packages/experiment-tag/test/util/cookie.test.ts
+++ b/packages/experiment-tag/test/util/cookie.test.ts
@@ -1,11 +1,17 @@
+import { CookieStorage } from '@amplitude/analytics-core';
+
+import { consentGate } from '../../src/consent/consent-gate';
 import {
   deleteRawCookie,
   getCookieDomainLevels,
+  getTopLevelDomain,
+  getTopLevelDomainSync,
   readRawCookie,
   resolveCrossSubdomainObject,
   SyncJsonCookie,
   writeRawCookie,
 } from '../../src/util/cookie';
+import { activateConsent } from '../consent/consent-test-util';
 
 /**
  * Minimal in-memory stand-in for analytics-core's async CookieStorage<string>,
@@ -126,6 +132,37 @@ describe('resolveCrossSubdomainObject', () => {
       web_exp_id_v2: 'fresh',
       first_seen: 'fresh-ts',
     });
+  });
+});
+
+describe('top-level domain resolution under consent', () => {
+  afterEach(() => {
+    consentGate.reset();
+    jest.restoreAllMocks();
+  });
+
+  it('returns the unprobed guess without probing while consent is pending', async () => {
+    activateConsent('pending');
+    const probe = jest.spyOn(CookieStorage, 'isDomainWritable');
+    expect(await getTopLevelDomain('app.example.com')).toBe('.example.com');
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it('sync variant skips the probe cookie while consent is withheld', () => {
+    activateConsent('denied');
+    // In this jsdom page a `.example.com` probe cookie can never be written,
+    // so the ungated path would walk every level and return ''. Getting the
+    // guess back proves the probe never ran.
+    expect(getTopLevelDomainSync('app.example.com')).toBe('.example.com');
+  });
+
+  it('probes for real once consent is granted', async () => {
+    activateConsent('granted');
+    const probe = jest
+      .spyOn(CookieStorage, 'isDomainWritable')
+      .mockResolvedValue(true);
+    expect(await getTopLevelDomain('app.example.com')).toBe('.example.com');
+    expect(probe).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

Final wiring PR of the consent-gating stack (#357 → #358 → #359 → this). Pending consent no longer defers startup — only an explicit denial does. A pending client starts immediately and applies experiments without flicker, while every side effect is held back by the layers built in the earlier PRs:

- **Startup** (`index.ts`): only `denied` stashes a deferred start; `pending` runs the client. A grant on a pending client resolves the gates armed below it (storage flush, impression replay, relay injection) instead of re-starting.
- **Caches**: the `amp-exp-*` variant/flag caches use a `MemoryStorage` while consent is withheld, so the SDK's internal caches never touch sessionStorage pre-consent.
- **Relay iframe**: `scheduleRelaySync` defers injection through a one-shot consent listener — a grant injects it after the storage-gate flush listeners have run (the merge reads a complete local event store); a refusal spends the subscription and the relay stays out for the page. A revocation on a live relay destroys the iframe and detaches the dual-write, so no further requests reach the third-party CDN origin.
- **Redirects**: while pending, the sessionStorage/cookie impression copies are memory-buffered and die with the page, so the `AMP_REDIRECT` URL param transport is forced on for every redirect (regardless of the `encodeRedirectInUrl` opt-in — it stores nothing on the device). A gated destination page consumes the param and cleans the URL even without the opt-in.

## Test plan

- [x] New `consent-pending-run.test.ts`: relay not injected under pending; grant injects; refusal never injects; revocation tears down a live relay; MemoryStorage injected only under withheld consent; forced AMP_REDIRECT origin + destination behavior
- [x] Updated `consent-gate.test.ts` / `consent-journeys.test.ts` to the new semantics (pending runs gated, only denied defers)
- [x] Full experiment-tag suite: 27 suites, 437 tests passing

Made with [Cursor](https://cursor.com)