### PR TITLE
chore(build): remove dead target param and unused path imports from rollup configs

### DIFF
--- a/packages/analytics-connector/rollup.config.js
+++ b/packages/analytics-connector/rollup.config.js
@@ -1,5 +1,3 @@
-import { resolve as pathResolve } from 'path';
-
 import babel from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
@@ -8,7 +6,7 @@ import replace from '@rollup/plugin-replace';
 import typescript from '@rollup/plugin-typescript';
 import analyze from 'rollup-plugin-analyzer';
 
-const getCommonBrowserConfig = (target) => ({
+const getCommonBrowserConfig = () => ({
   input: 'src/index.ts',
   treeshake: {
     moduleSideEffects: 'no-external',
@@ -46,7 +44,7 @@ const getOutputConfig = (outputOptions) => ({
 const configs = [
   // legacy build for field "main"
   {
-    ...getCommonBrowserConfig('es6'),
+    ...getCommonBrowserConfig(),
     ...getOutputConfig({
       entryFileNames: 'analytics-connector.umd.js',
       exports: 'named',
@@ -57,7 +55,7 @@ const configs = [
 
   // tree shakable build for field "module"
   {
-    ...getCommonBrowserConfig('es6'),
+    ...getCommonBrowserConfig(),
     ...getOutputConfig({
       entryFileNames: 'analytics-connector.esm.js',
       format: 'esm',

--- a/packages/experiment-browser/rollup.config.js
+++ b/packages/experiment-browser/rollup.config.js
@@ -1,5 +1,3 @@
-import { resolve as pathResolve } from 'path';
-
 import babel from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
@@ -12,7 +10,7 @@ import gzip from 'rollup-plugin-gzip';
 
 import * as packageJson from './package.json';
 
-const getCommonBrowserConfig = (target) => ({
+const getCommonBrowserConfig = () => ({
   input: 'src/index.ts',
   treeshake: {
     moduleSideEffects: 'no-external',
@@ -51,7 +49,7 @@ const getOutputConfig = (outputOptions) => ({
 const configs = [
   // legacy build for field "main"
   {
-    ...getCommonBrowserConfig('es6'),
+    ...getCommonBrowserConfig(),
     ...getOutputConfig({
       entryFileNames: 'experiment.umd.js',
       exports: 'named',
@@ -62,7 +60,7 @@ const configs = [
 
   // tree shakable build for field "module"
   {
-    ...getCommonBrowserConfig('es6'),
+    ...getCommonBrowserConfig(),
     ...getOutputConfig({
       entryFileNames: 'experiment.esm.js',
       format: 'esm',
@@ -75,14 +73,14 @@ const configs = [
   },
 
   {
-    ...getCommonBrowserConfig('es6'),
+    ...getCommonBrowserConfig(),
     ...getOutputConfig({
       entryFileNames: 'experiment-browser.min.js',
       exports: 'named',
       format: 'umd',
     }),
     plugins: [
-      ...getCommonBrowserConfig('es6').plugins,
+      ...getCommonBrowserConfig().plugins,
       terser({
         format: {
           comments:

--- a/packages/experiment-core/rollup.config.js
+++ b/packages/experiment-core/rollup.config.js
@@ -1,11 +1,9 @@
-import { resolve as pathResolve } from 'path';
-
 import babel from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
 
-const getCommonBrowserConfig = (target) => ({
+const getCommonBrowserConfig = () => ({
   input: 'src/index.ts',
   treeshake: {
     moduleSideEffects: 'no-external',
@@ -35,7 +33,7 @@ const getOutputConfig = (outputOptions) => ({
 const configs = [
   // legacy build for field "main"
   {
-    ...getCommonBrowserConfig('es6'),
+    ...getCommonBrowserConfig(),
     ...getOutputConfig({
       entryFileNames: 'experiment-core.umd.js',
       exports: 'named',
@@ -46,7 +44,7 @@ const configs = [
 
   // tree shakable build for field "module"
   {
-    ...getCommonBrowserConfig('es6'),
+    ...getCommonBrowserConfig(),
     ...getOutputConfig({
       entryFileNames: 'experiment-core.esm.js',
       format: 'esm',

--- a/packages/experiment-tag/rollup.config.js
+++ b/packages/experiment-tag/rollup.config.js
@@ -1,5 +1,5 @@
 import { execSync } from 'child_process';
-import { join, resolve as pathResolve } from 'path';
+import { join } from 'path';
 
 import babel from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
@@ -26,7 +26,7 @@ try {
   console.warn('Unable to get git branch name:', error.message);
 }
 
-const getCommonBrowserConfig = (target) => ({
+const getCommonBrowserConfig = () => ({
   input: 'src/index.ts',
   treeshake: {
     moduleSideEffects: 'no-external',
@@ -68,7 +68,7 @@ const getOutputConfig = (outputOptions) => ({
   },
 });
 
-const config = getCommonBrowserConfig('es6');
+const config = getCommonBrowserConfig();
 const configs = [
   {
     ...config,

--- a/packages/plugin-segment/rollup.config.js
+++ b/packages/plugin-segment/rollup.config.js
@@ -1,4 +1,3 @@
-import { resolve as pathResolve } from 'path';
 import { join } from 'path';
 
 import babel from '@rollup/plugin-babel';
@@ -14,7 +13,7 @@ import license from 'rollup-plugin-license';
 
 import * as packageJson from './package.json';
 
-const getCommonBrowserConfig = (target) => ({
+const getCommonBrowserConfig = () => ({
   input: 'src/index.ts',
   treeshake: {
     moduleSideEffects: 'no-external',
@@ -55,7 +54,7 @@ const getOutputConfig = (outputOptions) => ({
   },
 });
 
-const config = getCommonBrowserConfig('es6');
+const config = getCommonBrowserConfig();
 const configs = [
   {
     ...config,


### PR DESCRIPTION
### Summary

Dead-code cleanup in the five `rollup.config.js` files. No behavior change.

**1. The unused `target` parameter**

`getCommonBrowserConfig(target)` is declared in all five configs but `target` is never referenced in any of their bodies. It became dead in #367, which unified the babel setup and deleted `babel.es2015.config.js` — the code that consumed the argument went away, the signature stayed.

The call sites still passed `'es6'`, which reads like a build target but is silently discarded. The real target comes from `babel.config.js` (`@babel/preset-env` targets) and `tsconfig.json` (`"target": "es6"`).

This is actively misleading: it produced a tech-debt ticket (WEB-135) reporting that the SDK "is built to ES5 via `getCommonBrowserConfig('es5')`" — a call that does not exist anywhere in the repo and hasn't since #367.

**2. The unused `pathResolve` import**

`import { resolve as pathResolve } from 'path'` is unused in the same five files. `experiment-tag` keeps `join`; `plugin-segment` had two separate `path` imports and keeps the `join` one.

Neither would have been caught automatically — `rollup.config.js` is in `.eslintignore`, so `no-unused-vars` never runs on these files.

**Verification**

`yarn build` before and after, comparing `sha256sum` of every emitted bundle: all nine dist artifacts are byte-for-byte identical.

```
packages/analytics-connector/dist/analytics-connector.{esm,umd}.js
packages/experiment-browser/dist/experiment{-browser.min,.esm,.umd}.js
packages/experiment-core/dist/experiment-core.{esm,umd}.js
packages/experiment-tag/dist/experiment-tag-min.js
packages/plugin-segment/dist/experiment-plugin-segment-min.js
```

`prettier --check` passes on all five files.

**Note on WEB-135**

This PR covers only the cleanup half of that ticket. It deliberately does **not** add the `browserslist` config the ticket asks for: the policy it proposes (copied from the `javascript` repo) would move the support floor from Chrome 55 / Firefox 54 / Safari 11 to Chrome 109 / Firefox 150 / Safari 26.4, dropping global coverage from 96% to 84%. That's a sensible policy for a first-party app that is continuously redeployed, but this SDK runs on customers' end users' browsers, so the floor is a support commitment rather than a choice. That part of the ticket needs a separate decision.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No — build output is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sz1uzFFPYUKgLQ2EC8Emet

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sz1uzFFPYUKgLQ2EC8Emet)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-config-only edits with verified byte-identical dist output; no runtime or API impact.
> 
> **Overview**
> **Dead-code cleanup** across five package `rollup.config.js` files (`analytics-connector`, `experiment-browser`, `experiment-core`, `experiment-tag`, `plugin-segment`). No change to emitted bundles.
> 
> `getCommonBrowserConfig` no longer accepts a `target` argument; call sites stop passing `'es6'`. That parameter was unused after an earlier Babel unification—the misleading signature suggested a per-config compile target while real targets still come from `babel.config.js` and `tsconfig`.
> 
> Unused `import { resolve as pathResolve } from 'path'` is removed where it was never referenced (`experiment-tag` and `plugin-segment` keep `join` for license output paths).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 065f2ce2c940b18b9f2c194d6d83d507b33969c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->