### PR TITLE
chore: upgrade target to es2017

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,14 +2,7 @@
 
 module.exports = {
   presets: [
-    [
-      '@babel/preset-env',
-      {
-        targets: {
-          browsers: ['ie >= 8'],
-        },
-      },
-    ],
+    ['@babel/preset-env', { targets: '> 0%' }],
     '@babel/preset-typescript',
   ],
 };

--- a/examples/react-app/amplitude-integration/tsconfig.json
+++ b/examples/react-app/amplitude-integration/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -20,7 +16,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/examples/react-app/basic/tsconfig.json
+++ b/examples/react-app/basic/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -20,7 +16,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/packages/analytics-connector/rollup.config.js
+++ b/packages/analytics-connector/rollup.config.js
@@ -48,9 +48,8 @@ const getOutputConfig = (outputOptions) => ({
 });
 
 const configs = [
-  // legacy build for field "main" - ie8, umd, es5 syntax
   {
-    ...getCommonBrowserConfig('es5'),
+    ...getCommonBrowserConfig('es2017'),
     ...getOutputConfig({
       entryFileNames: 'analytics-connector.umd.js',
       exports: 'named',
@@ -59,9 +58,8 @@ const configs = [
     external: [],
   },
 
-  // tree shakable build for field "module" - ie8, esm, es5 syntax
   {
-    ...getCommonBrowserConfig('es5'),
+    ...getCommonBrowserConfig('es2017'),
     ...getOutputConfig({
       entryFileNames: 'analytics-connector.esm.js',
       format: 'esm',
@@ -69,7 +67,7 @@ const configs = [
     external: [],
   },
 
-  // modern build for field "es2015" - not ie, esm, es2015 syntax
+  // build for es2015
   {
     ...getCommonBrowserConfig('es2015'),
     ...getOutputConfig({

--- a/packages/experiment-browser/rollup.config.js
+++ b/packages/experiment-browser/rollup.config.js
@@ -53,9 +53,8 @@ const getOutputConfig = (outputOptions) => ({
 });
 
 const configs = [
-  // legacy build for field "main" - ie8, umd, es5 syntax
   {
-    ...getCommonBrowserConfig('es5'),
+    ...getCommonBrowserConfig('es2017'),
     ...getOutputConfig({
       entryFileNames: 'experiment.umd.js',
       exports: 'named',
@@ -64,9 +63,8 @@ const configs = [
     external: [],
   },
 
-  // tree shakable build for field "module" - ie8, esm, es5 syntax
   {
-    ...getCommonBrowserConfig('es5'),
+    ...getCommonBrowserConfig('es2017'),
     ...getOutputConfig({
       entryFileNames: 'experiment.esm.js',
       format: 'esm',
@@ -78,7 +76,7 @@ const configs = [
     ],
   },
 
-  // modern build for field "es2015" - not ie, esm, es2015 syntax
+  // build for field es2015
   {
     ...getCommonBrowserConfig('es2015'),
     ...getOutputConfig({
@@ -92,14 +90,14 @@ const configs = [
     ],
   },
   {
-    ...getCommonBrowserConfig('es5'),
+    ...getCommonBrowserConfig('es2017'),
     ...getOutputConfig({
       entryFileNames: 'experiment-browser.min.js',
       exports: 'named',
       format: 'umd',
     }),
     plugins: [
-      ...getCommonBrowserConfig('es5').plugins,
+      ...getCommonBrowserConfig('es2017').plugins,
       terser({
         format: {
           comments:

--- a/packages/experiment-core/rollup.config.js
+++ b/packages/experiment-core/rollup.config.js
@@ -37,9 +37,8 @@ const getOutputConfig = (outputOptions) => ({
 });
 
 const configs = [
-  // legacy build for field "main" - ie8, umd, es5 syntax
   {
-    ...getCommonBrowserConfig('es5'),
+    ...getCommonBrowserConfig('es2017'),
     ...getOutputConfig({
       entryFileNames: 'experiment-core.umd.js',
       exports: 'named',
@@ -48,9 +47,8 @@ const configs = [
     external: [],
   },
 
-  // tree shakable build for field "module" - ie8, esm, es5 syntax
   {
-    ...getCommonBrowserConfig('es5'),
+    ...getCommonBrowserConfig('es2017'),
     ...getOutputConfig({
       entryFileNames: 'experiment-core.esm.js',
       format: 'esm',
@@ -58,7 +56,7 @@ const configs = [
     external: ['unfetch'],
   },
 
-  // modern build for field "es2015" - not ie, esm, es2015 syntax
+  // build for field "es2015"
   {
     ...getCommonBrowserConfig('es2015'),
     ...getOutputConfig({

--- a/packages/experiment-tag/rollup.config.js
+++ b/packages/experiment-tag/rollup.config.js
@@ -74,7 +74,7 @@ const getOutputConfig = (outputOptions) => ({
   },
 });
 
-const config = getCommonBrowserConfig('es5');
+const config = getCommonBrowserConfig('es2017');
 const configs = [
   {
     ...config,

--- a/packages/plugin-segment/rollup.config.js
+++ b/packages/plugin-segment/rollup.config.js
@@ -59,7 +59,7 @@ const getOutputConfig = (outputOptions) => ({
   },
 });
 
-const config = getCommonBrowserConfig('es5');
+const config = getCommonBrowserConfig('es2017');
 const configs = [
   {
     ...config,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,15 @@
 {
   "compilerOptions": {
-    "lib": ["es5", "es6", "dom"],
+    "lib": ["es2017", "dom"],
     "module": "es2020",
     "noEmitOnError": true,
     "esModuleInterop": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "target": "es5",
+    "target": "es2017",
     "noEmit": true,
     "rootDir": ".",
-    "baseUrl": ".",
-    "downlevelIteration": true
+    "baseUrl": "."
   }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary

es5 is ancient, upgrade to es2017 which is also old but this removes a lot of polyfill code

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change to published SDK output: main/module builds no longer target ES5/IE8, which can break consumers on very old browsers.
> 
> **Overview**
> Drops **ES5/IE8** as the default compile target in favor of **ES2017**, reducing polyfill overhead in published bundles.
> 
> Rollup configs across `experiment-browser`, `experiment-core`, `analytics-connector`, `experiment-tag`, and `plugin-segment` now build the main UMD/ESM outputs as ES2017. Dedicated `es2015` builds are unchanged. Root and example `tsconfig`s, plus Babel, are updated to match (Babel targets `> 0%` instead of `ie >= 8`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4e8dfb88d7b451313f7bf6a075c07a6d7dc741d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->