### PR TITLE
Revert "ci: use amplitude/actions permission check and Node 22"

### DIFF
--- a/.github/workflows/publish-to-s3.yml
+++ b/.github/workflows/publish-to-s3.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ${{ github.actor }} permission check
-        uses: amplitude/actions/repo-permission-check-action@v0 # 2.0.2
+        uses: 'lannonbr/repo-permission-check-action@2bb8c89ba8bf115c4bfab344d6a6f442b24c9a1f' # 2.0.2
         with:
           permission: 'write'
         env:
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '22'
+          node-version: '20'
           cache: 'yarn'
 
       - name: Set up SSH for deploy key

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ${{ github.actor }} permission check
-        uses: amplitude/actions/repo-permission-check-action@v0 # 2.0.2
+        uses: 'lannonbr/repo-permission-check-action@2bb8c89ba8bf115c4bfab344d6a6f442b24c9a1f' # 2.0.2
         with:
           permission: 'write'
         env:
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '22'
+          node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Set up SSH for deploy key


### PR DESCRIPTION
Reverts amplitude/experiment-js-client#363

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only rollback of workflow action source and Node version for deploy/release paths; no application or runtime code changes.
> 
> **Overview**
> Reverts the CI updates from experiment-js-client#363 for the **Publish to S3** and **Release** workflows only.
> 
> The authorize step again uses the pinned **`lannonbr/repo-permission-check-action`** commit instead of **`amplitude/actions/repo-permission-check-action@v0`**, and both workflows run **`setup-node` with Node 20** instead of Node 22. Other workflows (e.g. `ci.yml`, `bundle-size.yml`) are unchanged and may still use Node 22.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8841c709cd0ce28781fc254c2ff77f24af1eb98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->