### PR TITLE
fix: update dom-mutator

### DIFF
--- a/packages/experiment-tag/package.json
+++ b/packages/experiment-tag/package.json
@@ -32,7 +32,7 @@
     "@amplitude/analytics-types": "^2.11.0",
     "@amplitude/experiment-core": "^0.13.5",
     "@amplitude/experiment-js-client": "^1.23.0",
-    "dom-mutator": "git+ssh://git@github.com/amplitude/dom-mutator#bb5f4b52273e6a3de39dcf6db6f428d66d988a7b",
+    "dom-mutator": "git+ssh://git@github.com/amplitude/dom-mutator#12c98baf791d3f5b803f6f30517512df6f1b0a2a",
     "rollup-plugin-license": "^3.6.0",
     "unfetch": "4.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4158,9 +4158,9 @@ dom-accessibility-api@^0.5.1:
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
   integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
 
-"dom-mutator@git+ssh://git@github.com/amplitude/dom-mutator#bb5f4b52273e6a3de39dcf6db6f428d66d988a7b":
+"dom-mutator@git+ssh://git@github.com/amplitude/dom-mutator#12c98baf791d3f5b803f6f30517512df6f1b0a2a":
   version "0.7.1"
-  resolved "git+ssh://git@github.com/amplitude/dom-mutator#bb5f4b52273e6a3de39dcf6db6f428d66d988a7b"
+  resolved "git+ssh://git@github.com/amplitude/dom-mutator#12c98baf791d3f5b803f6f30517512df6f1b0a2a"
   dependencies:
     morphdom "^2.7.8"
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Amplitude Experiment Javascript Client SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
-->

### Summary
Update dom-mutator 
See https://github.com/amplitude/dom-mutator/pull/40

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-js-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Only the mutation library revision changes, but that library drives live-page DOM updates in the experiment tag, so regressions would surface in production experiences without any local code review in this diff.
> 
> **Overview**
> Pins **`dom-mutator`** in `@amplitude/experiment-tag` to a newer Amplitude git commit (`12c98ba…`, replacing `bb5f4b5…`) and refreshes **`yarn.lock`** so installs resolve to that revision.
> 
> There are **no source changes** in this repo; behavior for the snippet’s DOM mutation path (via `dom-mutator` in `experiment.ts`) follows whatever landed upstream in [dom-mutator#40](https://github.com/amplitude/dom-mutator/pull/40).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6aa90fc72b6fd034bdf6d0a07cbc48833bbbc091. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->